### PR TITLE
Bug:Taxes jump to max when first increased

### DIFF
--- a/civics.js
+++ b/civics.js
@@ -11,7 +11,7 @@ export function defineGovernment(){
     
     if (!global.civic['taxes']){
         global.civic['taxes'] = {
-            tax_rate: '20',
+            tax_rate: 20,
             display: false
         };
     }


### PR DESCRIPTION
https://github.com/pmotschmann/Evolve/issues/150
`if (!global.civic['taxes']){
        global.civic['taxes'] = {
            tax_rate: '20',
            display: false
        };
    }`
tax_rate is a string
` else if (global.civic.taxes.tax_rate < 30){
                    global.civic.taxes.tax_rate += inc;
                    if (global.civic.taxes.tax_rate > 30){
                        global.civic.taxes.tax_rate = 30;
                    }
                }`
When you add inc instead of 21 the result is 201 and when compared with 30 the result is true, then is set to the maximum value