### PR TITLE
Various Bug Fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -10225,6 +10225,10 @@ export const actions = {
                         global.civic['garrison'].max += 20;
                         global.civic['garrison'].workers += 20;
                     }
+                    for (let i=0; i<3; i++){
+                        global.civic.foreign[`gov${i}`].sab = 0;
+                        global.civic.foreign[`gov${i}`].act = 'none';
+                    }
                     return true;
                 }
                 return false;
@@ -10253,10 +10257,9 @@ export const actions = {
                 return `<div>${loc('tech_wc_morale_effect',[races[global.race.species].home])}</div><div class="has-text-special">${loc('tech_unification_warning')}</div>`;
             }, 
             action(){
-                let morale = global.race['no_plasmid'] ? 140 : 150;
-                if (global.race['no_crispr']){
-                    morale -= 10;
-                }
+                let morale = (global.civic.foreign.gov0.unrest + global.civic.foreign.gov1.unrest + global.civic.foreign.gov2.unrest) / 5;
+                morale += (300 - (global.civic.foreign.gov0.hstl + global.civic.foreign.gov1.hstl + global.civic.foreign.gov2.hstl)) / 7.5;
+                morale = +(200 - morale).toFixed(1);
                 if (global.city.morale.current >= morale){
                     global.tech['world_control'] = 1;
                     $('#garrison').empty();
@@ -10276,6 +10279,10 @@ export const actions = {
                     if (global.civic.foreign.gov2.occ){
                         global.civic['garrison'].max += 20;
                         global.civic['garrison'].workers += 20;
+                    }
+                    for (let i=0; i<3; i++){
+                        global.civic.foreign[`gov${i}`].sab = 0;
+                        global.civic.foreign[`gov${i}`].act = 'none';
                     }
                     return true;
                 }
@@ -10302,10 +10309,8 @@ export const actions = {
             },
             effect(){ return `<div>${loc('tech_wc_money_effect',[races[global.race.species].home])}</div><div class="has-text-special">${loc('tech_unification_warning')}</div>`; },
             action(){
-                let price = global.race['no_plasmid'] ? 3000000 : 5000000;
-                if (global.race['no_crispr']){
-                    price -= 1000000;
-                }
+                let price = global.civic.foreign.gov0.eco + global.civic.foreign.gov1.eco + global.civic.foreign.gov2.eco;
+                price *= 15384;
                 if (global.resource.Money.amount >= price){
                     global.resource.Money.amount -= price;
                     global.tech['world_control'] = 1;
@@ -10326,6 +10331,10 @@ export const actions = {
                     if (global.civic.foreign.gov2.occ){
                         global.civic['garrison'].max += 20;
                         global.civic['garrison'].workers += 20;
+                    }
+                    for (let i=0; i<3; i++){
+                        global.civic.foreign[`gov${i}`].sab = 0;
+                        global.civic.foreign[`gov${i}`].act = 'none';
                     }
                     return true;
                 }
@@ -10994,7 +11003,13 @@ export const actions = {
             cost: {},
             no_queue(){ return true },
             effect(){
-                let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+                let garrisoned = global.civic.garrison.workers;
+                for (let i=0; i<3; i++){
+                    if (global.civic.foreign[`gov${i}`].occ){
+                        garrisoned += 20;
+                    }
+                }
+                let pop = global['resource'][global.race.species].amount + garrisoned;
                 let plasmid = Math.round(pop / 3);
                 let k_base = global.stats.know;
                 let k_inc = 50000;
@@ -11027,7 +11042,13 @@ export const actions = {
             cost: {},
             no_queue(){ return true },
             effect(){
-                let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+                let garrisoned = global.civic.garrison.workers;
+                for (let i=0; i<3; i++){
+                    if (global.civic.foreign[`gov${i}`].occ){
+                        garrisoned += 20;
+                    }
+                }
+                let pop = global['resource'][global.race.species].amount + garrisoned;
                 let plasmid = Math.round(pop / 3);
                 let k_base = global.stats.know;
                 let k_inc = 50000;
@@ -12527,7 +12548,13 @@ function bioseed(){
     let plasmid = global.race.Plasmid.count;
     let antiplasmid = global.race.Plasmid.anti;
     let phage = global.race.Phage.count;
-    let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+    let garrisoned = global.civic.garrison.workers;
+    for (let i=0; i<3; i++){
+        if (global.civic.foreign[`gov${i}`].occ){
+            garrisoned += 20;
+        }
+    }
+    let pop = global['resource'][global.race.species].amount + garrisoned;
     let new_plasmid = Math.round(pop / 3);
     let k_base = global.stats.know;
     let k_inc = 50000;
@@ -12679,7 +12706,13 @@ function big_bang(){
     let antiplasmid = global.race.Plasmid.anti;
     let phage = global.race.Phage.count;
     let dark = global.race.Dark.count;
-    let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+    let garrisoned = global.civic.garrison.workers;
+    for (let i=0; i<3; i++){
+        if (global.civic.foreign[`gov${i}`].occ){
+            garrisoned += 20;
+        }
+    }
+    let pop = global['resource'][global.race.species].amount + garrisoned;
     let new_plasmid = Math.round(pop / 2);
     let k_base = global.stats.know;
     let k_inc = 40000;

--- a/src/civics.js
+++ b/src/civics.js
@@ -1581,7 +1581,13 @@ function defineMad(){
                     : loc('civics_mad_missiles_desc');
             },
             warning(){
-                let plasma = Math.round((global['resource'][global.race.species].amount + global.civic.garrison.workers) / 3);
+                let garrisoned = global.civic.garrison.workers;
+                for (let i=0; i<3; i++){
+                    if (global.civic.foreign[`gov${i}`].occ){
+                        garrisoned += 20;
+                    }
+                }
+                let plasma = Math.round((global['resource'][global.race.species].amount + garrisoned) / 3);
                 let k_base = global.stats.know;
                 let k_inc = 100000;
                 while (k_base > k_inc){
@@ -1618,7 +1624,13 @@ function warhead(){
     let geo = global.city.geology;
     let plasmid = global.race.Plasmid.count;
     let antiplasmid = global.race.Plasmid.anti;
-    let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+    let garrisoned = global.civic.garrison.workers;
+    for (let i=0; i<3; i++){
+        if (global.civic.foreign[`gov${i}`].occ){
+            garrisoned += 20;
+        }
+    }
+    let pop = global['resource'][global.race.species].amount + garrisoned;
     let new_plasmid = Math.round(pop / 3);
     let k_base = global.stats.know;
     let k_inc = 100000;

--- a/src/industry.js
+++ b/src/industry.js
@@ -436,7 +436,17 @@ function loadFactory(parent,bind){
                 let assembly = global.tech['factory'] ? true : false;
                 switch(type){
                     case 'Lux':{
-                        let demand = +(global.resource[global.race.species].amount * (assembly ? f_rate.Lux.demand[global.tech['factory']] : f_rate.Lux.demand[0])).toFixed(2);
+                        let demand = +(global.resource[global.race.species].amount * (assembly ? f_rate.Lux.demand[global.tech['factory']] : f_rate.Lux.demand[0]))
+                        if (global.race['toxic']){
+                            demand *= 1.20;
+                        }
+                        if (global.civic.govern.type === 'corpocracy'){
+                            demand *= 1.5;
+                        }
+                        if (global.civic.govern.type === 'socialist'){
+                            demand *= 0.8;
+                        }
+                        demand = demand.toFixed(2);
                         let fur = assembly ? f_rate.Lux.fur[global.tech['factory']] : f_rate.Lux.fur[0];
                         return loc('modal_factory_lux_label',[fur,loc('resource_Furs_name'),demand]);
                     }

--- a/src/main.js
+++ b/src/main.js
@@ -5215,13 +5215,13 @@ function spyCaught(i){
     }
     switch (i){
         case 0:
-            messageQueue(loc('event_spy',[loc('civics_gov0',[races[global.race.species].name])]),'danger');
+            messageQueue(loc('event_spy',[govTitle(i)]),'danger');
             break;
         case 1:
-            messageQueue(loc('event_spy',[loc('civics_gov1')]),'danger');
+            messageQueue(loc('event_spy',[govTitle(i)]),'danger');
             break;
         case 2:
-            messageQueue(loc('event_spy',[loc('civics_gov2',[races[global.race.species].home])]),'danger');
+            messageQueue(loc('event_spy',[govTitle(i)]),'danger');
             break;
     }
 }

--- a/src/races.js
+++ b/src/races.js
@@ -1201,7 +1201,7 @@ export const traits = {
         type: 'major',
     },
     slow_regen: { // Your soldiers wounds heal slower.
-        desc: loc('trait_revive'),
+        desc: loc('trait_slow_regen'),
         type: 'major',
     },
     forge: { // Smelters do not require fuel

--- a/src/races.js
+++ b/src/races.js
@@ -1185,7 +1185,7 @@ export const traits = {
         type: 'major',
     },
     environmentalist: { // Use renewable energy instead of dirtly coal & oil power.
-        desc: loc('trait_befuddle'),
+        desc: loc('trait_environmentalist'),
         type: 'major',
     },
     unorganized: { // Increased time between revolutions
@@ -1241,7 +1241,7 @@ export const traits = {
         type: 'major',
     },
     thalassophobia: { // Wharves are unavailable
-        desc: loc('trait_humpback'),
+        desc: loc('trait_thalassophobia'),
         type: 'major',
     },
     fiery: { // Major war bonus

--- a/src/space.js
+++ b/src/space.js
@@ -1473,7 +1473,7 @@ const spaceProjects = {
                 let power = $(this)[0].powered() * -1;
                 return `<div>${loc('space_dwarf_reactor_effect1',[power])}</div><div>${loc('space_dwarf_reactor_effect2',[elerium])}</div>`;
             },
-            powered(){ return -25; },
+            powered(){ return powerModifier(-25); },
             action(){
                 if (payCosts($(this)[0].cost)){
                     incrementStruct('e_reactor');
@@ -2360,7 +2360,13 @@ const interstellarProjects = {
                     let mass = +(global.interstellar.stellar_engine.mass + global.interstellar.stellar_engine.exotic).toFixed(10);
                     let exotic = +(global.interstellar.stellar_engine.exotic).toFixed(10);
                     if (global.tech['whitehole']){
-                        let pop = global['resource'][global.race.species].amount + global.civic.garrison.workers;
+                        let garrisoned = global.civic.garrison.workers;
+                        for (let i=0; i<3; i++){
+                            if (global.civic.foreign[`gov${i}`].occ){
+                                garrisoned += 20;
+                            }
+                        }
+                        let pop = global['resource'][global.race.species].amount + garrisoned;
                         let plasmid = Math.round(pop / 2);
                         let k_base = global.stats.know;
                         let k_inc = 40000;


### PR DESCRIPTION
Occupying soldiers now count towards prestige gains, ongoing espionage actions are terminated upon unifying, wc_morale and wc_money now use the updated formulas in their action() functions, spyCaught() function now says the correct government names, Luxury resource label displays more accurate amount of $ gained, Elerium Reactor output accounts for Antimatter universe, and Slow Regen now displays the correct description.