### PR TITLE
Renaming Crispr sub-tab to CRISPR

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -31,7 +31,7 @@
   "sol_system": "%0 System",
   "tab_arpa_projects": "Projects",
   "tab_arpa_genetics": "Genetics",
-  "tab_arpa_crispr": "Crispr",
+  "tab_arpa_crispr": "CRISPR",
   "to_full": "To Full",
   "to_empty": "To Empty",
   "requires_power": "Requires Power",


### PR DESCRIPTION
Properly capitalized CRISPR tab