### PR TITLE
Refactor : Reset reward calculations

### DIFF
--- a/src/civics.js
+++ b/src/civics.js
@@ -1,6 +1,6 @@
 import { global, poppers, clearStates, save, keyMultiplier, resizeGame, sizeApproximation } from './vars.js';
 import { loc } from './locale.js';
-import { challenge_multiplier, timeFormat, vBind, modRes, messageQueue, genCivName } from './functions.js';
+import { challenge_multiplier, timeFormat, vBind, modRes, messageQueue, genCivName, calculateResetRewards } from './functions.js';
 import { unlockAchieve, unlockFeat, checkAchievements } from './achieve.js';
 import { races, racialTrait } from './races.js';
 import { loadIndustry } from './industry.js';
@@ -1657,22 +1657,12 @@ function defineMad(){
                     : loc('civics_mad_missiles_desc');
             },
             warning(){
-                let garrisoned = global.civic.garrison.workers;
-                for (let i=0; i<3; i++){
-                    if (global.civic.foreign[`gov${i}`].occ){
-                        garrisoned += 20;
-                    }
+                var rewards = calculateResetRewards('mad');
+                var plasmidCount = rewards.plasmid; 
+                if (global.race.universe === 'antimatter') {
+                    plasmidCount = rewards.antiplasmid;
                 }
-                let plasma = Math.round((global['resource'][global.race.species].amount + garrisoned) / 3);
-                let k_base = global.stats.know;
-                let k_inc = 100000;
-                while (k_base > k_inc){
-                    plasma++;
-                    k_base -= k_inc;
-                    k_inc *= 1.1;
-                }
-                plasma = challenge_multiplier(plasma,'mad');
-                return loc('civics_mad_missiles_warning',[plasma,plasmidType]);
+                return loc('civics_mad_missiles_warning',[plasmidCount,plasmidType]);
             }
         }
     });
@@ -1700,22 +1690,9 @@ function warhead(){
     let geo = global.city.geology;
     let plasmid = global.race.Plasmid.count;
     let antiplasmid = global.race.Plasmid.anti;
-    let garrisoned = global.civic.garrison.workers;
-    for (let i=0; i<3; i++){
-        if (global.civic.foreign[`gov${i}`].occ){
-            garrisoned += 20;
-        }
-    }
-    let pop = global['resource'][global.race.species].amount + garrisoned;
-    let new_plasmid = Math.round(pop / 3);
-    let k_base = global.stats.know;
-    let k_inc = 100000;
-    while (k_base > k_inc){
-        new_plasmid++;
-        k_base -= k_inc;
-        k_inc *= 1.1;
-    }
-    new_plasmid = challenge_multiplier(new_plasmid,'mad');
+
+    var rewards = calculateResetRewards('mad');
+
     global.stats.reset++;
     global.stats.mad++;
     global.stats.tdays += global.stats.days;
@@ -1727,12 +1704,12 @@ function warhead(){
     global.stats.tdied += global.stats.died;
     global.stats.died = 0;
     if (global.race.universe === 'antimatter'){
-        antiplasmid += new_plasmid;
-        global.stats.antiplasmid += new_plasmid;
+        antiplasmid += rewards.antiplasmid;
+        global.stats.antiplasmid += rewards.antiplasmid;
     }
     else {
-        plasmid += new_plasmid;
-        global.stats.plasmid += new_plasmid;
+        plasmid += rewards.plasmid;
+        global.stats.plasmid += rewards.plasmid;
     }
     let new_achieve = unlockAchieve(`apocalypse`);
     if (unlockAchieve(`squished`,true)){ new_achieve = true; }

--- a/src/space.js
+++ b/src/space.js
@@ -1,5 +1,5 @@
 import { global, poppers, sizeApproximation, p_on, belt_on, int_on, quantum_level } from './vars.js';
-import { powerModifier, challenge_multiplier, spaceCostMultiplier, vBind, messageQueue } from './functions.js';
+import { powerModifier, challenge_multiplier, spaceCostMultiplier, vBind, messageQueue, calculateResetRewards } from './functions.js';
 import { unlockAchieve } from './achieve.js';
 import { races } from './races.js';
 import { spatialReasoning, defineResources } from './resources.js';
@@ -2367,29 +2367,9 @@ const interstellarProjects = {
                     let mass = +(global.interstellar.stellar_engine.mass + global.interstellar.stellar_engine.exotic).toFixed(10);
                     let exotic = +(global.interstellar.stellar_engine.exotic).toFixed(10);
                     if (global.tech['whitehole']){
-                        let garrisoned = global.civic.garrison.workers;
-                        for (let i=0; i<3; i++){
-                            if (global.civic.foreign[`gov${i}`].occ){
-                                garrisoned += 20;
-                            }
-                        }
-                        let pop = global['resource'][global.race.species].amount + garrisoned;
-                        let plasmid = Math.round(pop / 2);
-                        let k_base = global.stats.know;
-                        let k_inc = 40000;
-                        while (k_base > k_inc){
-                            plasmid++;
-                            k_base -= k_inc;
-                            k_inc *= 1.012;
-                        }
+                        var rewards = calculateResetRewards('bigbang');
                         let plasmidType = global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name');
-                        plasmid = challenge_multiplier(plasmid,'bigbang');
-                        let phage = challenge_multiplier(Math.floor(Math.log2(plasmid) * Math.E * 2.5),'bigbang');
-                        let dark = +(Math.log(1 + (global.interstellar.stellar_engine.exotic * 40))).toFixed(3);
-                        dark += +(Math.log2(global.interstellar.stellar_engine.mass - 7)/2.5).toFixed(3);
-                        dark = challenge_multiplier(dark,'bigbang',3);
-
-                        return `<div>${loc('interstellar_blackhole_desc4',[home,mass,exotic])}</div><div class="has-text-advanced">${loc('interstellar_blackhole_desc5',[plasmid,phage,dark,plasmidType])}</div>`;
+                        return `<div>${loc('interstellar_blackhole_desc4',[home,mass,exotic])}</div><div class="has-text-advanced">${loc('interstellar_blackhole_desc5',[rewards.plasmid,rewards.phage,rewards.dark,plasmidType])}</div>`;
                     }
                     else {
                         return global.interstellar.stellar_engine.exotic > 0 ? loc('interstellar_blackhole_desc4',[home,mass,exotic]) : loc('interstellar_blackhole_desc3',[home,mass]);


### PR DESCRIPTION
Move duplicate code for calculating reset rewards (Plasmids, phage, etc.) to a common function.

No gameplay changes (rewards for resets are unchanged.)