### PR TITLE
Fixed Dreaded achievement not rewarding if Dreadnoughts not researched.

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -5523,7 +5523,7 @@ function ascend(){
         unlockAchieve('miners_dream');
     }
 
-    if (global.galaxy.hasOwnProperty('dreadnought') && global.galaxy.dreadnought.count === 0){
+    if (!global.galaxy.hasOwnProperty('dreadnought') || global.galaxy.dreadnought.count === 0){
         unlockAchieve(`dreaded`);
     }
 


### PR DESCRIPTION
Now awards Dreaded if Dreadnoughts are NOT researched OR count is zero.