### PR TITLE
Fixed `arpa_perks_challenge2` typo

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -2317,7 +2317,7 @@
   "arpa_perks_birth": "Gain increased population growth rate",
   "arpa_perks_enhance": "Manual resource gathering rate doubled",
   "arpa_perks_challenge": "Challenge Genes unlocked",
-  "arpa_perks_challenge2": "%0% of Standard Mastery and %1% of Universe-specfic Mastery works in alternate universes",
+  "arpa_perks_challenge2": "%0% of Standard Mastery and %1% of Universe-specific Mastery works in alternate universes",
   "arpa_perks_challenge3": "The Mastery minor trait is unlocked",
   "arpa_perks_ancients": "Advanced religion techs unlocked",
   "arpa_perks_ancients2": "Temples unlock Priests",


### PR DESCRIPTION
Specific is missing an `i`.
"%0% of Standard Mastery and %1% of Universe-specific Mastery works in alternate universes"