### PR TITLE
Add Scarletite to global.city.foundry upon foundry research

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -717,6 +717,7 @@ const techs = {
                     Mythril: 0,
                     Aerogel: 0,
                     Nanoweave: 0,
+                    Scarletite: 0,
                 };
                 return true;
             }


### PR DESCRIPTION
Tested on local game. Currently, Scarletite is not added to "global.city.foundry" when the "foundry" tech is researched. However, Scarletite is added to "global.city.foundry" in vars.js if the foundry tech has been researched when the page is reloaded. Therefore, Scarletite is present in "global.city.foundry" after the "foundry" tech has been researched and the page is reloaded, but not before the page is reloaded.

This causes TMVictor's script to break in the "autoJobs". By including this in "global.city.foundry" when the tech is researched, this fixes TMVictor's script for job automation.