### PR TITLE
Let the browser decide if a scrollbar is needed

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1652,6 +1652,7 @@ html.orangeSoda {
 
 // Base CSS
 html {
+    overflow-y: auto;
     box-sizing: border-box;
     font-size: 16px;
 }


### PR DESCRIPTION
At least on Windows the page has a scrollbar which is not scrollable. And over all it is not necessary as the elements on the page have their own scrollbars.

Scrolling the page is only needed on mobile as far as I can tell, and this will work fine.

Buefy adds the forced `scroll`.