### PR TITLE
Remove the need to recalculate height in javascript

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1956,6 +1956,10 @@ a {
         display: flex;
         flex-direction: column;
         height: calc(100vh - 2.4rem);
+
+        &:empty {
+            display: none;
+        }
     }
 
     .bldQueue,

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1952,6 +1952,12 @@ a {
         }
     }
 
+    #queueColumn {
+        display: flex;
+        flex-direction: column;
+        height: calc(100vh - 2.4rem);
+    }
+
     .bldQueue,
     .msgQueue {
         height: 5rem;
@@ -1968,14 +1974,11 @@ a {
 
     .msgQueue {
         font-size: .75rem;
-
-        &.right {
-            height: ~"calc(100vh - 9rem)";
-        }
     }
 
     .bldQueue,
     .bldQueue.right {
+        flex-shrink: 0;
         padding-top: .25rem;
 
         h2 {

--- a/src/main.js
+++ b/src/main.js
@@ -7101,13 +7101,6 @@ function midLoop(){
         });
     });
 
-    if ($(`#buildQueue.right`).length > 0){
-        $(`#msgQueue.right`).css('height',`calc(100vh - 6.5rem - ${$(`#buildQueue.right`).height()}px)`);
-    }
-    else {
-        $(`#msgQueue`).css('height',`5rem`);
-    }
-
     if ($(`#mechList`).length > 0){
         $(`#mechList`).css('height',`calc(100vh - 11.5rem - ${$(`#mechAssembly`).height()}px)`);
     }


### PR DESCRIPTION
Removing the scrollbar on body revealed that the height gets recalculated, I believe this removes the need for it completely. Unsure If I missed some edge case, but appears to work.

![a](https://user-images.githubusercontent.com/613331/105626078-55766700-5e36-11eb-9db2-b895d38e1662.png)
![b](https://user-images.githubusercontent.com/613331/105626082-57402a80-5e36-11eb-919d-a7c96ee064fc.png)