### PR TITLE
QOL: prevent flickering in buildqueue by padding min and sec with zeroes

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -772,14 +772,18 @@ export function timeFormat(time){
                     formatted = `${days}d ${r}h`;
                 }
                 else {
+                    r = ('0' + r).slice(-2);
                     formatted = `${hours}h ${r}m`;
                 }
             }
             else {
+                mins = ('0' + mins).slice(-2);
+                secs = ('0' + secs).slice(-2);
                 formatted = `${mins}m ${secs}s`;
             }
         }
         else {
+            time = ('0' + time).slice(-2);
             formatted = `${time}s`;
         }
     }


### PR DESCRIPTION
Very small QOL enhancement, pad the seconds and minutes with zeroes in the buildQueue.

For example:
-  Lodge (2m 3s) -> Lodge (02m 03s)

By fixing the number of characters in minutes and seconds, this reduce the flickering of the build queue.

Not much work, but easy to test.