### PR TITLE
Ghost 3 fix for smoldering races

### DIFF
--- a/src/industry.js
+++ b/src/industry.js
@@ -300,7 +300,7 @@ function loadSmelter(parent,bind){
                 return value > 0 ? `+${sizeApproximation(value,2)}` : sizeApproximation(value,2);
             },
             spook(v){
-                if (bind && ((global.race['kindling_kindred'] && (global.city.smelter.Steel === 6 || global.city.smelter.Iron === 6)) || global.city.smelter.Wood === 6) && global.city.smelter.Coal === 6 && global.city.smelter.Oil === 6){
+                if (bind && (((global.race['kindling_kindred'] || global.race['smoldering']) && (global.city.smelter.Steel === 6 || global.city.smelter.Iron === 6)) || global.city.smelter.Wood === 6) && global.city.smelter.Coal === 6 && global.city.smelter.Oil === 6){
                     let trick = trickOrTreat(3,12,true);
                     if (trick.length > 0){
                         return trick;


### PR DESCRIPTION
This lets you obtain ghost 3 when you have the Smoldering trait but not Kindling Kindred or Forge.