### PR TITLE
Mech optimizations

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -14,10 +14,10 @@ export function enableDebug(){
         window.evolve = {
             actions: deepClone(actions),
             races: deepClone(races),
-            tradeRatio: JSON.parse(JSON.stringify(tradeRatio)),
-            craftCost: JSON.parse(JSON.stringify(craftCost())),
-            atomic_mass: JSON.parse(JSON.stringify(atomic_mass)),
-            f_rate: JSON.parse(JSON.stringify(f_rate)),
+            tradeRatio: deepClone(tradeRatio),
+            craftCost: deepClone(craftCost()),
+            atomic_mass: deepClone(atomic_mass),
+            f_rate: deepClone(f_rate),
             checkTechRequirements: deepClone(checkTechRequirements),
             checkAffordable: deepClone(checkAffordable),
             adjustCosts: deepClone(adjustCosts),
@@ -38,8 +38,8 @@ export function enableDebug(){
 
 export function updateDebugData(){
     if (global.settings.expose){
-        window.evolve.global = JSON.parse(JSON.stringify(global));
-        window.evolve.craftCost = JSON.parse(JSON.stringify(craftCost())),
-        window.evolve.breakdown = JSON.parse(JSON.stringify(breakdown));
+        window.evolve.global = deepClone(global);
+        window.evolve.craftCost = deepClone(craftCost()),
+        window.evolve.breakdown = deepClone(breakdown);
     }
 }

--- a/src/governor.js
+++ b/src/governor.js
@@ -4,7 +4,7 @@ import { races } from './races.js';
 import { actions, checkCityRequirements, housingLabel, wardenLabel, updateQueueNames, checkAffordable } from './actions.js';
 import { govCivics, govTitle } from './civics.js';
 import { crateGovHook, atomic_mass } from './resources.js';
-import { checkHellRequirements, mechSize, drawMechList, mechCost } from './portal.js';
+import { checkHellRequirements, mechSize, mechCost } from './portal.js';
 import { loc } from './locale.js';
 
 export const gmen = {
@@ -1107,7 +1107,6 @@ export const gov_tasks = {
                                         global.portal.mechbay.mechs[i].equip.push(equip);
                                     }
                                 }
-                                drawMechList();
                             }
                             break;
                         }
@@ -1170,7 +1169,7 @@ export const gov_tasks = {
                         infernal: false
                     });
                     global.portal.mechbay.bay += size;
-                    drawMechList();
+                    global.portal.mechbay.active++;
                 }
             }
         }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ import { f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs } from './industr
 import { defineIndustry, checkControlling, garrisonSize, armyRating, govTitle, govCivics } from './civics.js';
 import { actions, updateDesc, challengeGeneHeader, challengeActionHeader, scenarioActionHeader, addAction, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, removeAction, evoProgress, housingLabel, updateQueueNames, wardenLabel, setPlanet, resQueue, bank_vault, start_cataclysm, cleanTechPopOver, raceList } from './actions.js';
 import { renderSpace, fuel_adjust, int_fuel_adjust, zigguratBonus, setUniverse, universe_types, gatewayStorage, piracy } from './space.js';
-import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechSize, mechCollect } from './portal.js';
+import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechSize, mechCollect, updateMechbay } from './portal.js';
 import { arpa, buildArpa } from './arpa.js';
 import { events, eventList } from './events.js';
 import { govern, govActive } from './governor.js';
@@ -2447,13 +2447,12 @@ function fastLoop(){
                 }
             });
             if (global.portal['mechbay']){
-                let space = 0;
-                global.portal.mechbay.mechs.forEach(function(mech){
-                    space += mechSize(mech.size);
-                    if (space <= global.portal.mechbay.max && mech.size === 'collector'){
+                for (let i = 0; i < global.portal.mechbay.active; i++) {
+                    let mech = global.portal.mechbay.mechs[i];
+                    if (mech.size === 'collector') {
                         supply += mechCollect(mech) * time_multiplier;
                     }
-                });
+                }
             }
             global.portal.purifier.supply += supply;
             global.portal.purifier.diff = supply / time_multiplier;
@@ -7075,27 +7074,22 @@ function midLoop(){
         }
 
         if (global.portal.hasOwnProperty('mechbay') && global.tech['hell_spire'] && global.tech.hell_spire >= 9){
-            let bays = (spire_on['mechbay'] || 0);
-            global.portal.mechbay.max = bays * 25;
-
             if (!global.portal.spire['boss']){
                 genSpireFloor();
             }
+            updateMechbay();
 
-            let space = 0;
             let progress = 0;
-            global.portal.mechbay.mechs.forEach(function(mech){
-                space += mechSize(mech.size);
-                if (space <= global.portal.mechbay.max){
-                    if (global.portal.hasOwnProperty('waygate') && global.tech.hasOwnProperty('waygate') && global.portal.waygate.on === 1 && global.tech.waygate >= 2 && global.portal.waygate.progress < 100){
-                        progress += mechRating(mech,true);
-                    }
-                    else {
-                        progress += mechRating(mech,false);
-                    }
+            for (let i = 0; i < global.portal.mechbay.active; i++) {
+                let mech = global.portal.mechbay.mechs[i];
+                if (global.portal.hasOwnProperty('waygate') && global.tech.hasOwnProperty('waygate') && global.portal.waygate.on === 1 && global.tech.waygate >= 2 && global.portal.waygate.progress < 100){
+                    progress += mechRating(mech,true);
                 }
-            });
-            global.portal.mechbay.bay = space;
+                else {
+                    progress += mechRating(mech,false);
+                }
+            }
+
             if (global.portal.hasOwnProperty('waygate') && global.tech.hasOwnProperty('waygate') && global.portal.waygate.on === 1 && global.tech.waygate >= 2 && global.portal.waygate.progress < 100){
                 global.portal.waygate.progress += progress;
                 global.portal.waygate.time = progress === 0 ? timeFormat(-1) : timeFormat((100 - global.portal.waygate.progress) / progress);

--- a/src/portal.js
+++ b/src/portal.js
@@ -1466,7 +1466,7 @@ const fortressModules = {
             effect: loc('portal_spire_survey_effect'),
             action(){
                 if (payCosts($(this)[0].cost)){
-                    global.portal['mechbay'] = { count: 0, on: 0, bay: 0, max: 0, mechs: [] };
+                    global.portal['mechbay'] = { count: 0, on: 0, bay: 0, max: 0, active: 0, scouts: 0, mechs: [] };
                     global.portal['spire'] = { count: 1, progress: 0, boss: '', type: '', status: {} };
                     genSpireFloor();
                     messageQueue(loc('portal_spire_survey_msg'),'info',false,['progress','hell']);
@@ -1525,9 +1525,7 @@ const fortressModules = {
                 return false;
             },
             postPower(){
-                let bays = (spire_on['mechbay'] || 0);
-                global.portal.mechbay.max = bays * 25;
-                drawMechs();
+                updateMechbay();
             }
         },
         spire: {
@@ -3299,7 +3297,7 @@ export function drawMechLab(){
                         let mech = deepClone(global.portal.mechbay.blueprint);
                         global.portal.mechbay.mechs.push(mech);
                         global.portal.mechbay.bay += size;
-                        drawMechs();
+                        global.portal.mechbay.active++;
                     }
                 },
                 setSize(s){
@@ -3512,37 +3510,36 @@ function drawMechs(){
     clearMechDrag();
     clearElement($('#mechList'));
     let list = $('#mechList');
-    let used = 0;
-    for (let i=0; i<global.portal.mechbay.mechs.length; i++){
-        let mech = global.portal.mechbay.mechs[i];
-        used += mechSize(mech.size);
-        let inactive = used > global.portal.mechbay.max ? true : false;
-        let infernal = mech.infernal ? `${loc('portal_mech_infernal')} ` : ``;
-        let desc = $(`<div class="mechRow${inactive ? ` inactive-row` : ``}"><a ${inactive ? `class="scrap${i} has-text-danger"` : `class="scrap${i}"`} @click="scrap(${i})">${loc(`portal_mech_scrap`)}</a> | <span>${loc(`portal_mech`)} #${i+1}</span>: <span class="has-text-caution">${infernal}${loc(`portal_mech_size_${mech.size}`)} ${loc(`portal_mech_chassis_${mech.chassis}`)}</span></div>`);
-        let gear_list = $(`<div class="gearList ${mech.size}"></div>`);
-        desc.append(gear_list);
-        if (mech.hardpoint.length > 0){
-            let wep_list = $(`<div></div>`);
-            gear_list.append(wep_list);
-            mech.hardpoint.forEach(function(hp){
-                wep_list.append(`<span> | </span><span class="has-text-danger">${loc(`portal_mech_weapon_${hp}`)}</span>`);
-            });
-        }
-        let eqp_list = $(`<div></div>`);
-        gear_list.append(eqp_list);
-        mech.equip.forEach(function(eq){
-            eqp_list.append(`<span> | </span><span class="has-text-warning">{{ '${eq}' | equipment('${mech.size}') }}</span>`);
-        });
-        list.append(desc);
-    }
+
+    list.append(`
+      <div v-for="(mech, index) of mechs" :key="index" class="mechRow" :class="index < active ? '' : 'inactive-row' ">
+        <a class="scrap" @click="scrap(index)">${loc('portal_mech_scrap')}</a>
+        <span> | </span><span>${loc('portal_mech')} #{{index + 1}}: </span>
+        <span class="has-text-caution">{{ mech.infernal ? "${loc('portal_mech_infernal')} " : "" }}{{ mech | size }} {{ mech | chassis }}</span>
+        <div :class="'gearList '+mech.size">
+          <div>
+            <template v-for="hp of mech.hardpoint">
+              <span> | </span>
+              <span class="has-text-danger">{{ hp | weapon }}</span>
+            </template>
+          </div>
+          <div>
+            <template v-for="eq of mech.equip">
+              <span> | </span>
+              <span class="has-text-warning">{{ eq, mech.size | equipment }}</span>
+            </template>
+          </div>
+        </div>
+      </div>`);
 
     vBind({
         el: '#mechList',
-        data: global.portal.mechbay.mechs,
+        data: global.portal.mechbay,
         methods: {
             scrap(id){
                 if (global.portal.mechbay.mechs[id]){
                     let costs = mechCost(global.portal.mechbay.mechs[id].size,global.portal.mechbay.mechs[id].infernal);
+                    let size = mechSize(global.portal.mechbay.mechs[id].size);
                     global.portal.purifier.supply += Math.floor(costs.c / 3);
                     global.resource.Soul_Gem.amount += Math.floor(costs.s / 2);
 
@@ -3550,7 +3547,8 @@ function drawMechs(){
                         global.portal.purifier.supply = global.portal.purifier.sup_max;
                     }
                     global.portal.mechbay.mechs.splice(id,1);
-                    drawMechs();
+                    global.portal.mechbay.bay -= size;
+                    global.portal.mechbay.active--;
                 }
             }
         },
@@ -3569,28 +3567,30 @@ function drawMechs(){
                         break;
                 }
                 return loc(`portal_mech_equip_${type}`);
+            },
+            weapon(hp) {
+                return loc(`portal_mech_weapon_${hp}`);
+            },
+            size(m) {
+                return loc(`portal_mech_size_${m.size}`);
+            },
+            chassis(m) {
+                return loc(`portal_mech_chassis_${m.chassis}`);
             }
         }
     });
 
     dragMechList();
 
-    for (let i=0; i<global.portal.mechbay.mechs.length; i++){
+    $(`#mechList .scrap`).each(function(i, node){
         popover(`mechList-scrap${i}`, function(){
             let costs = mechCost(global.portal.mechbay.mechs[i].size,global.portal.mechbay.mechs[i].infernal);
             return loc(`portal_mech_scrap_refund`,[Math.floor(costs.c / 3),Math.floor(costs.s / 2)]);
         },
         {
-            elm: `#mechList .scrap${i}`,
+            elm: node,
         });
-    }
-}
-
-export function drawMechList(){
-    if (!global.settings.tabLoad && (global.settings.civTabs !== 2 || global.settings.govTabs !== 4)){
-        return;
-    }
-    drawMechs();
+    });
 }
 
 export function mechSize(s){
@@ -3624,12 +3624,34 @@ function dragMechList(){
     let el = $('#mechList')[0];
     Sortable.create(el,{
         onEnd(e){
+            let items = e.from.querySelectorAll(':scope > .mechRow');
+            e.from.insertBefore(e.item, items[e.oldIndex + (e.oldIndex > e.newIndex)]);
+
             let order = global.portal.mechbay.mechs;
             order.splice(e.newDraggableIndex, 0, order.splice(e.oldDraggableIndex, 1)[0]);
-            global.portal.mechbay.mechs = order;
-            drawMechs();
+            updateMechbay();
         }
     });
+}
+
+export function updateMechbay(){
+    let max = (spire_on['mechbay'] || 0) * 25;
+    let bay = 0;
+    let active = 0;
+    let scouts = 0;
+    for (let mech of global.portal.mechbay.mechs) {
+        bay += mechSize(mech.size);
+        if (bay <= max){
+            active++;
+            if (mech.size === 'small') {
+                scouts++;
+            }
+        }
+    }
+    global.portal.mechbay.bay = bay;
+    global.portal.mechbay.max = max;
+    global.portal.mechbay.active = active;
+    global.portal.mechbay.scouts = scouts;
 }
 
 export function genSpireFloor(){
@@ -3701,15 +3723,7 @@ function terrainRating(mech,rating,effects){
         }
     }
     if (mech.size !== 'small' && rating < 1){
-        let space = 0;
-        let sizes = { small: 0, medium: 0, large: 0, titan: 0, collector: 0 };
-        global.portal.mechbay.mechs.forEach(function(m){
-            space += mechSize(m.size);
-            if (space <= global.portal.mechbay.max){
-                sizes[m.size]++;
-            }
-        });
-        rating += (effects.includes('fog') || effects.includes('dark') ? 0.005 : 0.01) * sizes.small;
+        rating += (effects.includes('fog') || effects.includes('dark') ? 0.005 : 0.01) * global.portal.mechbay.scouts;
         if (rating > 1){
             rating = 1;
         }

--- a/src/vars.js
+++ b/src/vars.js
@@ -905,6 +905,13 @@ if (convertVersion(global['version']) < 101015){
     }
 }
 
+if (convertVersion(global['version']) < 101017){
+    if (global.hasOwnProperty('portal') && global.portal.hasOwnProperty('mechbay') && !global.portal.mechbay.hasOwnProperty('active')){
+        global.portal.mechbay['active'] = 0;
+        global.portal.mechbay['scouts'] = 0;
+    }
+}
+
 global['version'] = '1.1.16';
 delete global['revision'];
 delete global['beta'];


### PR DESCRIPTION
Added v-for to mech lab to fix memory leak with caching vue's.
Removed redraws(and scrolling back to top) after mechs list manipulation, to make building\scrapping\sorting more responsive.
drawMechList removed, as it not needed with reactive list.
All scrap poppers added using single selector, to improve initial build up time of list.
Hack in mech list's sortable restores dom to initial state after dragging, so vue can rerender altered list correctly, using mechs array.
Cached amount of scouts(improved performance of mech power calculation from O(n^2) to O(n)), and active mechs(mostly technical need, for mechs list activity check).
Fixed releasing of bay space after scraping mech on pause.
Replaced stringify with deep copy in debug expose. JSON can be noticeable slow with thousand of mechs to copy. Deep copy does same(it still can't be used to alter game data), but faster.