### PR TITLE
Fix description of Dreaded achievment

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -2416,7 +2416,7 @@
   "achieve_ascended_desc": "Ascended to a higher plane of existence",
   "achieve_ascended_flair": "You're your own flashlight!",
   "achieve_dreaded_name": "Dreaded",
-  "achieve_dreaded_desc": "Ascended without constructing any Dreadnoughts",
+  "achieve_dreaded_desc": "Ascended without owning any Dreadnoughts",
   "achieve_dreaded_flair": "Did you dread the achievement?",
   "achieve_anarchist_name": "Anarchist",
   "achieve_anarchist_desc": "Initiated a nuclear holocaust with an anarchy government",


### PR DESCRIPTION
The achievement "Dreaded" is earned if you ascend without owning
a dreadnought. It's possible to earn this achievement if you've
constructed a dreadnought but it was destroyed in an assault. The
description of the achievement doesn't make this obvious. Fix this by
rewording the description slightly.