### PR TITLE
Genus shift fixes

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,6 @@
 import { global, p_on } from './vars.js';
 import { loc } from './locale.js';
-import { races } from './races.js';
+import { races, traits } from './races.js';
 import { govTitle, garrisonSize, armyRating } from './civics.js';
 import { housingLabel, drawTech } from './actions.js';
 import { tradeRatio } from './resources.js';

--- a/src/main.js
+++ b/src/main.js
@@ -1255,11 +1255,12 @@ function fastLoop(){
             global.galaxy.trade.max = cap;
 
             let used = 0;
-            for (let i=0; i<galaxyOffers.length; i++){
-                let exprt_res = galaxyOffers[i].sell.res;
-                let exprt_vol = galaxyOffers[i].sell.vol;
-                let imprt_res = galaxyOffers[i].buy.res;
-                let imprt_vol = galaxyOffers[i].buy.vol;
+            let offers = galaxyOffers();
+            for (let i=0; i<offers.length; i++){
+                let exprt_res = offers[i].sell.res;
+                let exprt_vol = offers[i].sell.vol;
+                let imprt_res = offers[i].buy.res;
+                let imprt_vol = offers[i].buy.vol;
                 let exp_total = 0;
                 let imp_total = 0;
 
@@ -6430,11 +6431,9 @@ function midLoop(){
                 caps['Coal'] += gain;
                 bd_Coal[loc('space_red_garage_title')] = gain+'v';
 
-                if (!global.race['kindling_kindred'] && !global.race['smoldering']){
-                    gain = (global.space.garage.count * (spatialReasoning(7500 * multiplier)));
-                    caps['Lumber'] += gain;
-                    bd_Lumber[loc('space_red_garage_title')] = gain+'v';
-                }
+                gain = (global.space.garage.count * (spatialReasoning(7500 * multiplier)));
+                caps['Lumber'] += gain;
+                bd_Lumber[loc('space_red_garage_title')] = gain+'v';
 
                 gain = (global.space.garage.count * (spatialReasoning(7500 * multiplier)));
                 caps['Chrysotile'] += gain;

--- a/src/resources.js
+++ b/src/resources.js
@@ -1285,44 +1285,47 @@ function initGalaxyTrade(){
     galacticTrade();
 }
 
-export const galaxyOffers = [
-    {
-        buy: { res: 'Deuterium', vol: 5 },
-        sell: { res: 'Helium_3', vol: 25 }
-    },
-    {
-        buy: { res: 'Neutronium', vol: 2.5 },
-        sell: { res: 'Copper', vol: 200 }
-    },
-    {
-        buy: { res: 'Adamantite', vol: 3 },
-        sell: { res: 'Iron', vol: 300 }
-    },
-    {
-        buy: { res: 'Elerium', vol: 1 },
-        sell: { res: 'Oil', vol: 125 }
-    },
-    {
-        buy: { res: 'Nano_Tube', vol: 10 },
-        sell: { res: 'Titanium', vol: 20 }
-    },
-    {
-        buy: { res: 'Graphene', vol: 25 },
-        sell: { res: global.race['kindling_kindred'] || global.race['smoldering'] ? (global.race['smoldering'] ? 'Chrysotile' : 'Stone') : 'Lumber', vol: 1000 }
-    },
-    {
-        buy: { res: 'Stanene', vol: 40 },
-        sell: { res: 'Aluminium', vol: 800 }
-    },
-    {
-        buy: { res: 'Bolognium', vol: 0.75 },
-        sell: { res: 'Uranium', vol: 4 }
-    },
-    {
-        buy: { res: 'Vitreloy', vol: 1 },
-        sell: { res: 'Infernite', vol: 1 }
-    }
-];
+export function galaxyOffers(){
+    let offers = [
+        {
+            buy: { res: 'Deuterium', vol: 5 },
+            sell: { res: 'Helium_3', vol: 25 }
+        },
+        {
+            buy: { res: 'Neutronium', vol: 2.5 },
+            sell: { res: 'Copper', vol: 200 }
+        },
+        {
+            buy: { res: 'Adamantite', vol: 3 },
+            sell: { res: 'Iron', vol: 300 }
+        },
+        {
+            buy: { res: 'Elerium', vol: 1 },
+            sell: { res: 'Oil', vol: 125 }
+        },
+        {
+            buy: { res: 'Nano_Tube', vol: 10 },
+            sell: { res: 'Titanium', vol: 20 }
+        },
+        {
+            buy: { res: 'Graphene', vol: 25 },
+            sell: { res: global.race['kindling_kindred'] || global.race['smoldering'] ? (global.race['smoldering'] ? 'Chrysotile' : 'Stone') : 'Lumber', vol: 1000 }
+        },
+        {
+            buy: { res: 'Stanene', vol: 40 },
+            sell: { res: 'Aluminium', vol: 800 }
+        },
+        {
+            buy: { res: 'Bolognium', vol: 0.75 },
+            sell: { res: 'Uranium', vol: 4 }
+        },
+        {
+            buy: { res: 'Vitreloy', vol: 1 },
+            sell: { res: 'Infernite', vol: 1 }
+        }
+    ];
+    return offers;
+}
 
 export function galacticTrade(modal){
     let galaxyTrade = modal ? modal : $(`#galaxyTrade`);
@@ -1333,21 +1336,22 @@ export function galacticTrade(modal){
     if (global.galaxy['trade']){
         galaxyTrade.append($(`<div class="market-item trade-header"><span class="has-text-special">${loc('galaxy_trade')}</span></div>`));
 
-        for (let i=0; i<galaxyOffers.length; i++){
+        let offers = galaxyOffers();
+        for (let i=0; i<offers.length; i++){
             let offer = $(`<div class="market-item trade-offer"></div>`);
             galaxyTrade.append(offer);
 
-            offer.append($(`<span class="offer-item has-text-success">${global.resource[galaxyOffers[i].buy.res].name}</span>`));
+            offer.append($(`<span class="offer-item has-text-success">${global.resource[offers[i].buy.res].name}</span>`));
             offer.append($(`<span class="offer-vol has-text-advanced">+{{ '${i}' | t_vol }}/s</span>`));
             
-            offer.append($(`<span class="offer-item has-text-danger">${global.resource[galaxyOffers[i].sell.res].name}</span>`));
+            offer.append($(`<span class="offer-item has-text-danger">${global.resource[offers[i].sell.res].name}</span>`));
             offer.append($(`<span class="offer-vol has-text-caution">-{{ '${i}' | s_vol }}/s</span>`));
 
             let trade = $(`<span class="trade"><span class="has-text-warning">${loc('resource_market_routes')}</span></span>`);
             offer.append(trade);
             
-            let assign = loc('galaxy_freighter_assign',[global.resource[galaxyOffers[i].buy.res].name,global.resource[galaxyOffers[i].sell.res].name]);
-            let unassign = loc('galaxy_freighter_unassign',[global.resource[galaxyOffers[i].buy.res].name,global.resource[galaxyOffers[i].sell.res].name]);
+            let assign = loc('galaxy_freighter_assign',[global.resource[offers[i].buy.res].name,global.resource[offers[i].sell.res].name]);
+            let unassign = loc('galaxy_freighter_unassign',[global.resource[offers[i].buy.res].name,global.resource[offers[i].sell.res].name]);
             trade.append($(`<b-tooltip :label="desc('${unassign}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="${unassign}" class="sub has-text-danger" @click="less('${i}')"><span>-</span></span></b-tooltip>`));
             trade.append($(`<span class="current">{{ g.f${i} }}</span>`));
             trade.append($(`<b-tooltip :label="desc('${assign}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="${assign}" class="add has-text-success" @click="more('${i}')"><span>+</span></span></b-tooltip>`));
@@ -1393,7 +1397,8 @@ export function galacticTrade(modal){
                     global.galaxy.trade[`f${idx}`] = 0;
                 }
                 else {
-                    for (let i=0; i<galaxyOffers.length; i++){
+                    let offers = galaxyOffers();
+                    for (let i=0; i<offers.length; i++){
                         global.galaxy.trade.cur -= global.galaxy.trade[`f${i}`];
                         global.galaxy.trade[`f${i}`] = 0;
                     }
@@ -1405,7 +1410,8 @@ export function galacticTrade(modal){
         },
         filters: {
             t_vol(idx){
-                let buy_vol = galaxyOffers[idx].buy.vol;
+                let offers = galaxyOffers();
+                let buy_vol = offers[idx].buy.vol;
                 if (global.race['persuasive']){
                     buy_vol *= 1 + (global.race['persuasive'] / 100);
                 }
@@ -1425,7 +1431,8 @@ export function galacticTrade(modal){
                 return buy_vol;
             },
             s_vol(idx){
-                let sell_vol = galaxyOffers[idx].sell.vol;
+                let offers = galaxyOffers();
+                let sell_vol = offers[idx].sell.vol;
                 if (global.stats.achieve.hasOwnProperty('trade')){
                     let rank = global.stats.achieve.trade.l;
                     if (rank > 5){ rank = 5; }

--- a/src/tech.js
+++ b/src/tech.js
@@ -82,6 +82,9 @@ const techs = {
         action(){
             if (payCosts($(this)[0])){
                 global.resource.Stone.display = true;
+                if (global.race['smoldering']){
+                    global.resource.Chrysotile.display = true;
+                }
                 return true;
             }
             return false;
@@ -468,7 +471,7 @@ const techs = {
         era: 'civilized',
         reqs: { primitive: 3, storage: 1 },
         trait: ['carnivore'],
-        not_trait: ['cataclysm','artifical'],
+        not_trait: ['cataclysm','artifical','soul_eater'],
         grant: ['hunting',1],
         cost: {
             Knowledge(){ return 80; }
@@ -491,7 +494,6 @@ const techs = {
         era: 'civilized',
         reqs: { hunting: 1, housing: 1, currency: 1 },
         grant: ['hunting',2],
-        not_trait: ['soul_eater'],
         cost: {
             Knowledge(){ return 180; }
         },
@@ -513,6 +515,7 @@ const techs = {
         era: 'civilized',
         reqs: { housing: 1, currency: 1 },
         grant: ['s_lodge',1],
+        not_trait: ['carnivore'],
         condition(){
             return global.race.species === 'wendigo' || (!global.race['soul_eater'] && (global.race['detritivore'] || global.race['artifical'])) ? true : false;
         },


### PR DESCRIPTION
Fixed changing galaxy trade after purging\restoring lumber.
Fixed removing wood stored in cataclysm garage after shift.
Fixed rock quarry definition after removing sappy.
Fixed some other minor issues with removing traits, e.g. mutating out of cannibalize now properly removing sacrifice techs, or terrifying looks for trade techs in purgatory, etc.
Changed a bit trait requirements for techs: carnivore explicitly lock out of alt lodge. And soul eater's lock moved from hunting2(lodge) down to hunting1(smokehouse). It's rather bugfixes, than changes.
Added chrysotile unlock to soul eater's alt tools, same as it does with regular tools of other races.
Added missed import to events. (Not shapeshift related, just fixed it along the way)
Implemented shifts between detritivore\carnivore\soul eater, and combining them. It's not always makes logical sense(it's possible to have both compost and soul wells) or give any benefits(soul eater with carnivore still works as regular soul eater), as it was made looking at current techs\buildings requirements, all it supposed to do is *just work*, allowing to shift to any genus, without touching game balance.