### PR TITLE
More shifting fixes + mixing genuses

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2645,7 +2645,7 @@ function fastLoop(){
             }
         }
 
-        if (global.race['carnivore']){
+        if (global.race['carnivore'] && !global.race['soul_eater'] && !global.race['artifical']){
             if (global.resource['Food'].amount > 10){
                 let rot = +((global.resource['Food'].amount - 10) * (0.5)).toFixed(3);
                 if (global.city['smokehouse']){

--- a/src/main.js
+++ b/src/main.js
@@ -1586,7 +1586,7 @@ function fastLoop(){
             power_generated[loc('city_mill_title2')] = -(power);
         }
 
-        if (global.city['windmill'] && global.tech['wind_plant'] && (global.race['soul_eater'] || global.race['detritivore'] || global.race['carnivore'] || global.race['artifical'])){
+        if (global.city['windmill'] && global.tech['wind_plant']){
             let power = powerModifier(global.city.windmill.count * actions.city.windmill.powered());
             max_power += power;
             power_grid -= power;
@@ -2677,93 +2677,98 @@ function fastLoop(){
                     food_bd[loc('city_transmitter')] = food_base + 'v';
                 }
             }
-            else if (global.race['detritivore']){
-                if (global.city['compost']){
-                    let operating = global.city.compost.on;
-                    if (!global.race['kindling_kindred']){
-                        let lumberIncrement = 0.5;
-                        let lumber_cost = operating * lumberIncrement;
-
-                        while (lumber_cost * time_multiplier > global.resource.Lumber.amount && lumber_cost > 0){
-                            lumber_cost -= lumberIncrement;
-                            operating--;
-                        }
-
-                        breakdown.p.consume.Lumber[loc('city_compost_heap')] = -(lumber_cost);
-                        modRes('Lumber', -(lumber_cost * time_multiplier));
-                    }
-                    food_base = operating * (1.2 + (global.tech['compost'] * 0.8));
-                    food_base *= global.city.biome === 'grassland' ? biomes.grassland.vars()[0] : 1;
-                    food_base *= global.city.biome === 'volcanic' ? biomes.volcanic.vars()[0] : 1;
-                    food_base *= global.city.biome === 'hellscape' ? biomes.hellscape.vars()[0] : 1;
-                    food_base *= global.city.ptrait === 'trashed' ? planetTraits.trashed.vars()[0] : 1;
-                    food_bd[loc('city_compost_heap')] = food_base + 'v';
-                }
-            }
-            else if (global.race['carnivore'] || global.race['soul_eater']){
-                let strength = global.tech['military'] ? (global.tech.military >= 5 ? global.tech.military - 1 : global.tech.military) : 1;
-                food_base = global.civic.hunter.workers * strength * (global.race['carnivore'] ? 2 : 0.5);
-                if (global.race['ghostly']){
-                    food_base *= 1 + (traits.ghostly.vars()[0] / 100);
-                }
-                food_bd[loc('job_hunter')] = food_base + 'v';
-
-                if (global.race['carnivore'] && global.city['lodge'] && food_base > 0){
-                    food_base *= 1 + (global.city.lodge.count / 20);
-                    food_bd[`ᄂ${loc('city_lodge')}`] = (global.city.lodge.count * 5) + '%';
-                }
-
-                if (global.city['soul_well']){
-                    let souls = global.city['soul_well'].count * (global.race['ghostly'] ? (2 + traits.ghostly.vars()[1]) : 2);
-                    food_bd[loc('city_soul_well')] = souls + 'v';
-                    food_base += souls;
-                }
-            }
             else {
-                let weather_multiplier = 1;
-                if (!global.race['submerged']){
-                    if (global.city.calendar.temp === 0){
-                        if (global.city.calendar.weather === 0){
-                            weather_multiplier *= global.race['chilled'] ? (1 + traits.chilled.vars()[3] / 100) : 0.7;
+                if (global.race['detritivore']){
+                    if (global.city['compost']){
+                        let operating = global.city.compost.on;
+                        if (!global.race['kindling_kindred']){
+                            let lumberIncrement = 0.5;
+                            let lumber_cost = operating * lumberIncrement;
+
+                            while (lumber_cost * time_multiplier > global.resource.Lumber.amount && lumber_cost > 0){
+                                lumber_cost -= lumberIncrement;
+                                operating--;
+                            }
+
+                            breakdown.p.consume.Lumber[loc('city_compost_heap')] = -(lumber_cost);
+                            modRes('Lumber', -(lumber_cost * time_multiplier));
                         }
-                        else {
-                            weather_multiplier *= global.race['chilled'] ? (1 + traits.chilled.vars()[4] / 100) : 0.85;
-                        }
-                    }
-                    if (global.city.calendar.weather === 2){
-                        weather_multiplier *= global.race['chilled'] ? (1 - traits.chilled.vars()[5] / 100) : 1.1;
+                        let food_compost = operating * (1.2 + (global.tech['compost'] * 0.8));
+                        food_compost *= global.city.biome === 'grassland' ? biomes.grassland.vars()[0] : 1;
+                        food_compost *= global.city.biome === 'volcanic' ? biomes.volcanic.vars()[0] : 1;
+                        food_compost *= global.city.biome === 'hellscape' ? biomes.hellscape.vars()[0] : 1;
+                        food_compost *= global.city.ptrait === 'trashed' ? planetTraits.trashed.vars()[0] : 1;
+                        food_bd[loc('city_compost_heap')] = food_compost + 'v';
+                        food_base += food_compost;
                     }
                 }
+                if (global.race['carnivore'] || global.race['soul_eater']){
+                    let strength = global.tech['military'] ? (global.tech.military >= 5 ? global.tech.military - 1 : global.tech.military) : 1;
+                    let food_hunt = global.civic.hunter.workers * strength * (global.race['carnivore'] ? 2 : 0.5);
+                    if (global.race['ghostly']){
+                        food_hunt *= 1 + (traits.ghostly.vars()[0] / 100);
+                    }
+                    food_bd[loc('job_hunter')] = food_hunt + 'v';
 
-                if (global.race['forager']){
-                    let forage = 1 + (global.tech['foraging'] ? 0.75 * global.tech['foraging'] : 0);
-                    food_base = global.civic.forager.workers * forage * 0.35;
-                    food_bd[loc('job_forager')] = food_base + 'v';
+                    if (global.race['carnivore'] && global.city['lodge'] && food_hunt > 0){
+                        food_hunt *= 1 + (global.city.lodge.count / 20);
+                        food_bd[`ᄂ${loc('city_lodge')}`] = (global.city.lodge.count * 5) + '%';
+                    }
+
+                    if (global.city['soul_well']){
+                        let souls = global.city['soul_well'].count * (global.race['ghostly'] ? (2 + traits.ghostly.vars()[1]) : 2);
+                        food_hunt += souls;
+                        food_bd[loc('city_soul_well')] = souls + 'v';
+                    }
+                    food_base += food_hunt;
                 }
-
-                if (global.city['farm']){
-                    let farmers = global.civic.farmer.workers;
-                    let farmhands = 0;
-                    if (farmers > global.city.farm.count){
-                        farmhands = farmers - global.city.farm.count;
-                        farmers = global.city.farm.count;
+                if (global.city['farm'] || global.race['forager']) {
+                    let weather_multiplier = 1;
+                    if (!global.race['submerged']){
+                        if (global.city.calendar.temp === 0){
+                            if (global.city.calendar.weather === 0){
+                                weather_multiplier *= global.race['chilled'] ? (1 + traits.chilled.vars()[3] / 100) : 0.7;
+                            }
+                            else {
+                                weather_multiplier *= global.race['chilled'] ? (1 + traits.chilled.vars()[4] / 100) : 0.85;
+                            }
+                        }
+                        if (global.city.calendar.weather === 2){
+                            weather_multiplier *= global.race['chilled'] ? (1 - traits.chilled.vars()[5] / 100) : 1.1;
+                        }
                     }
 
-                    let mill_multiplier = 1;
-                    if (global.city['mill']){
-                        let mill_bonus = global.tech['agriculture'] >= 5 ? 0.05 : 0.03;
-                        let working = global.city['mill'].count - global.city['mill'].on;
-                        mill_multiplier += (working * mill_bonus);
+                    if (global.race['forager']){
+                        let forage = 1 + (global.tech['foraging'] ? 0.75 * global.tech['foraging'] : 0);
+                        let food_forage = global.civic.forager.workers * forage * 0.35;
+                        food_bd[loc('job_forager')] = food_forage + 'v';
+                        food_base += food_forage;
                     }
 
-                    let food = (farmers * farmerValue(true)) + (farmhands * farmerValue(false));
+                    if (global.city['farm']){
+                        let farmers = global.civic.farmer.workers;
+                        let farmhands = 0;
+                        if (farmers > global.city.farm.count){
+                            farmhands = farmers - global.city.farm.count;
+                            farmers = global.city.farm.count;
+                        }
 
-                    food_bd[loc('job_farmer')] = (food) + 'v';
-                    food_base += (food * weather_multiplier * mill_multiplier);
+                        let mill_multiplier = 1;
+                        if (global.city['mill']){
+                            let mill_bonus = global.tech['agriculture'] >= 5 ? 0.05 : 0.03;
+                            let working = global.city['mill'].count - global.city['mill'].on;
+                            mill_multiplier += (working * mill_bonus);
+                        }
 
-                    if (food > 0){
-                        food_bd[`ᄂ${loc('city_mill_title1')}`] = ((mill_multiplier - 1) * 100) + '%';
-                        food_bd[`ᄂ${loc('morale_weather')}`] = ((weather_multiplier - 1) * 100) + '%';
+                        let food = (farmers * farmerValue(true)) + (farmhands * farmerValue(false));
+
+                        food_bd[loc('job_farmer')] = (food) + 'v';
+                        food_base += (food * weather_multiplier * mill_multiplier);
+
+                        if (food > 0){
+                            food_bd[`ᄂ${loc('city_mill_title1')}`] = ((mill_multiplier - 1) * 100) + '%';
+                            food_bd[`ᄂ${loc('morale_weather')}`] = ((weather_multiplier - 1) * 100) + '%';
+                        }
                     }
                 }
             }
@@ -7619,11 +7624,6 @@ function midLoop(){
 
         if (global.tech['foundry'] === 3 && (global.race['kindling_kindred'] || global.race['smoldering'])){
             global.tech['foundry'] = 4;
-        }
-
-        if (global.race['carnivore'] && global.civic.farmer.workers > 0){
-            global.civic.farmer.workers = 0;
-            global.civic.farmer.max = 0;
         }
 
         if (global.race['kindling_kindred'] || global.race['smoldering']){

--- a/src/tech.js
+++ b/src/tech.js
@@ -3,7 +3,7 @@ import { loc } from './locale.js';
 import { vBind, clearElement, calcQueueMax, calcRQueueMax, calcPrestige, messageQueue, clearPopper } from './functions.js';
 import { unlockAchieve, alevel, universeAffix } from './achieve.js';
 import { payCosts, housingLabel, wardenLabel, updateQueueNames, drawTech, fanaticism, checkAffordable } from './actions.js';
-import { races, genusVars } from './races.js';
+import { races, genusVars, checkAltPurgatory } from './races.js';
 import { defineResources, resource_values, atomic_mass } from './resources.js';
 import { loadFoundry } from './jobs.js';
 import { defineIndustry, buildGarrison, checkControlling, govTitle } from './civics.js';
@@ -479,7 +479,7 @@ const techs = {
         effect: loc('tech_smokehouse_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['smokehouse'] = { count: 0 };
+                checkAltPurgatory('city','smokehouse','silo',{ count: 0 });
                 return true;
             }
             return false;
@@ -500,7 +500,7 @@ const techs = {
         effect: loc('tech_lodge_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['lodge'] = { count: 0 };
+                checkAltPurgatory('city','lodge','farm',{ count: 0 });
                 return true;
             }
             return false;
@@ -525,7 +525,7 @@ const techs = {
         effect(){ return global.race['detritivore'] || global.race['artifical'] ? loc('tech_lodge_effect_alt') : loc('tech_lodge_effect'); },
         action(){
             if (payCosts($(this)[0])){
-                global.city['lodge'] = { count: 0 };
+                checkAltPurgatory('city','lodge','farm',{ count: 0 });
                 return true;
             }
             return false;
@@ -650,7 +650,7 @@ const techs = {
         effect: loc('tech_agriculture_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['farm'] = { count: 0 };
+                checkAltPurgatory('city','farm','lodge',{ count: 0 });
                 return true;
             }
             return false;
@@ -709,7 +709,7 @@ const techs = {
         effect: loc('tech_silo_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['silo'] = { count: 0 };
+                checkAltPurgatory('city','silo','smokehouse',{ count: 0 });
                 return true;
             }
             return false;
@@ -729,10 +729,8 @@ const techs = {
         effect: loc('tech_mill_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['mill'] = {
-                    count: 0,
-                    on: 0
-                };
+                checkAltPurgatory('city','mill','windmill',{ count: 0 });
+                global.city['mill'].on = 0;
                 return true;
             }
             return false;
@@ -791,7 +789,7 @@ const techs = {
         effect: loc('tech_wind_plant_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['windmill'] = { count: 0 };
+                checkAltPurgatory('city','windmill','mill',{ count: 0 });
                 return true;
             }
             return false;

--- a/src/tech.js
+++ b/src/tech.js
@@ -493,6 +493,7 @@ const techs = {
         category: 'agriculture',
         era: 'civilized',
         reqs: { hunting: 1, housing: 1, currency: 1 },
+        not_trait: ['herbivore'],
         grant: ['hunting',2],
         cost: {
             Knowledge(){ return 180; }
@@ -508,21 +509,21 @@ const techs = {
     },
     alt_lodge: {
         id: 'tech-alt_lodge',
-        title(){ return global.race['detritivore'] || global.race['artifical'] ? loc('tech_lodge_alt') : loc('tech_lodge'); },
-        desc(){ return global.race['detritivore'] || global.race['artifical'] ? loc('tech_lodge_alt') : loc('tech_lodge'); },
+        title(){ return this.condition() ? loc('tech_lodge_alt') : loc('tech_lodge'); },
+        desc(){ return this.condition() ? loc('tech_lodge_alt') : loc('tech_lodge'); },
         wiki: global.race['carnivore'] ? false : true,
         category: 'housing',
         era: 'civilized',
         reqs: { housing: 1, currency: 1 },
         grant: ['s_lodge',1],
-        not_trait: ['carnivore'],
         condition(){
-            return global.race.species === 'wendigo' || (!global.race['soul_eater'] && (global.race['detritivore'] || global.race['artifical'])) ? true : false;
+            return (((global.race.species === 'wendigo' || global.race['detritivore']) && !global.race['carnivore'] && !global.race['herbivore'])
+              || (global.race['carnivore'] && global.race['soul_eater']) || global.race['artifical']) ? true : false;
         },
         cost: {
             Knowledge(){ return global.race['artifical'] ? 10000 : 180; }
         },
-        effect(){ return global.race['detritivore'] || global.race['artifical'] ? loc('tech_lodge_effect_alt') : loc('tech_lodge_effect'); },
+        effect(){ return this.condition() ? loc('tech_lodge_effect_alt') : loc('tech_lodge_effect'); },
         action(){
             if (payCosts($(this)[0])){
                 checkAltPurgatory('city','lodge','farm',{ count: 0 });
@@ -642,7 +643,10 @@ const techs = {
         category: 'agriculture',
         era: 'civilized',
         reqs: { primitive: 3 },
-        not_trait: ['carnivore','soul_eater','detritivore','cataclysm','artifical'],
+        condition(){
+            return (global.race['herbivore'] || (!global.race['carnivore'] && !global.race['detritivore'] && !global.race['soul_eater'])) ? true : false;
+        },
+        not_trait: ['cataclysm','artifical'],
         grant: ['agriculture',1],
         cost: {
             Knowledge(){ return 10; }
@@ -702,6 +706,7 @@ const techs = {
         category: 'storage',
         era: 'civilized',
         reqs: { agriculture: 2, storage: 1 },
+        not_trait: ['carnivore'],
         grant: ['agriculture',3],
         cost: {
             Knowledge(){ return 80; }
@@ -781,7 +786,9 @@ const techs = {
         category: 'power_generation',
         era: 'globalized',
         reqs: { high_tech: 4 },
-        condition(){ return (global.tech['hunting'] && global.tech['hunting'] >= 2) || global.race['detritivore'] || global.race['artifical'] || global.race['soul_eater'] ? true : false; },
+        condition(){
+            return (global.tech['hunting'] >= 2 || global.race['detritivore'] || global.race['artifical'] || global.race['soul_eater'] || (global.race['carnivore'] && global.race['herbivore'])) ? true : false;
+        },
         grant: ['wind_plant',1],
         cost: {
             Knowledge(){ return 66000; }


### PR DESCRIPTION
Purgatory entries(techs and structures) properly upscaling after switching, progressing, and switching back, not only after first switch. (Might need starting new run or editing save)
Alt lodges tech synced with agriculture and hunting, to unsure housing will still be available after switch.
Mill and windmill checked first in purgatory on tech research, as they not synced as well as farm\lodges and such, and it's possible to unlock windmill already having some mills in purgatory.
(Frankly, that might be too OP, as it allows to get bunch of windmills right away, at cost of cheap mills, but they was defined as interchangeable in old carnivore mutation code, and still remains so)
Detritivore won't ever have hunters. (They locked from hunting techs, so giving them carnivore hunters with no smokehouse is pointless, and as soul eaters they already will have wells)
Fixed rituals adjustments.
Fixed spoiling souls and signal.