### PR TITLE
Map fixes

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -20,7 +20,8 @@ const spaceProjects = {
                 return races[global.race.species].home;
             },
             desc: loc('space_home_info_desc'),
-            zone: 'inner'
+            zone: 'inner',
+            syndicate(){ return false; }
         },
         test_launch: {
             id: 'space-test_launch',
@@ -1105,7 +1106,8 @@ const spaceProjects = {
             desc(){
                 return loc('space_hell_info_desc',[races[global.race.species].solar.hell]);
             },
-            zone: 'inner'
+            zone: 'inner',
+            syndicate(){ return false; }
         },
         hell_mission: {
             id: 'space-hell_mission',
@@ -1278,7 +1280,8 @@ const spaceProjects = {
                 return loc('space_sun_info_desc',[races[global.race.species].home]);
             },
             support: 'swarm_control',
-            zone: 'inner'
+            zone: 'inner',
+            syndicate(){ return false; }
         },
         sun_mission: {
             id: 'space-sun_mission',
@@ -1811,7 +1814,8 @@ const spaceProjects = {
             desc(){
                 return loc('space_dwarf_info_desc',[races[global.race.species].solar.dwarf]);
             },
-            zone: 'inner'
+            zone: 'inner',
+            syndicate(){ return false; }
         },
         dwarf_mission: {
             id: 'space-dwarf_mission',


### PR DESCRIPTION
Fixed Hell being defined and drawn on map as destinations.
Planet with not unlocked syndicate shown with gray color, same as non-destination. Spoilers!
With two above `dist` property on planets was removed, as it firstly wasn't correct, and secondly not needed anymore - syndicate check alone is enough.
Map zoom is centered at middle of canvas. I.e. planets won't drift sideway on zooming, staying in focus.
Map zoom uses `wheel` event instead of `mousewheel` - second one is non-standard and deprecated, and wont work in FF.
Fixed titan and enceladus syndicate_cap. They used to check `global.tech['triton']` in *two* places - in syndicate() and in their definitions, making value from definition unreachable. Now they always looking in definition, and also changed value in definition to what actually was ingame before this fix.
Fixed landing point calculation. My first attempt was too smartass to actually work good enough - it's way too inaccurate, showing more like approximate direction -+ few degrees, instead of real coordinates. Current approach is bruteforcing position, not so elegant, but perfectly accurate. (`genXYcoord(planet)` it's just a fallback, it shouldn't ever be reached) 
It does look for position only on demand - before ship dispatch, so bruteforcing won't really tax performance, and it seems to be fast enough to let it be so inefficient, until some *real* nasa scientist will bring fast and accurate implementation :)