### PR TITLE
Random fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7437,6 +7437,7 @@ function sentience(){
 
     if (global.stats.feat['adept'] && global.stats.achieve['whitehole'] && global.stats.achieve.whitehole.l > 0){
         let rank = Math.min(global.stats.achieve.whitehole.l,global.stats.feat['adept']);
+        global.resource.Food.amount += rank * 100;
         global.resource.Stone.max += rank * 60;
         global.resource.Stone.amount += rank * 100;
         if (global.race['smoldering']){
@@ -7964,7 +7965,7 @@ export function resQueue(){
             data: global.r_queue,
             methods: {
                 remove(index){
-                    cleanTechPopOver(`rq${global.r_queue.queue[index].id}`);
+                    clearPopper(`rq${global.r_queue.queue[index].id}`);
                     global.r_queue.queue.splice(index,1);
                     resQueue();
                 },
@@ -8026,7 +8027,7 @@ function resDragQueue(){
 function attachQueuePopovers(){
     for (let i=0; i<global.r_queue.queue.length; i++){
         let id = `rq${global.r_queue.queue[i].id}`;
-        cleanTechPopOver(id);
+        clearPopper(id);
 
         let c_action;
         let segments = global.r_queue.queue[i].id.split("-");
@@ -8037,17 +8038,11 @@ function attachQueuePopovers(){
                 actionDesc(obj.popper,c_action,global[segments[0]][segments[1]],false);
             },
             out: function(){
-                cleanTechPopOver(id);
+                clearPopper(id);
             },
             wide: c_action['wide']
         });
     }
-}
-
-export function cleanTechPopOver(id){
-    $(`#popper`).hide();
-    vBind({el: `#popTimer`},'destroy');
-    clearPopper();
 }
 
 function bananaPerk(val){

--- a/src/functions.js
+++ b/src/functions.js
@@ -405,6 +405,7 @@ export function buildQueue(){
                             global.queue.queue[index].q -= global.queue.queue[index].qs;
                         }
                         if (global.queue.queue[index].q <= 0){
+                            clearPopper(`q${global.queue.queue[index].id}${index}`);
                             global.queue.queue.splice(index,1);
                             buildQueue();
                             break;
@@ -1515,7 +1516,7 @@ function smolderAdjust(costs, offset, wiki){
                 let adjustRate = res === 'Plywood' ? 2 : 1;
                 newCosts['Chrysotile'] = function(){ return Math.round(costs[res](offset, wiki) * adjustRate) || 0; }
             }
-            else if (['Structs','Chrysotile','Knowledge','Custom','Soul_Gem','Plasmid','Phage','Dark','Harmony','Blood_Stone','Artifact','Corrupt_Gem','Codex','Demonic_Essence','Horseshoe'].includes(res)){
+            else if (['HellArmy','Structs','Chrysotile','Knowledge','Custom','Soul_Gem','Plasmid','Phage','Dark','Harmony','Blood_Stone','Artifact','Corrupt_Gem','Codex','Demonic_Essence','Horseshoe'].includes(res)){
                 newCosts[res] = function(){ return costs[res](offset, wiki); }
             }
             else {

--- a/src/industry.js
+++ b/src/industry.js
@@ -256,12 +256,16 @@ function loadSmelter(parent,bind){
                     if (global.city.smelter[type] > 0){
                         global.city.smelter[type]--;
                         let total = global.city.smelter.Wood + global.city.smelter.Coal + global.city.smelter.Oil + global.city.smelter.Star + global.city.smelter.Inferno;
-                        if (global.city.smelter.Iron + global.city.smelter.Steel > total){
+                        let used = global.city.smelter.Iron + global.city.smelter.Steel + global.city.smelter.Iridium;
+                        if (used > total){
                             if (global.city.smelter.Iron > 0){
                                 global.city.smelter.Iron--;
                             }
-                            else {
+                            else if (global.city.smelter.Steel > 0) {
                                 global.city.smelter.Steel--;
+                            }
+                            else if (global.city.smelter.Iridium > 0) {
+                                global.city.smelter.Iridium--;
                             }
                         }
                     }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { defineResources, resource_values, spatialReasoning, craftCost, plasmidB
 import { defineJobs, job_desc, loadFoundry, farmerValue } from './jobs.js';
 import { f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources } from './industry.js';
 import { defineIndustry, checkControlling, garrisonSize, armyRating, govTitle, govCivics } from './civics.js';
-import { actions, updateDesc, setChallengeScreen, addAction, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, removeAction, evoProgress, housingLabel, updateQueueNames, wardenLabel, setPlanet, resQueue, bank_vault, start_cataclysm, cleanTechPopOver, raceList } from './actions.js';
+import { actions, updateDesc, setChallengeScreen, addAction, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, removeAction, evoProgress, housingLabel, updateQueueNames, wardenLabel, setPlanet, resQueue, bank_vault, start_cataclysm, raceList } from './actions.js';
 import { renderSpace, fuel_adjust, int_fuel_adjust, zigguratBonus, setUniverse, universe_types, gatewayStorage, piracy, spaceTech } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay } from './portal.js';
 import { syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, storehouseMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift } from './truepath.js';
@@ -7831,7 +7831,7 @@ function midLoop(){
 
                 if (t_action['grant'] && global.tech[t_action.grant[0]] && global.tech[t_action.grant[0]] >= t_action.grant[1]){
                     global.r_queue.queue.splice(i,1);
-                    cleanTechPopOver(`rq${c_action.id}`);
+                    clearPopper(`rq${c_action.id}`);
                     break;
                 }
                 else {
@@ -7868,7 +7868,7 @@ function midLoop(){
                         c_action.post();
                     }
                     global.r_queue.queue.splice(idx,1);
-                    cleanTechPopOver(`rq${c_action.id}`);
+                    clearPopper(`rq${c_action.id}`);
                     resQueue();
                 }
             }

--- a/src/portal.js
+++ b/src/portal.js
@@ -5,7 +5,7 @@ import { traits, races } from './races.js';
 import { defineResources, spatialReasoning } from './resources.js';
 import { loadFoundry } from './jobs.js';
 import { armyRating, govCivics } from './civics.js';
-import { payCosts, setAction, drawTech, bank_vault, cleanTechPopOver } from './actions.js';
+import { payCosts, setAction, drawTech, bank_vault } from './actions.js';
 import { checkRequirements, incrementStruct } from './space.js';
 import { govActive } from './governor.js';
 import { loadTab } from './index.js';
@@ -1470,7 +1470,7 @@ const fortressModules = {
                 if (global.tech['sphinx_bribe']){
                     drawTech();
                     renderFortress();
-                    cleanTechPopOver('portal-bribe_sphinx');
+                    clearPopper('portal-bribe_sphinx');
                 }
             }
         },
@@ -1499,7 +1499,7 @@ const fortressModules = {
             post(){
                 if (global.tech['hell_spire'] && global.tech.hell_spire === 9){
                     renderFortress();
-                    cleanTechPopOver('portal-spire_survey');
+                    clearPopper('portal-spire_survey');
                 }
             }
         },

--- a/src/resources.js
+++ b/src/resources.js
@@ -1154,34 +1154,37 @@ export function marketItem(mount,market_item,name,color,full){
                     if (global.race['conniving']){
                         value *= 1 - (traits.conniving.vars()[0] / 100);
                     }
-                    var price = Math.round(value * qty);
-                    if (global.resource.Money.amount >= price){
-                        global.resource[res].amount += Number(qty);
-                        global.resource.Money.amount -= Number(price);
-                        
-                        global.resource[res].value += Number((qty / Math.rand(1000,10000)).toFixed(2));
+                    let amount = Math.floor(Math.min(qty, global.resource.Money.amount / value,
+                      global.resource[res].max - global.resource[res].amount));
+                    if (amount > 0){
+                        global.resource[res].amount += amount;
+                        global.resource.Money.amount -= Math.round(value * amount);
+
+                        global.resource[res].value += Number((amount / Math.rand(1000,10000)).toFixed(2));
                     }
                 }
             },
             sell(res){
                 if (!global.race['no_trade']){
-                    var qty = global.city.market.qty;
-                    if (global.resource[res].amount >= qty){
-                        let divide = 4;
-                        if (global.race['merchant']){
-                            divide *= 1 - (traits.merchant.vars()[0] / 100);
-                        }
-                        if (global.race['asymmetrical']){
-                            divide *= 1 + (traits.asymmetrical.vars()[0] / 100);
-                        }
-                        if (global.race['conniving']){
-                            divide *= 1 - (traits.conniving.vars()[1] / 100);
-                        } 
-                        let price = Math.round(global.resource[res].value * qty / divide);
-                        global.resource[res].amount -= Number(qty);
-                        global.resource.Money.amount += Number(price);
-                        
-                        global.resource[res].value -= Number((qty / Math.rand(1000,10000)).toFixed(2));
+                    let qty = global.city.market.qty;
+                    let divide = 4;
+                    if (global.race['merchant']){
+                        divide *= 1 - (traits.merchant.vars()[0] / 100);
+                    }
+                    if (global.race['asymmetrical']){
+                        divide *= 1 + (traits.asymmetrical.vars()[0] / 100);
+                    }
+                    if (global.race['conniving']){
+                        divide *= 1 - (traits.conniving.vars()[1] / 100);
+                    }
+                    let price = global.resource[res].value / divide;
+                    let amount = Math.floor(Math.min(qty, global.resource[res].amount,
+                      (global.resource.Money.max - global.resource.Money.amount) / price));
+                    if (amount > 0) {
+                        global.resource[res].amount -= amount;
+                        global.resource.Money.amount += Math.round(price * amount);
+
+                        global.resource[res].value -= Number((amount / Math.rand(1000,10000)).toFixed(2));
                         if (global.resource[res].value < Number(resource_values[res] / 2)){
                             global.resource[res].value = Number(resource_values[res] / 2);
                         }
@@ -2540,6 +2543,7 @@ export function loadAlchemy(name,color,basic){
                     for (let i=0; i<keyMult; i++){
                         if (global.race.alchemy[spell] > 0){
                             global.race.alchemy[spell]--;
+                            global.resource.Mana.diff++;
                         }
                         else {
                             break;

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -1,5 +1,5 @@
 import { global, p_on, support_on, sizeApproximation, quantum_level } from './vars.js';
-import { vBind, clearElement, popover, messageQueue, powerCostMod, powerModifier, spaceCostMultiplier, deepClone } from './functions.js';
+import { vBind, clearElement, popover, clearPopper, messageQueue, powerCostMod, powerModifier, spaceCostMultiplier, deepClone } from './functions.js';
 import { races, genusVars, traits } from './races.js';
 import { spatialReasoning } from './resources.js';
 import { defineIndustry, armyRating, garrisonSize } from './civics.js';
@@ -2096,6 +2096,7 @@ function drawShips(){
                             global.space.shipyard.ships[id].destination = {x: dest.x, y: dest.y};
                             global.civic.garrison.crew += crew;
                             drawShips();
+                            clearPopper(`ship${id}loc${l}`);
                         }
                     }
                 },
@@ -2171,8 +2172,8 @@ function calcLandingPoint(ship, planet) {
     let ship_speed = shipSpeed(ship) / 225;
     let cross1_dist = Math.abs(ship_dist - spacePlanetStats[planet].dist);
     let cross2_dist = Math.abs(ship_dist + spacePlanetStats[planet].dist);
-    let cross1_days = Math.min(cross1_dist, cross2_dist) / ship_speed;
-    let cross2_days = Math.max(cross1_dist, cross2_dist) / ship_speed;
+    let cross1_days = Math.floor(Math.min(cross1_dist, cross2_dist) / ship_speed);
+    let cross2_days = Math.ceil(Math.max(cross1_dist, cross2_dist) / ship_speed);
     let planet_orbit = spacePlanetStats[planet].orbit === -1
       ? global.city.calendar.orbit
       : spacePlanetStats[planet].orbit;


### PR DESCRIPTION
Removing queue\ship time popups on click, so they won't stuck on screen anymore.
Removed `cleanTechPopOver()`, replacing it with `clearPopper()`. This thing obsolete and broken since last poppers rework. It ignores passed argument, removing *any* active tooltip instead of requested one, and then removes popTimer which would be removed in `clearElement()` anyway. Overall it does nothing good.
Added missing rounding to `calcLandingPoint()`. Mostly nitpick fix - ship landing position could be something like half day off, which won't even be noticeable.
Smelter's subFuel correctly processing iridium, removing it with when there's no fuel.
Adept perk actually gives food.
Amount of soldiers required to assault soul forge not discounted by smoldering anymore. Mostly for consistency, as amount of soldiers required for *upkeep* of said forge isn't affected by smoldering.
Removing transmutations instantly returns mana in vue callback, making it possible to work with it when game is paused.
Bulk buying and selling automatically adjusted down to maximum storable and affordable amount. (Not really a bug, that's trivial and many times requested QOL feature)