### PR TITLE
use Aquatic consistently

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -8105,7 +8105,7 @@
   "wiki_planet_swamp3": "Stone Production %0",
   "wiki_planet_swamp_trait": "Swamp planets have increased odds of rain.",
   "wiki_planet_swamp_trait2": "Swamps are harder to invade, but they are bountiful with resources.",
-  "wiki_planet_swamp_genus": "Can spawn Fey and Oceanic races.",
+  "wiki_planet_swamp_genus": "Can spawn Fey and Aquatic races.",
   "wiki_planet_swamp_condition": "Requires Oceanic or Forest Civilizer unlocked in current universe to spawn.",
   "wiki_planet_ashland0": "Agriculture %0",
   "wiki_planet_ashland1": "Cement %0",

--- a/strings/strings.ru-RU.json
+++ b/strings/strings.ru-RU.json
@@ -8105,7 +8105,7 @@
   "wiki_planet_swamp3": "Stone Production %0",
   "wiki_planet_swamp_trait": "Swamp planets have increased odds of rain.",
   "wiki_planet_swamp_trait2": "Swamps are harder to invade, but they are bountiful with resources.",
-  "wiki_planet_swamp_genus": "Can spawn Fey and Oceanic races.",
+  "wiki_planet_swamp_genus": "Can spawn Fey and Aquatic races.",
   "wiki_planet_swamp_condition": "Requires Oceanic or Forest Civilizer unlocked in current universe to spawn.",
   "wiki_planet_ashland0": "Agriculture %0",
   "wiki_planet_ashland1": "Cement %0",


### PR DESCRIPTION
The description for swamp biomes says they can spawn Oceanic races. The
actual racial type is Aquatic. This is correctly specified in the
Oceanic biome.

Fix the swampland biome text to be consistent.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
