### PR TITLE
mistranslation patch

### DIFF
--- a/strings/strings.ko-KR.json
+++ b/strings/strings.ko-KR.json
@@ -2948,7 +2948,7 @@
   "achieve_extinct_orc_name": "이방인",
   "achieve_extinct_orc_desc": "오크 문명을 멸망으로로 이끄세요.",
   "achieve_extinct_orc_flair": "영광의 불길 속에서 나가버렸어.",
-  "achieve_extinct_cath_name": "세이버 이빨 호랑이",
+  "achieve_extinct_cath_name": "검치호랑이",
   "achieve_extinct_cath_desc": "고양이 문명을 멸망으로 이끄세요.",
   "achieve_extinct_cath_flair": "마지막 게시물을 긁었어.",
   "achieve_extinct_wolven_name": "다이어울프",


### PR DESCRIPTION
세이버 이빨 호랑이 -> 검치호랑이
'Sabertooth Tiger' is translated to Korean '검치호랑이', not 세이버 이빨 호랑이.