### PR TITLE
Queue refactoring & fixes 

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -30,7 +30,8 @@ export const actions = {
                     modRes('RNA',global.race['rapid_mutation'] ? 2 : 1,true);
                 }
                 return false;
-            }
+            },
+            queue_complete(){ return 0; }
         },
         dna: {
             id: 'evolution-dna',
@@ -44,7 +45,8 @@ export const actions = {
                 }
                 return false;
             },
-            effect: loc('evo_dna_effect')
+            effect: loc('evo_dna_effect'),
+            queue_complete(){ return 0; }
         },
         membrane: {
             id: 'evolution-membrane',
@@ -62,8 +64,7 @@ export const actions = {
                     return true;
                 }
                 return false;
-            },
-            queueable: true
+            }
         },
         organelles: {
             id: 'evolution-organelles',
@@ -86,8 +87,7 @@ export const actions = {
                     return true;
                 }
                 return false;
-            },
-            queueable: true
+            }
         },
         nucleus: {
             id: 'evolution-nucleus',
@@ -107,8 +107,7 @@ export const actions = {
                     return true;
                 }
                 return false;
-            },
-            queueable: true
+            }
         },
         eukaryotic_cell: {
             id: 'evolution-eukaryotic_cell',
@@ -129,8 +128,7 @@ export const actions = {
                     return true;
                 }
                 return false;
-            },
-            queueable: true
+            }
         },
         mitochondria: {
             id: 'evolution-mitochondria',
@@ -147,8 +145,7 @@ export const actions = {
                     return true;
                 }
                 return false;
-            },
-            queueable: true
+            }
         },
         sexual_reproduction: {
             id: 'evolution-sexual_reproduction',
@@ -175,15 +172,11 @@ export const actions = {
                     }
                     global.evolution['final'] = 20;
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.sexual_reproduction.count}
         },
         phagocytosis: {
             id: 'evolution-phagocytosis',
@@ -209,15 +202,11 @@ export const actions = {
                     global.evolution['final'] = 40;
                     addAction('evolution','multicellular');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.phagocytosis.count; }
         },
         chloroplasts: {
             id: 'evolution-chloroplasts',
@@ -243,15 +232,11 @@ export const actions = {
                     global.evolution['final'] = 40;
                     addAction('evolution','multicellular');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.chloroplasts.count; }
         },
         chitin: {
             id: 'evolution-chitin',
@@ -277,15 +262,11 @@ export const actions = {
                     global.evolution['final'] = 40;
                     addAction('evolution','multicellular');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.chitin.count; }
         },
         exterminate: {
             id: 'evolution-exterminate',
@@ -320,15 +301,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.exterminate.count; }
         },
         multicellular: {
             id: 'evolution-multicellular',
@@ -357,15 +334,11 @@ export const actions = {
                         addAction('evolution','spores');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.multicellular.count; }
         },
         spores: {
             id: 'evolution-spores',
@@ -383,15 +356,11 @@ export const actions = {
                     global.evolution['final'] = 80;
                     addAction('evolution','bryophyte');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.spores.count; }
         },
         poikilohydric: {
             id: 'evolution-poikilohydric',
@@ -409,15 +378,11 @@ export const actions = {
                     global.evolution['final'] = 80;
                     addAction('evolution','bryophyte');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.poikilohydric.count; }
         },
         bilateral_symmetry: {
             id: 'evolution-bilateral_symmetry',
@@ -462,15 +427,11 @@ export const actions = {
                     }
 
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.bilateral_symmetry.count; }
         },
         bryophyte: {
             id: 'evolution-bryophyte',
@@ -508,15 +469,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.bryophyte.count; }
         },
         athropods: {
             id: 'evolution-athropods',
@@ -543,15 +500,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.athropods.count; }
         },
         mammals: {
             id: 'evolution-mammals',
@@ -607,15 +560,11 @@ export const actions = {
                     addAction('evolution','dwarfism');
                     addAction('evolution','animalism');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.mammals.count; }
         },
         humanoid: {
             id: 'evolution-humanoid',
@@ -650,15 +599,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.humanoid.count; }
         },
         gigantism: {
             id: 'evolution-gigantism',
@@ -693,15 +638,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.gigantism.count; }
         },
         dwarfism: {
             id: 'evolution-dwarfism',
@@ -736,15 +677,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.dwarfism.count; }
         },
         animalism: {
             id: 'evolution-animalism',
@@ -774,15 +711,11 @@ export const actions = {
                     addAction('evolution','herbivore');
                     //addAction('evolution','omnivore');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.animalism.count; }
         },
         carnivore: {
             id: 'evolution-carnivore',
@@ -813,15 +746,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.carnivore.count; }
         },
         herbivore: {
             id: 'evolution-herbivore',
@@ -852,15 +781,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.herbivore.count; }
         },
         omnivore: {
             id: 'evolution-omnivore',
@@ -891,15 +816,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.omnivore.count; }
         },
         celestial: {
             id: 'evolution-celestial',
@@ -926,15 +847,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.celestial.count; }
         },
         demonic: {
             id: 'evolution-demonic',
@@ -961,15 +878,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.demonic.count; }
         },
         aquatic: {
             id: 'evolution-aquatic',
@@ -996,15 +909,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.aquatic.count; }
         },
         fey: {
             id: 'evolution-fey',
@@ -1031,15 +940,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.fey.count; },
         },
         heat: {
             id: 'evolution-heat',
@@ -1066,15 +971,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.heat.count; }
         },
         polar: {
             id: 'evolution-polar',
@@ -1101,15 +1002,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.polar.count; }
         },
         sand: {
             id: 'evolution-sand',
@@ -1136,15 +1033,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.sand.count; }
         },
         eggshell: {
             id: 'evolution-eggshell',
@@ -1164,15 +1057,11 @@ export const actions = {
                     addAction('evolution','endothermic');
                     addAction('evolution','ectothermic');
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.eggshell.count; }
         },
         endothermic: {
             id: 'evolution-endothermic',
@@ -1201,15 +1090,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.endothermic.count; }
         },
         ectothermic: {
             id: 'evolution-ectothermic',
@@ -1238,15 +1123,11 @@ export const actions = {
                         addAction('evolution','bunker');
                     }
                     evoProgress();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.ectothermic.count; }
         },
         sentience: {
             id: 'evolution-sentience',
@@ -1609,12 +1490,7 @@ export const actions = {
                     return '';
                 }
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true
+            queue_complete(){ return 1 - global.evolution.sentience.count; }
         },
         custom: {
             id: 'evolution-custom',
@@ -1631,16 +1507,10 @@ export const actions = {
                     removeAction(actions.evolution.sentience.id);
                     global.race.species = 'custom';
                     sentience();
-                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true,
+            queue_complete(){ return 1 - global.evolution.sentience.count; },
             emblem(){ return format_emblem('extinct_custom'); }
         },
         bunker: {
@@ -1654,15 +1524,11 @@ export const actions = {
             action(){
                 if (payCosts($(this)[0])){
                     setChallengeScreen();
+                    return true;
                 }
                 return false;
             },
-            no_queue(){
-                let key = $(this)[0].id.split('-')[1];
-                return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-            },
-            queue_complete(){ return 1; },
-            queueable: true,
+            queue_complete(){ return 1 - global.evolution.bunker.count; },
             flair: loc('evo_bunker_flair')
         },
         joyless: {
@@ -1679,6 +1545,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('joyless'); },
             flair: loc('evo_challenge_joyless_flair'),
             highlight(){ return global.race['joyless'] ? true : false; }
@@ -1697,6 +1564,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('steelen'); },
             flair: loc('evo_challenge_steelen_flair'),
             highlight(){ return global.race['steelen'] ? true : false; }
@@ -1715,6 +1583,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('dissipated'); },
             flair: loc('evo_challenge_decay_flair'),
             highlight(){ return global.race['decay'] ? true : false; }
@@ -1733,6 +1602,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('technophobe'); },
             flair: loc('evo_challenge_emfield_flair'),
             highlight(){ return global.race['emfield'] ? true : false; }
@@ -1751,6 +1621,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('wheelbarrow'); },
             flair: loc('evo_challenge_inflation_flair'),
             highlight(){ return global.race['inflation'] ? true : false; }
@@ -1769,6 +1640,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('extinct_sludge'); },
             flair: loc('evo_challenge_sludge_flair'),
             highlight(){ return global.race['sludge'] ? true : false; }
@@ -1794,6 +1666,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('lamentis'); },
             flair: loc('evo_challenge_orbit_decay_flair'),
             highlight(){ return global.race['orbit_decay'] ? true : false; }
@@ -1813,6 +1686,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('extinct_junker'); },
             flair: loc('evo_challenge_junker_flair'),
             highlight(){ return global.race['junker'] ? true : false; }
@@ -1838,6 +1712,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('iron_will'); },
             flair: loc('evo_challenge_cataclysm_flair'),
             highlight(){ return global.race['cataclysm'] ? true : false; }
@@ -1856,6 +1731,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('banana'); },
             flair: loc('evo_challenge_banana_flair'),
             highlight(){ return global.race['banana'] ? true : false; }
@@ -1874,6 +1750,7 @@ export const actions = {
                 }
                 return false;
             },
+            queue_complete(){ return 0; },
             emblem(){ return format_emblem('pathfinder'); },
             flair: loc('evo_challenge_truepath_flair'),
             highlight(){ return global.race['truepath'] ? true : false; }
@@ -1887,7 +1764,7 @@ export const actions = {
             wiki: false,
             category: 'outskirts',
             reqs: { primitive: 1 },
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             not_tech: ['santa'],
             not_trait: ['cataclysm'],
             class: ['hgift'],
@@ -2059,7 +1936,7 @@ export const actions = {
             category: 'outskirts',
             reqs: { primitive: 1 },
             not_trait: ['soul_eater','cataclysm','artifical'],
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {
                 Mana(){ return global.tech['conjuring'] ? 1 : 0; },
             },
@@ -2110,7 +1987,7 @@ export const actions = {
             category: 'outskirts',
             reqs: {},
             not_trait: ['evil','cataclysm'],
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {
                 Mana(){ return global.tech['conjuring'] && global.tech['conjuring'] >= 2 ? 1 : 0; },
             },
@@ -2159,7 +2036,7 @@ export const actions = {
             category: 'outskirts',
             reqs: { primitive: 2 },
             not_trait: ['cataclysm'],
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {
                 Mana(){ return global.tech['conjuring'] && global.tech['conjuring'] >= 2 ? 1 : 0; },
             },
@@ -2209,7 +2086,7 @@ export const actions = {
             reqs: { primitive: 2 },
             trait: ['smoldering'],
             not_trait: ['cataclysm'],
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {
                 Mana(){ return global.tech['conjuring'] && global.tech['conjuring'] >= 2 ? 1 : 0; },
             },
@@ -2249,7 +2126,7 @@ export const actions = {
             reqs: {},
             trait: ['evil'],
             not_trait: ['kindling_kindred','smoldering','cataclysm'],
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             action(){
                 let gain = global.race['strong'] ? traits.strong.vars()[0] : 1;
                 if (global.genes['enhance']){
@@ -2290,7 +2167,7 @@ export const actions = {
             cost: {
                 Money(){ return 25000; },
             },
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             action(){
                 if (global.race['slaver'] && global.city['slave_pen']){
                     let max = global.city.slave_pen.count * 4;
@@ -4697,7 +4574,6 @@ export const actions = {
                 }
             },
             reqs: { genesis: 5 },
-            no_queue(){ return global.starDock.seeder.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.starDock.seeder.count; },
             cost: {
@@ -4734,8 +4610,8 @@ export const actions = {
                 return `<div>${label}</div><div class="has-text-danger">${loc('star_dock_genesis_desc2')}</div>`;
             },
             reqs: { genesis: 6 },
+            queue_complete(){ return 0; },
             cost: {},
-            no_queue(){ return true },
             effect(){
                 let gains = calcPrestige('bioseed');
                 let plasmidType = global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name');
@@ -4759,8 +4635,8 @@ export const actions = {
                 return `<div>${label}</div><div class="has-text-danger">${loc('star_dock_genesis_desc2')}</div>`;
             },
             reqs: { genesis: 7 },
+            queue_complete(){ return 0; },
             cost: {},
-            no_queue(){ return true },
             effect(){
                 let gains = calcPrestige('bioseed');
                 let plasmidType = global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name');
@@ -4894,7 +4770,7 @@ export function buildTemplate(key, region){
                     return eventActive(`summer`);
                 },
                 [tKey]: [tName],
-                no_queue(){ return true },
+                queue_complete(){ return 0; },
                 effect(){
                     let morale = (global.resource.Thermite.diff * 2.5) / (global.resource.Thermite.diff * 2.5 + 500) * 500;
                     let thermite = 100000 + global.stats.reset * 9000;
@@ -4929,7 +4805,7 @@ export function buildTemplate(key, region){
                     Iron(){ return global[region].firework.count === 0 ? 7500 : 0; },
                     Cement(){ return global[region].firework.count === 0 ? 10000 : 0; }
                 },
-                no_queue(){ return true },
+                queue_complete(){ return 0; },
                 switchable(){ return true; },
                 effect(){
                     return global[region].firework.count === 0 ? loc(`city_firework_build`) : loc(`city_firework_effect`);
@@ -4956,7 +4832,7 @@ export function buildTemplate(key, region){
                 category: 'military',
                 reqs: {},
                 trait: ['artifical'],
-                no_queue(){ return global.resource[global.race.species].max > global.resource[global.race.species].amount ? false : true; },
+                queue_complete(){ return global.resource[global.race.species].max - global.resource[global.race.species].amount; },
                 cost: {
                     Money(offset){ return global['resource'][global.race.species].amount ? costMultiplier('citizen', offset, assemblyCostAdjust(125), 1.01) : 0; },
                     Copper(offset){ return global.race['deconstructor'] ? 0 : global['resource'][global.race.species].amount >= 5 ? costMultiplier('citizen', offset, assemblyCostAdjust(50), 1.01) : 0; },
@@ -5038,6 +4914,7 @@ export function buildTemplate(key, region){
                 category: 'outskirts',
                 reqs: { primitive: 3 },
                 trait: ['hooved'],
+                inflation: false,
                 cost: {
                     Lumber(offset){
                         let shoes = (global.race['shoecnt'] || 0) + (offset || 0);
@@ -5077,6 +4954,14 @@ export function buildTemplate(key, region){
                             global.resource.Horseshoe.amount++;
                             global.race.shoecnt++;
                             shoed = true;
+
+                            if ((global.race.shoecnt === 5001 && global.resource.Orichalcum.display) ||
+                                (global.race.shoecnt === 501 && global.resource.Adamantite.display) ||
+                                (global.race.shoecnt === 151 && global.resource.Steel.display) ||
+                                (global.race.shoecnt === 76 && global.resource.Iron.display) ||
+                                (global.race.shoecnt === 13 && global.resource.Copper.display && global.resource.Lumber.display)){
+                                return 0;
+                            }
                         }
                     }
                     return shoed;
@@ -5111,16 +4996,10 @@ raceList.forEach(race => actions.evolution[race] = {
             removeAction(actions.evolution.sentience.id);
             global.race.species = race;
             sentience();
-            return true;
         }
         return false;
     },
-    no_queue(){
-        let key = $(this)[0].id.split('-')[1];
-        return !global.evolution.hasOwnProperty(key) || global.evolution[key].count >= 1 ? true : false;
-    },
-    queue_complete(){ return 1; },
-    queueable: true,
+    queue_complete(){ return 1 - global.evolution.sentience.count; },
     emblem(){ return format_emblem(`extinct_${race}`); }
 });
 
@@ -5164,7 +5043,8 @@ Object.keys(challengeList).forEach(challenge => actions.evolution[challenge] = {
         }
         return false;
     },
-    highlight(){ return global.race[challengeList[challenge]] ? true : false; }
+    highlight(){ return global.race[challengeList[challenge]] ? true : false; },
+    queue_complete(){ return 0; }
 });
 
 function challengeEffect(c){
@@ -6096,29 +5976,20 @@ function runAction(c_action,action,type){
                     }
                     let grant = false;
                     let add_queue = false;
-                    let no_queue = (action === 'evolution' && !c_action['queueable']) || (c_action['no_queue'] && c_action['no_queue']()) ? true : false;
                     let loopNum = global.settings.qKey && keyMap.q ? 1 : keyMult;
                     for (let i=0; i<loopNum; i++){
                         let res = false;
                         if ((global.settings.qKey && keyMap.q) || (!(res = c_action.action(1)))){
-                            if (res !== 0 && !no_queue && global.tech['queue'] && (keyMult === 1 || (global.settings.qKey && keyMap.q))){
-                                let max_queue = global.tech['queue'] >= 2 ? (global.tech['queue'] >= 3 ? 8 : 5) : 3;
-                                if (global.stats.feat['journeyman'] && global.stats.feat['journeyman'] >= 2 && global.stats.achieve['seeder'] && global.stats.achieve.seeder.l >= 2){
-                                    let rank = Math.min(global.stats.achieve.seeder.l,global.stats.feat['journeyman']);
-                                    max_queue += rank >= 4 ? 2 : 1;
-                                }
-                                if (global.genes['queue'] && global.genes['queue'] >= 2){
-                                    max_queue *= 2;
-                                }
-                                let pragVal = govActive('pragmatist',0);
-                                if (pragVal){
-                                    max_queue = Math.round(max_queue * (1 + (pragVal / 100)));
-                                }
+                            if (res !== 0 && global.tech['queue'] && (keyMult === 1 || (global.settings.qKey && keyMap.q))){
                                 let used = 0;
+                                let buid_max = c_action['queue_complete'] ? c_action.queue_complete() : Number.MAX_SAFE_INTEGER;
                                 for (let j=0; j<global.queue.queue.length; j++){
                                     used += Math.ceil(global.queue.queue[j].q / global.queue.queue[j].qs);
+                                    if (global.queue.queue[j].id === c_action.id) {
+                                        buid_max -= global.queue.queue[j].q;
+                                    }
                                 }
-                                if (used < global.queue.max){
+                                if (used < global.queue.max && buid_max > 0){
                                     let repeat = global.settings.qKey ? keyMult : 1;
                                     if (repeat > global.queue.max - used){
                                         repeat = global.queue.max - used;
@@ -6126,15 +5997,16 @@ function runAction(c_action,action,type){
                                     let q_size = c_action['queue_size'] ? c_action['queue_size'] : 1;
                                     if (global.settings.q_merge !== 'merge_never'){
                                         if (global.queue.queue.length > 0 && global.queue.queue[global.queue.queue.length-1].id === c_action.id){
-                                            global.queue.queue[global.queue.queue.length-1].q += q_size * repeat;
+                                            global.queue.queue[global.queue.queue.length-1].q += Math.min(buid_max, q_size * repeat);
                                         }
                                         else {
-                                            global.queue.queue.push({ id: c_action.id, action: action, type: type, label: typeof c_action.title === 'string' ? c_action.title : c_action.title(), cna: false, time: 0, q: q_size * repeat, qs: q_size, t_max: 0 });
+                                            global.queue.queue.push({ id: c_action.id, action: action, type: type, label: typeof c_action.title === 'string' ? c_action.title : c_action.title(), cna: false, time: 0, q: Math.min(buid_max, q_size * repeat), qs: q_size, t_max: 0 });
                                         }
                                     }
                                     else {
-                                        for (let k=0; k<repeat; k++){
-                                            global.queue.queue.push({ id: c_action.id, action: action, type: type, label: typeof c_action.title === 'string' ? c_action.title : c_action.title(), cna: false, time: 0, q: q_size, qs: q_size, t_max: 0 });
+                                        for (let k=0; k<repeat && buid_max > 0; k++){
+                                            global.queue.queue.push({ id: c_action.id, action: action, type: type, label: typeof c_action.title === 'string' ? c_action.title : c_action.title(), cna: false, time: 0, q: Math.min(buid_max, q_size), qs: q_size, t_max: 0 });
+                                            buid_max -= q_size;
                                         }
                                     }
                                     add_queue = true;
@@ -6142,7 +6014,7 @@ function runAction(c_action,action,type){
                             }
                             break;
                         }
-                        else if (!(global.settings.qKey && keyMap.q)){
+                        else {
                             if (global.race['inflation'] && global.tech['primitive']){
                                 if (!c_action.hasOwnProperty('inflation') || c_action.inflation){
                                     global.race.inflation++;
@@ -6151,32 +6023,29 @@ function runAction(c_action,action,type){
                         }
                         grant = true;
                     }
-                    if (!checkAffordable(c_action)){
-                        let id = c_action.id;
-                        $(`#${id}`).addClass('cna');
+                    if (grant){
+                        postBuild(c_action,action,type);
+                        if (global.tech['queue'] && c_action['queue_complete']) {
+                            let buid_max = c_action.queue_complete();
+                            for (let i=0, j=0; j<global.queue.queue.length; i++, j++){
+                                let item = global.queue.queue[j];
+                                if (item.id === c_action.id) {
+                                    if (buid_max < 1) {
+                                        clearPopper(`q${item.id.id}${i}`);
+                                        global.queue.queue.splice(j--,1);
+                                        add_queue = true;
+                                    }
+                                    else if (item.q > buid_max) {
+                                        item.q = buid_max;
+                                        buid_max = 0;
+                                    }
+                                    else {
+                                        buid_max -= item.q;
+                                    }
+                                }
+                            }
+                        }
                     }
-                    if (c_action['grant'] && grant){
-                        let tech = c_action.grant[0];
-                        global.tech[tech] = c_action.grant[1];
-                        removeAction(c_action.id);
-                        drawCity();
-                        drawTech();
-                        renderSpace();
-                        renderFortress();
-                    }
-                    else if (c_action['refresh']){
-                        removeAction(c_action.id);
-                        drawCity();
-                        drawTech();
-                        renderSpace();
-                        renderFortress();
-                    }
-                    if (c_action['post']){
-                        setTimeout(function(){
-                            c_action.post();
-                        }, 250);
-                    }
-                    updateDesc(c_action,action,type);
                     if (add_queue){
                         buildQueue();
                     }
@@ -6184,6 +6053,30 @@ function runAction(c_action,action,type){
                 }
         }
     }
+}
+
+export function postBuild(c_action,action,type){
+    if (!checkAffordable(c_action)){
+        let id = c_action.id;
+        $(`#${id}`).addClass('cna');
+    }
+    if (c_action['grant']){
+        let tech = c_action.grant[0];
+        global.tech[tech] = c_action.grant[1];
+    }
+    if (c_action['grant'] || c_action['refresh']){
+        removeAction(c_action.id);
+        drawCity();
+        drawTech();
+        renderSpace();
+        renderFortress();
+    }
+    if (c_action['post']){
+        setTimeout(function(){
+            c_action.post();
+        }, 250);
+    }
+    updateDesc(c_action,action,type);
 }
 
 export function setPlanet(hell){

--- a/src/portal.js
+++ b/src/portal.js
@@ -271,7 +271,7 @@ const fortressModules = {
             desc: loc('portal_pit_mission_title'),
             reqs: { hell_pit: 1 },
             grant: ['hell_pit',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_pit >= 2 ? 0 : 1; },
             cost: {
                 Money(){ return 5000000; },
                 Helium_3(){ return 300000; },
@@ -292,7 +292,7 @@ const fortressModules = {
             desc: loc('portal_assault_forge_title'),
             reqs: { hell_pit: 2 },
             grant: ['hell_pit',3],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_pit >= 3 ? 0 : 1; },
             cost: {
                 Money(){ return 10000000; },
                 HellArmy(){
@@ -319,8 +319,6 @@ const fortressModules = {
                 return `<div>${loc('portal_soul_forge_desc')}</div><div class="has-text-special">${loc('requires_power')}</div>`;
             },
             reqs: { hell_pit: 4 },
-            no_queue(){ return global.portal.soul_forge.count >= 1 || global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
             queue_complete(){ return 1 - global.portal.soul_forge.count; },
             powered(){ return powerCostMod(30); },
             postPower(o){
@@ -448,7 +446,7 @@ const fortressModules = {
             desc: loc('portal_ruins_mission_title'),
             reqs: { hell_ruins: 1 },
             grant: ['hell_ruins',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_ruins >= 2 ? 0 : 1; },
             cost: {
                 Money(){ return 100000000; },
                 Oil(){ return 500000; },
@@ -506,14 +504,13 @@ const fortressModules = {
             condition(){
                 return global.portal.vault.count >= 2 ? false : true;
             },
+            queue_complete(){ return 2 - global.portal.vault.count; },
             cost: {
                 Soul_Gem(offset){ return ((offset || 0) + (global.portal.hasOwnProperty('vault') ? global.portal.vault.count : 0)) === 0 ? 100 : 0; },
                 Money(offset){ return ((offset || 0) + (global.portal.hasOwnProperty('vault') ? global.portal.vault.count : 0)) === 1 ? 250000000 : 0; },
                 Adamantite(offset){ return ((offset || 0) + (global.portal.hasOwnProperty('vault') ? global.portal.vault.count : 0)) === 1 ? 12500000 : 0; },
                 Orichalcum(offset){ return ((offset || 0) + (global.portal.hasOwnProperty('vault') ? global.portal.vault.count : 0)) === 1 ? 30000000 : 0; },
             },
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
             effect(wiki){
                 let count = (wiki || 0) + (global.portal.hasOwnProperty('vault') ? global.portal.vault.count : 0);
                 return count < 1 ? loc('portal_vault_effect',[100]) : loc('portal_vault_effect2'); },
@@ -717,6 +714,7 @@ const fortressModules = {
             title: loc('portal_ancient_pillars_title'),
             desc: loc('portal_ancient_pillars_desc'),
             reqs: { hell_ruins: 2 },
+            queue_complete(){ return global.tech['pillars'] && global.tech.pillars === 1 && global.race.universe !== 'micro' ? 1 : 0; },
             cost: {
                 Harmony(wiki){
                     if (wiki !== undefined){
@@ -732,7 +730,6 @@ const fortressModules = {
                     return global.race.universe !== 'micro' && global.tech['pillars'] && global.tech.pillars === 1 ? Object.keys(global.pillars).length * 125000 + 1000000 : 0;
                 },
             },
-            no_queue(){ return true },
             count(){
                 return Object.keys(races).length - 1;
             },
@@ -795,7 +792,7 @@ const fortressModules = {
             desc: loc('portal_gate_mission_title'),
             reqs: { high_tech: 18 },
             grant: ['hell_gate',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_gate >= 1 ? 0 : 1; },
             cost: {
                 Money(){ return 250000000; },
                 Knowledge(){ return 27500000; }
@@ -822,7 +819,6 @@ const fortressModules = {
                 }
             },
             reqs: { hell_gate: 2 },
-            no_queue(){ return global.portal.west_tower.count < towerSize() ? false : true },
             queue_size: 25,
             queue_complete(){ return towerSize() - global.portal.west_tower.count; },
             cost: {
@@ -878,7 +874,6 @@ const fortressModules = {
                 }
             },
             reqs: { hell_gate: 2 },
-            no_queue(){ return global.portal.east_tower.count < towerSize() ? false : true },
             queue_size: 25,
             queue_complete(){ return towerSize() - global.portal.east_tower.count; },
             cost: {
@@ -1001,7 +996,7 @@ const fortressModules = {
             desc: loc('portal_lake_mission_title'),
             reqs: { hell_lake: 1 },
             grant: ['hell_lake',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_lake >= 2 ? 0 : 1; },
             cost: {
                 Money(){ return 500000000; },
                 Oil(){ return 750000; },
@@ -1249,7 +1244,7 @@ const fortressModules = {
             desc: loc('portal_spire_mission_title'),
             reqs: { hell_spire: 1 },
             grant: ['hell_spire',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_spire >= 2 ? 0 : 1; },
             cost: {
                 Species(){ return popCost(50); },
                 Oil(){ return 900000; },
@@ -1381,7 +1376,6 @@ const fortressModules = {
                 }
             },
             reqs: { hell_spire: 5 },
-            no_queue(){ return global.portal.bridge.count < 10 ? false : true },
             queue_size: 1,
             queue_complete(){ return 10 - global.portal.bridge.count; },
             cost: {
@@ -1418,7 +1412,7 @@ const fortressModules = {
             title(){ return global.tech.hell_spire === 7 ? loc('portal_sphinx_solve') : loc('portal_sphinx_title'); },
             desc: loc('portal_sphinx_desc'),
             reqs: { hell_spire: 6 },
-            no_queue(){ return global.tech.hell_spire < 8 ? false : true; },
+            queue_complete(){ return 8 - global.tech.hell_spire; },
             cost: {
                 Knowledge(offset){
                     let count = (offset || 0) + (!global.tech['hell_spire'] || global.tech.hell_spire < 7 ? 0 : global.tech.hell_spire === 7 ? 1 : 2);
@@ -1494,7 +1488,7 @@ const fortressModules = {
             desc: loc('portal_spire_survey_title'),
             reqs: { hell_spire: 8 },
             grant: ['hell_spire',9],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell_spire >= 9 ? 0 : 1; },
             cost: {
                 Oil(){ return 1200000; },
                 Helium_3(){ return 900000; },
@@ -1569,7 +1563,7 @@ const fortressModules = {
             title: loc('portal_spire_title'),
             desc: loc('portal_spire_title'),
             reqs: { hell_spire: 9 },
-            no_queue(){ return true; },
+            queue_complete(){ return 0; },
             cost: {},
             effect(){
                 let floor = global.portal.hasOwnProperty('spire') ? global.portal.spire.count : 0;
@@ -1627,9 +1621,8 @@ const fortressModules = {
                 }
             },
             reqs: { waygate: 1 },
-            no_queue(){ return global.tech['waygate'] && global.tech.waygate < 2 ? false : true },
             queue_size: 1,
-            queue_complete(){ return global.tech['waygate'] && global.tech.waygate >= 2 ? 0 : 10 - global.portal.waygate.count; },
+            queue_complete(){ return global.tech.waygate >= 2 ? 0 : 10 - global.portal.waygate.count; },
             cost: {
                 Species(offset){
                     if (offset){

--- a/src/space.js
+++ b/src/space.js
@@ -29,7 +29,7 @@ const spaceProjects = {
             desc: loc('space_home_test_launch_desc'),
             reqs: { space: 1 },
             grant: ['space',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.space >= 2 ? 0 : 1; },
             cost: {
                 Money(){ return 100000; },
                 Oil(offset,wiki){ return fuel_adjust(7500,false,wiki); }
@@ -196,7 +196,7 @@ const spaceProjects = {
             desc: loc('space_moon_mission_desc'),
             reqs: { space: 2, space_explore: 2 },
             grant: ['space',3],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.space >= 3 ? 0 : 1; },
             cost: {
                 Oil(offset,wiki){ return +fuel_adjust(12000,false,wiki).toFixed(0); }
             },
@@ -405,7 +405,7 @@ const spaceProjects = {
             },
             reqs: { space: 3, space_explore: 3 },
             grant: ['space',4],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.space >= 4 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(4500,false,wiki).toFixed(0); }
             },
@@ -1166,7 +1166,7 @@ const spaceProjects = {
             },
             reqs: { space: 3, space_explore: 3 },
             grant: ['hell',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.hell >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(6500,false,wiki).toFixed(0); }
             },
@@ -1340,7 +1340,7 @@ const spaceProjects = {
             },
             reqs: { space_explore: 4 },
             grant: ['solar',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.solar >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(15000,false,wiki).toFixed(0); }
             },
@@ -1438,7 +1438,7 @@ const spaceProjects = {
             },
             reqs: { space: 4, space_explore: 4 },
             grant: ['space',5],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.space >= 5 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(12500,false,wiki).toFixed(0); }
             },
@@ -1520,8 +1520,7 @@ const spaceProjects = {
                 return `<div>${loc('space_gas_star_dock_title')}</div><div class="has-text-special">${loc('space_gas_star_dock_desc_req')}</div>`;
             },
             reqs: { genesis: 3 },
-            no_queue(){ return global.space.star_dock.count >= 1 || global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
+            queue_complete(){ return 1 - global.space.star_dock.count; },
             cost: {
                 Money(offset){ return ((offset || 0) + (global.space.hasOwnProperty('star_dock') ? global.space.star_dock.count : 0)) === 0 ? 1500000 : 0; },
                 Steel(offset){ return ((offset || 0) + (global.space.hasOwnProperty('star_dock') ? global.space.star_dock.count : 0)) === 0 ? 500000 : 0; },
@@ -1563,7 +1562,7 @@ const spaceProjects = {
             },
             reqs: { space: 5 },
             grant: ['space',6],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.space >= 6 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(30000,false,wiki).toFixed(0); }
             },
@@ -1693,7 +1692,7 @@ const spaceProjects = {
             },
             reqs: { space: 5 },
             grant: ['asteroid',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.asteroid >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(25000,false,wiki).toFixed(0); }
             },
@@ -1881,7 +1880,7 @@ const spaceProjects = {
             },
             reqs: { asteroid: 1, elerium: 1 },
             grant: ['dwarf',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.dwarf >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(45000,false,wiki).toFixed(0); }
             },
@@ -1973,7 +1972,6 @@ const spaceProjects = {
             condition(){
                 return global.space.world_collider.count < 1859 ? true : false;
             },
-            no_queue(){ return global.space.world_collider.count < 1859 ? false : true },
             queue_size: 100,
             queue_complete(){ return 1859 - global.space.world_collider.count; },
             cost: {
@@ -2029,8 +2027,8 @@ const spaceProjects = {
             condition(){
                 return global.space.world_collider.count < 1859 ? false : true;
             },
+            queue_complete(){ return 0; },
             cost: {},
-            no_queue(){ return true },
             effect(){
                 let boost = 25;
                 if (global.interstellar['far_reach'] && p_on['far_reach'] > 0){
@@ -2063,7 +2061,6 @@ const spaceProjects = {
                 Neutronium(offset){ return ((offset || 0) + (global.space.hasOwnProperty('shipyard') ? global.space.shipyard.count : 0)) < 1 ? 10000 : 0; },
                 Mythril(offset){ return ((offset || 0) + (global.space.hasOwnProperty('shipyard') ? global.space.shipyard.count : 0)) < 1 ? 500000 : 0; },
             },
-            no_queue(){ return global.space.shipyard.count < 1 ? false : true },
             queue_complete(){ return 1 - global.space.shipyard.count; },
             effect(){
                 return `<div>${loc('outer_shipyard_effect')}</div><div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
@@ -2111,7 +2108,6 @@ const spaceProjects = {
             condition(){
                 return global.space.mass_relay.count < 100 ? true : false;
             },
-            no_queue(){ return global.space.mass_relay.count < 100 ? false : true },
             queue_size: 5,
             queue_complete(){ return 100 - global.space.mass_relay.count; },
             cost: {
@@ -2159,7 +2155,7 @@ const spaceProjects = {
                 return global.space.mass_relay.count >= 100 ? true : false;
             },
             wiki: false,
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {},
             powered(){
                 return powerCostMod(100);
@@ -2193,7 +2189,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc', [loc('interstellar_alpha_name')]),
             reqs: { ftl: 2 },
             grant: ['alpha',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.alpha >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(40000).toFixed(0); }
             },
@@ -2743,7 +2739,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc',[loc('interstellar_proxima_name')]),
             reqs: { alpha: 1 },
             grant: ['proxima',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.proxima >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(42000).toFixed(0); }
             },
@@ -2872,7 +2868,6 @@ const interstellarProjects = {
                 }
             },
             reqs: { proxima: 3 },
-            no_queue(){ return global.interstellar.dyson.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.interstellar.dyson.count; },
             condition(){
@@ -2920,7 +2915,6 @@ const interstellarProjects = {
                 }
             },
             reqs: { proxima: 3, dyson: 1 },
-            no_queue(){ return global.interstellar.dyson_sphere.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.interstellar.dyson_sphere.count; },
             condition(){
@@ -2968,7 +2962,6 @@ const interstellarProjects = {
                 }
             },
             reqs: { proxima: 3, dyson: 2 },
-            no_queue(){ return global.interstellar.orichalcum_sphere.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.interstellar.orichalcum_sphere.count; },
             condition(){
@@ -3015,7 +3008,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc',[loc('interstellar_nebula_name')]),
             reqs: { alpha: 1 },
             grant: ['nebula',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.nebula >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(55000).toFixed(0); }
             },
@@ -3141,7 +3134,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc', [loc('interstellar_neutron_name')]),
             reqs: { nebula: 1, high_tech: 14 },
             grant: ['neutron',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.neutron >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(60000).toFixed(0); },
                 Deuterium(){ return +int_fuel_adjust(10000).toFixed(0); }
@@ -3306,7 +3299,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc', [loc('interstellar_blackhole_name')]),
             reqs: { nebula: 1 },
             grant: ['blackhole',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.blackhole >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(75000).toFixed(0); },
                 Deuterium(){ return +int_fuel_adjust(25000).toFixed(0); }
@@ -3365,7 +3358,6 @@ const interstellarProjects = {
                 }
             },
             reqs: { blackhole: 3 },
-            no_queue(){ return global.interstellar.stellar_engine.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.interstellar.stellar_engine.count; },
             cost: {
@@ -3465,7 +3457,7 @@ const interstellarProjects = {
             desc: loc('interstellar_jump_ship_desc'),
             reqs: { stargate: 1 },
             grant: ['stargate',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.stargate >= 2 ? 0 : 1; },
             cost: {
                 Money(){ return 20000000; },
                 Copper(){ return 2400000; },
@@ -3489,7 +3481,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc', [loc('interstellar_wormhole_name')]),
             reqs: { stargate: 2 },
             grant: ['stargate',3],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.stargate >= 3 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(150000).toFixed(0); },
                 Deuterium(){ return +int_fuel_adjust(75000).toFixed(0); }
@@ -3520,7 +3512,6 @@ const interstellarProjects = {
             condition(){
                 return global.interstellar.stargate.count >= 200 ? false : true;
             },
-            no_queue(){ return global.interstellar.stargate.count < 200 ? false : true },
             queue_size: 10,
             queue_complete(){ return 200 - global.interstellar.stargate.count; },
             cost: {
@@ -3572,7 +3563,7 @@ const interstellarProjects = {
                 return global.interstellar.stargate.count >= 200 ? true : false;
             },
             wiki: false,
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {},
             powered(){
                 return powerCostMod(250);
@@ -3596,7 +3587,7 @@ const interstellarProjects = {
             desc: loc('space_mission_desc', [loc('interstellar_sirius_name')]),
             reqs: { ascension: 2 },
             grant: ['ascension',3],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.ascension >= 3 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(480000).toFixed(0); },
                 Deuterium(){ return +int_fuel_adjust(225000).toFixed(0); }
@@ -3615,7 +3606,7 @@ const interstellarProjects = {
             desc: loc('interstellar_sirius_b'),
             reqs: { ascension: 3 },
             grant: ['ascension',4],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.ascension >= 4 ? 0 : 1; },
             cost: {
                 Knowledge(){ return 20000000; },
             },
@@ -3643,7 +3634,6 @@ const interstellarProjects = {
             condition(){
                 return global.interstellar.space_elevator.count >= 100 ? false : true;
             },
-            no_queue(){ return global.interstellar.space_elevator.count < 100 ? false : true },
             queue_size: 5,
             queue_complete(){ return 100 - global.interstellar.space_elevator.count; },
             cost: {
@@ -3692,7 +3682,6 @@ const interstellarProjects = {
             condition(){
                 return global.interstellar.gravity_dome.count >= 100 ? false : true;
             },
-            no_queue(){ return global.interstellar.gravity_dome.count < 100 ? false : true },
             queue_size: 5,
             queue_complete(){ return 100 - global.interstellar.gravity_dome.count; },
             cost: {
@@ -3742,7 +3731,6 @@ const interstellarProjects = {
             condition(){
                 return global.interstellar.ascension_machine.count >= 100 ? false : true;
             },
-            no_queue(){ return global.interstellar.ascension_machine.count < 100 ? false : true },
             queue_size: 5,
             queue_complete(){ return 100 - global.interstellar.ascension_machine.count; },
             cost: {
@@ -3788,7 +3776,7 @@ const interstellarProjects = {
             condition(){
                 return global.interstellar.ascension_machine.count >= 100 ? true : false;
             },
-            no_queue(){ return true; },
+            queue_complete(){ return 0; },
             cost: {},
             powered(){
                 let heatsink = 100;
@@ -3905,7 +3893,7 @@ const galaxyProjects = {
             desc: loc('galaxy_gateway_mission'),
             reqs: { gateway: 1 },
             grant: ['gateway',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.gateway >= 2 ? 0 : 1; },
             cost: {
                 Helium_3(){ return +int_fuel_adjust(212000).toFixed(0); },
                 Deuterium(){ return +int_fuel_adjust(110000).toFixed(0); }
@@ -4462,7 +4450,7 @@ const galaxyProjects = {
             desc: loc('galaxy_gorddon_mission_desc'),
             reqs: { xeno: 2 },
             grant: ['xeno',3],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.xeno >= 3 ? 0 : 1; },
             cost: {
                 Structs(){
                     return {
@@ -4498,8 +4486,6 @@ const galaxyProjects = {
             title: loc('galaxy_embassy'),
             desc: `<div>${loc('galaxy_embassy')}</div><div class="has-text-special">${loc('requires_power')}</div>`,
             reqs: { xeno: 4 },
-            no_queue(){ return global.galaxy.embassy.count >= 1 || global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
             queue_complete(){ return 1 - global.galaxy.embassy.count; },
             cost: {
                 Money(offset){ return ((offset || 0) + (global.galaxy.hasOwnProperty('embassy') ? global.galaxy.embassy.count : 0)) < 1 ? 30000000 : 0; },
@@ -4673,8 +4659,6 @@ const galaxyProjects = {
                 return loc('galaxy_consulate_desc',[races[global.galaxy.hasOwnProperty('alien1') ? global.galaxy.alien1.id : global.race.species].home]);
             },
             reqs: { xeno: 8 },
-            no_queue(){ return global.galaxy.consulate.count >= 1 || global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
             queue_complete(){ return 1 - global.galaxy.consulate.count; },
             cost: {
                 Money(offset){ return ((offset || 0) + (global.galaxy.hasOwnProperty('consulate') ? global.galaxy.consulate.count : 0)) < 1 ? 90000000 : 0; },
@@ -4834,7 +4818,7 @@ const galaxyProjects = {
             desc(){ return loc('galaxy_alien2_mission_desc',[races[global.galaxy.hasOwnProperty('alien2') ? global.galaxy.alien2.id : global.race.species].solar.red]); },
             reqs: { andromeda: 4 },
             grant: ['conflict',1],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.conflict >= 1 ? 0 : 1; },
             cost: {
                 Custom(){
                     if (global.galaxy.hasOwnProperty('defense') && global.galaxy.defense.hasOwnProperty('gxy_alien2')){
@@ -5063,7 +5047,7 @@ const galaxyProjects = {
             desc(){ return loc('galaxy_alien2_mission_desc',[loc('galaxy_chthonian')]); },
             reqs: { chthonian: 1 },
             grant: ['chthonian',2],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.chthonian >= 2 ? 0 : 1; },
             cost: {
                 Custom(){
                     if (global.galaxy.hasOwnProperty('defense') && global.galaxy.defense.hasOwnProperty('gxy_chthonian')){

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -39,7 +39,7 @@ export const outerTruth = {
             reqs: { outer: 1 },
             grant: ['titan',1],
             path: ['truepath'],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.titan >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(250000,false,wiki).toFixed(0); },
                 Elerium(){ return 100; }
@@ -519,7 +519,6 @@ export const outerTruth = {
             condition(){
                 return global.space.ai_core.count >= 100 ? false : true;
             },
-            no_queue(){ return global.space.ai_core.count < 100 ? false : true },
             queue_size: 10,
             queue_complete(){ return 100 - global.space.ai_core.count; },
             cost: {
@@ -575,7 +574,7 @@ export const outerTruth = {
                 return global.space.hasOwnProperty('ai_core') && global.space.ai_core.count >= 100 ? true : false;
             },
             wiki: false,
-            no_queue(){ return true },
+            queue_complete(){ return 0; },
             cost: {},
             powered(){
                 return powerCostMod(100);
@@ -664,7 +663,7 @@ export const outerTruth = {
             reqs: { outer: 1 },
             grant: ['enceladus',1],
             path: ['truepath'],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.enceladus >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(250000,false,wiki).toFixed(0); },
                 Elerium(){ return 100; }
@@ -859,7 +858,7 @@ export const outerTruth = {
             reqs: { outer: 2 },
             grant: ['triton',1],
             path: ['truepath'],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.triton >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(600000,false,wiki).toFixed(0); },
                 Elerium(){ return 2500; }
@@ -886,8 +885,7 @@ export const outerTruth = {
             },
             reqs: { triton: 2 },
             path: ['truepath'],
-            no_queue(){ return global.space.fob.count >= 1 || global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
-            q_once: true,
+            queue_complete(){ return 1 - global.space.fob.count; },
             cost: {
                 Money(offset){ return ((offset || 0) + (global.space.hasOwnProperty('fob') ? global.space.fob.count : 0)) >= 1  ? 0 : spaceCostMultiplier('fob', offset, 250000000, 1.1); },
                 Copper(offset){ return ((offset || 0) + (global.space.hasOwnProperty('fob') ? global.space.fob.count : 0)) >= 1 ? 0 : spaceCostMultiplier('fob', offset, 8000000, 1.1); },
@@ -969,7 +967,7 @@ export const outerTruth = {
             },
             reqs: { triton: 3 },
             path: ['truepath'],
-            no_queue(){ return true; },
+            queue_complete(){ return 0; },
             cost: {},
             effect(){
                 let control = global.space['crashed_ship'] ? global.space.crashed_ship.count : 0;
@@ -1003,7 +1001,7 @@ export const outerTruth = {
             reqs: { outer: 7 },
             grant: ['kuiper',1],
             path: ['truepath'],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.kuiper >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(1000000,false,wiki).toFixed(0); },
                 Elerium(){ return 1000; }
@@ -1189,7 +1187,7 @@ export const outerTruth = {
             reqs: { outer: 7 },
             grant: ['eris',1],
             path: ['truepath'],
-            no_queue(){ return global.queue.queue.some(item => item.id === $(this)[0].id) ? true : false; },
+            queue_complete(){ return global.tech.eris >= 1 ? 0 : 1; },
             cost: {
                 Helium_3(offset,wiki){ return +fuel_adjust(1250000,false,wiki).toFixed(0); },
                 Elerium(){ return 1250; }
@@ -1319,7 +1317,7 @@ export const outerTruth = {
             },
             reqs: { eris: 3 },
             path: ['truepath'],
-            no_queue(){ return true; },
+            queue_complete(){ return 0; },
             cost: {},
             effect(){
                 let control = global.space['digsite'] ? global.space.digsite.count : 0;


### PR DESCRIPTION
Actions used to have four(sic!) properties declaring same thing - whether it can be queued, or not - no_queue, q_once, queueable, and queue_complete. Not anymore, everything uses queue_complete - it can cover all cases, by returning how many items can be added to queue at given time.
So, all other props and their checks was removed, and queue_complete added where it missed. Queue not getting checked at runtime anymore, all that happens on click - less performance tax & code duplication, plus queue shows correct amounts instantly, multiqueueing segmented buidings won't fill with 1000 ascension machine parts, just to remove excesses after a second. There won't be any excess from the beginning. And also finishing things manually will instantly remove duplicates from queue.

Also fixed couple of queue bugs - arpa queue won't get stuck with no income, and queuing buildings with *post* property won't trigger it right away(that's what causes chaotic unlocks in TP).
Few more buildings are queueable now, which wasn't, like pillars.
And one small QoL change: multibuying horseshoes will stop at resource breakpoints. E.g. ctrl+alt+shift on adamantium horseshoes won't eat all orichalcum. It'll stop right after resource change.
And also fixed missing inflation property on horseshoes. (lost in transit, during migration to templates)