### PR TITLE
Queueable slaves, and some fixes

### DIFF
--- a/src/governor.js
+++ b/src/governor.js
@@ -994,7 +994,7 @@ export const gov_tasks = {
                     }
                 });
                 if (global.resource[res].amount > amount && (global.resource[res].diff >= amount || global.resource[res].amount + global.resource[res].diff >= global.resource[res].max) ){
-                    actions.city.horseshoe.action(1);
+                    actions.city.horseshoe.action();
                 }
             }
         }

--- a/src/main.js
+++ b/src/main.js
@@ -8316,7 +8316,7 @@ function midLoop(){
                 let struct = global.queue.queue[idx];
                 let report_in = c_action['queue_complete'] ? c_action.queue_complete() : 1;
                 for (let i=0; i<attempts; i++){
-                    if (c_action.action()){
+                    if (c_action.action() !== false){
                         triggerd = true;
                         if (report_in - i <= 1){
                             messageQueue(loc('build_success',[global.queue.queue[idx].label]),'success',false,['queue','building_queue']);


### PR DESCRIPTION
Slave market can be queued now, and also fixes some bugs. Some of them old(slaves governor also was affected by multipliers key, and queued horseshoes affected by multipliers same as ones triggered by governor), some added by previous PR(id typo, extra horseshoes crafted in queue).