### PR TITLE
Skipping queued unaffordable ARPAs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8254,11 +8254,11 @@ function midLoop(){
                     struct['time'] = -1;
                 }
 
-                if (global.settings.qAny && !global.queue.pause && Math.floor(struct['time']) !== 0){
-                    buildArpa(struct.type,100,true);
-                }
-                else {
-                    if (!stop){
+                if (arpaTimeCheck(t_action, 0.01) >= 0){
+                    if (global.settings.qAny && !global.queue.pause && struct['time'] > 1){
+                        buildArpa(struct.type,100,true);
+                    }
+                    else if (!stop){
                         c_action = t_action;
                         idx = i;
                         arpa = true;

--- a/src/space.js
+++ b/src/space.js
@@ -982,7 +982,7 @@ const spaceProjects = {
                 let cat_wd = (global.race['cataclysm'] || global.race['orbit_decayed']) && !global.race['kindling_kindred'] ? `<div>${loc('space_red_mine_effect',[+(production('biodome','lumber')).toFixed(2),global.resource.Lumber.name])}</div>` : ``;
                 let pop = global.tech.mars >= 6 ? 0.1 : 0.05;
                 let sig_cap = global.race['artifical'] ? `<div>${loc('city_transmitter_effect',[spatialReasoning(500)])}</div` : '';
-                return `<div class="has-text-caution">${loc('space_used_support',[races[global.race.species].solar.red])}</div>${cat_fd}<div>${loc('space_red_biodome_effect',[food,global.resource.Food.name])}</div><div>${loc('space_red_biodome_effect2',[jobScale(pop)])}</div>${cat_wd}${sig_cap}`;
+                return `<div class="has-text-caution">${loc('space_used_support',[races[global.race.species].solar.red])}</div>${cat_fd}<div>${loc('space_red_biodome_effect',[food,global.resource.Food.name])}</div><div>${loc('space_red_biodome_effect2',[+(jobScale(pop)).toFixed(2)])}</div>${cat_wd}${sig_cap}`;
             },
             support(){ return -1; },
             powered(){ return powerCostMod(1); },


### PR DESCRIPTION
Now it, hopefully, should be done. With ordered queue enabled projects that can be built for at least 1%, or will get resources for that eventually, stays on top of the queue. Those ones which won't ever get even a single segments - skipped. Pretty much same as game skips regular buildings with "Never".

And also rounded biodome tooltip for high pop.