### PR TITLE
Imitation fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -8146,12 +8146,15 @@ function fanaticTrait(trait){
             randomMinorTrait(5);
             arpa('Genetics');
         }
+        else if (trait === 'imitation'){
+            setImitation(true);
+        }
+        else if (trait === 'shapeshifter'){
+            shapeShift(global.race['ss_genus']);
+        }
     }
     else {
         global.race[trait] = 1;
-        if (trait === 'imitation'){
-            setImitation(true);
-        }
         cleanAddTrait(trait);
     }
 }

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -1,7 +1,7 @@
 import { global, keyMultiplier, sizeApproximation, srSpeak } from './vars.js';
 import { clearElement, popover, clearPopper, flib, eventActive, timeFormat, vBind, messageQueue, adjustCosts, removeFromQueue, calcQueueMax, calcRQueueMax, buildQueue, calcPrestige, calc_mastery, darkEffect, easterEgg, getTraitDesc } from './functions.js';
 import { actions, updateQueueNames, drawTech, drawCity, addAction, removeAction, wardenLabel, checkCosts } from './actions.js';
-import { races, traits, cleanAddTrait, cleanRemoveTrait, setImitation, traitSkin } from './races.js';
+import { races, traits, cleanAddTrait, cleanRemoveTrait, traitSkin } from './races.js';
 import { renderSpace } from './space.js';
 import { drawMechLab } from './portal.js';
 import { govActive } from './governor.js';
@@ -2075,9 +2075,6 @@ function genetics(){
                         }
                         else {
                             global.race['modified']++;
-                        }
-                        if (t === 'imitation'){
-                            setImitation(true);
                         }
                         cleanAddTrait(t);
                         genetics();


### PR DESCRIPTION
Imitated genus excluded from shifting options. Current mimic changed to "none" after imitating race with mimicked genus. (Such overlaps used to be either useless, or could even waste traits)
Mimic re-aplied on rank up. so it won't require switching genus to also rank up mimicked traits.
Imitation also can be ranked up now, which didn't worked at all.
Some examples with custom passing imitation via fanat:
Synth -> Ent Imitation -> Ent imitation = Ent traits have ranks as stated for rank 3 imitation, i.e. rank 1 positives, and rank 2 negatives.
Ent -> Ent imitation -> Ent imitation = Ent's non-genus traits at ranks 3. They was already here, so imitations just ranked them up once per fanat.

Existed genus traits are still ignored, and never ranked up. I'm not sure why this option is explicitly blacklisted, so didin't touched that. I know it would cause issues with High Pop, but it was blacklisted before High Pop was added, so it's not the only reason.