### PR TITLE
Fixed eris scanning

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9038,13 +9038,17 @@ function longLoop(){
                         if (ship.damage > 90){ ship.damage = 90; }
                     }
                     if (global.tech.hasOwnProperty('eris_scan') && ship.location === 'spc_eris' && ship.transit === 0){
-                        eScan += sensorRange(ship.sensor) * 2;
+                        eScan += sensorRange(ship.sensor);
                     }
                 });
-                if (global.tech.hasOwnProperty('eris_scan') && global.tech.hasOwnProperty('eris') && global.tech.eris === 1 && eScan >= 100){
-                    global.tech.eris = 2;
-                    messageQueue(loc('space_eris_scan',[genusVars[races[global.race.species].type].solar.eris]),'info',false,['progress']);
-                    renderSpace();
+                if (global.tech.hasOwnProperty('eris_scan') && global.tech.hasOwnProperty('eris') && global.tech.eris === 1 && eScan > 50){
+                    global.tech.eris_scan += eScan - 50;
+                    if (global.tech.eris_scan >= 100){
+                        global.tech.eris_scan = 100;
+                        global.tech.eris = 2;
+                        messageQueue(loc('space_eris_scan',[genusVars[races[global.race.species].type].solar.eris]),'info',false,['progress']);
+                        renderSpace();
+                    }
                 }
                 if (global.space.hasOwnProperty('position')){
                     Object.keys(spacePlanetStats).forEach(function(planet){


### PR DESCRIPTION
Okay, that's pretty old bug, which i reported couple of times, but it still here. This one is missing chunk of game logic, so i had to improvise.
Here the thing, Eris have a counter for scanning. It have all vars, render code, but in fact there's only *two* states. It's either 0%... or fully scanned. `eris_scan` counter is *never* increasing.
As i have no idea what scanning speed intended to be - here it's set pretty fast. To not make runs noticeable longer than it currently is, but still show neat scanning process. Single quantum corvette will scan Eris in 10 game days. More ships - faster scanning. Min scanning requirements haven't changed, it's just not instant anymore. 
If this speed feels too fast - that's easy to change. (But, again, current speed is *instant*, and it always been this way, so any delay in progress is a nerf. Longer - harsher nerf.)

Working scanning in progress, using single quantum scanner, and with AT:
![scan](https://user-images.githubusercontent.com/544763/177605405-39c29f12-5302-4c5a-873d-fc337b6fe10d.gif)

