### PR TITLE
Synthetic promiscuous reskin and effect

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4816,7 +4816,11 @@ export function buildTemplate(key, region){
         {
             let id = region === 'space' ? 'space-assembly' : 'city-assembly';
             let assemblyCostAdjust = function(v){
-                return Math.round(highPopAdjust(v));
+                let cost = highPopAdjust(v);
+                if (global.race['promiscuous']){
+                    cost /= 1 + traits.promiscuous.vars()[1] * global.race['promiscuous'];
+                }
+                return Math.round(cost);
             }
             let action = {
                 id: id,

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -1915,7 +1915,7 @@ function genetics(){
             if (cost < 0){
                 cost *= -1;
             }
-            return loc('arpa_remove',[loc('trait_' + t + '_name'),cost,global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name')]);
+            return loc('arpa_remove',[traitSkin('name',t),cost,global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name')]);
         };
 
         let addCost = function(t){
@@ -1926,19 +1926,19 @@ function genetics(){
             if (cost < 0){
                 cost *= -1;
             }
-            return loc('arpa_gain',[loc('trait_' + t + '_name'),cost,global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name')]);
+            return loc('arpa_gain',[traitSkin('name',t),cost,global.race.universe === 'antimatter' ? loc('resource_AntiPlasmid_plural_name') : loc('resource_Plasmid_plural_name')]);
         };
 
         let mGeneCost = function(t){
             let cost = fibonacci(global.race.minor[t] ? global.race.minor[t] + 4 : 4);
             if (t === 'mastery'){ cost *= 5; }
-            return loc('arpa_gene_buy',[loc('trait_' + t + '_name'),sizeApproximation(cost),global.resource.Genes.name]);
+            return loc('arpa_gene_buy',[traitSkin('name',t),sizeApproximation(cost),global.resource.Genes.name]);
         };
 
         let mPhageCost = function(t){
             let cost = fibonacci(global.genes.minor[t] ? global.genes.minor[t] + 4 : 4);
             if (t === 'mastery'){ cost *= 2; }
-            return loc('arpa_phage_buy',[loc('trait_' + t + '_name'),sizeApproximation(cost),loc(`resource_Phage_name`)]);
+            return loc('arpa_phage_buy',[traitSkin('name',t),sizeApproximation(cost),loc(`resource_Phage_name`)]);
         };
 
         vBind({
@@ -2131,10 +2131,10 @@ function genetics(){
 
             popover(`popGenetrait${t}`, function(){
                 if (global.stats.feat['novice'] && global.stats.achieve['apocalypse'] && global.stats.achieve.apocalypse.l > 0){
-                    return `<div>${traits[t].desc}</div><div>${loc(`trait_${t}_effect`)}</div>`;
+                    return `<div>${traitSkin('desc',t)}</div><div>${loc(`trait_${t}_effect`)}</div>`;
                 }
                 else {
-                    return traits[t].desc;
+                    return traitSkin('desc',t);
                 }
             },
             {
@@ -2194,7 +2194,7 @@ function bindTrait(breakdown,trait){
     }
 
     let total = global.race[trait] > 1 ? `(${global.race[trait]}) ` : '';
-    m_trait.append(`<span class="has-text-warning name">${total}${traits[trait].name}</span>`);
+    m_trait.append(`<span class="has-text-warning name">${total}${traitSkin('name',trait)}</span>`);
 
     breakdown.append(m_trait);
 }

--- a/src/races.js
+++ b/src/races.js
@@ -2894,11 +2894,11 @@ export const traits = {
         type: 'minor',
         vars(r){ return [1]; },
     },
-    promiscuous: { // Population Growth Bonus
+    promiscuous: { // Organics Growth Bonus, Synths Population Discount
         name: loc('trait_promiscuous_name'),
         desc: loc('trait_promiscuous'),
         type: 'minor',
-        vars(r){ return [1]; },
+        vars(r){ return [1,0.02]; },
     },
     resilient: { // Coal Mining Bonus
         name: loc('trait_resilient_name'),
@@ -5031,6 +5031,7 @@ export function traitSkin(type,trait){
         {
             let name = {
                 hooved: global.race['sludge'] ? loc('trait_hooved_slime_name') : traits['hooved'].name,
+                promiscuous: global.race['artifical'] ? loc('trait_promiscuous_synth_name') : traits['promiscuous'].name,
             };
             return trait ? (name[trait] ? name[trait] : traits[trait].name) : name;
         } 
@@ -5038,6 +5039,7 @@ export function traitSkin(type,trait){
         {
             let desc = {
                 hooved: global.race['sludge'] ? loc('trait_hooved_slime') : traits['hooved'].desc,
+                promiscuous: global.race['artifical'] ? loc('trait_promiscuous_synth') : traits['promiscuous'].desc,
             };
             return trait ? (desc[trait] ? desc[trait] : traits[trait].desc) : desc;
         }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -4437,6 +4437,8 @@
   "trait_promiscuous": "Your race has an elevated birth rate.",
   "trait_promiscuous_name": "Promiscuous",
   "trait_promiscuous_effect": "Elevated birth rate.",
+  "trait_promiscuous_synth": "Your race is designed for mass production.",
+  "trait_promiscuous_synth_name": "Standartization",
   "trait_resilient": "Natural resilience to harsh conditions makes your species more adept at coal mining.",
   "trait_resilient_name": "Resilient",
   "trait_resilient_effect": "Coal mining efficiency increased.",


### PR DESCRIPTION
Synths have full access to promiscuous trait, they can rank it up or get as random trait, but it have no ingame effect at all. This change makes it actually useful, and does thematic reskin to fit artificial race.
Discount is pretty modest: -16% at rank 10, -28% at rank 20, -50% at rank 50, -66% at rank 100, etc.
0.02 per level looks reasonable to me. But it can be easily changed, even 0.01(-33% at 50, -50% at 100, etc) would be fine.
Cost still will be ridiculously expensive with few thousands of pops in late game, but half price is twice better than full price.