### PR TITLE
Decay fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5,14 +5,14 @@ import { unlockAchieve, challengeIcon, alevel, universeAffix } from './achieve.j
 import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift } from './races.js';
 import { defineResources, galacticTrade, spatialReasoning, resource_values } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, job_desc } from './jobs.js';
-import { loadIndustry } from './industry.js';
+import { loadIndustry, nf_resources } from './industry.js';
 import { defineGovernment, defineIndustry, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating } from './civics.js';
 import { spaceTech, interstellarTech, galaxyTech, universe_affixes, renderSpace, piracy } from './space.js';
 import { renderFortress, fortressTech } from './portal.js';
 import { arpa, gainGene, gainBlood } from './arpa.js';
 import { production, highPopAdjust } from './prod.js';
 import { techList, techPath } from './tech.js';
-import { govActive } from './governor.js';
+import { govActive, removeTask } from './governor.js';
 import { bioseed } from './resets.js';
 import { loadTab } from './index.js';
 
@@ -3432,7 +3432,7 @@ export const actions = {
                         }
                     }
                     global.city['foundry'].count++;
-                    global.civic.craftsman.max++;
+                    global.civic.craftsman.max += jobScale(1);
                     global.civic.craftsman.display = true;
                     if (!global.race['kindling_kindred'] && !global.race['smoldering']){
                         global.resource.Plywood.display = true;
@@ -7062,7 +7062,16 @@ export function orbitDecayed(){
         if (global.resource.Slave.display){
             global.resource.Slave.display = false;
             global.resource.Slave.amount = 0;
+            removeTask('slave');
         }
+        if (global.race['deconstructor']){
+            nf_resources.forEach(function (res){
+                global.city.nanite_factory[res] = 0;
+            });
+        }
+        Object.keys(global.resource).forEach(function (res){
+            global.resource[res].trade = 0;
+        });
 
         global.space['red_university'] = { count: 0 };
 
@@ -7102,6 +7111,16 @@ export function orbitDecayed(){
             global.civic.d_job = 'unemployed';
         }
 
+        global.race.purgatory.city = {};
+        if (global.queue.hasOwnProperty('queue')){
+            for (let i = global.queue.queue.length-1; i >= 0; i--){
+                let item = global.queue.queue[i];
+                if (item.action === 'city' || (item.action === 'space' && actions.space.spc_moon[item.type])){
+                    global.queue.queue.splice(i,1);
+                }
+            }
+        }
+
         if (global.arpa['sequence']){
             global.arpa.sequence.on = false;
             global.arpa.sequence.boost = false;
@@ -7115,7 +7134,7 @@ export function orbitDecayed(){
         global.settings.space.moon = false;
         global.settings.showCity = false;
 
-        clearElement($(`infoTimer`));
+        clearElement($(`#infoTimer`));
 
         renderSpace();
     }

--- a/src/civics.js
+++ b/src/civics.js
@@ -74,7 +74,7 @@ export function defineIndustry(){
     }
     clearElement($('#industry'));
 
-    if (global.city['smelter'] && (global.city.smelter.count > 0 || global.race['cataclysm'])){
+    if (global.city['smelter'] && (global.city.smelter.count > 0 || global.race['cataclysm'] || global.race['orbit_decayed'])){
         var smelter = $(`<div id="iSmelter" class="industry"><h2 class="header has-text-advanced">${loc('city_smelter')}</h2></div>`);
         $(`#industry`).append(smelter);
         loadIndustry('smelter',smelter,'#iSmelter');
@@ -99,7 +99,7 @@ export function defineIndustry(){
         $(`#industry`).append(casting);
         loadIndustry('pylon',casting,'#iPylon');
     }
-    if (global.race['smoldering'] && global.city['rock_quarry'] && !global.race['cataclysm']){
+    if (global.race['smoldering'] && global.city['rock_quarry'] && !global.race['cataclysm'] && !global.race['orbit_decayed']){
         var ratio = $(`<div id="iQuarry" class="industry"><h2 class="header has-text-advanced">${loc('city_rock_quarry')}</h2></div>`);
         $(`#industry`).append(ratio);
         loadIndustry('rock_quarry',ratio,'#iQuarry');

--- a/src/governor.js
+++ b/src/governor.js
@@ -656,6 +656,16 @@ export function govActive(trait,val){
     return false;
 }
 
+export function removeTask(task){
+    if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
+        for (let i=0; i<global.race.governor.tasks.length; i++){
+            if (global.race.governor.tasks[`t${i}`] === task){
+                global.race.governor.tasks[`t${i}`] = 'none';
+            }
+        }
+    }
+}
+
 export const gov_tasks = {
     tax: { // Dynamic Taxes
         name: loc(`gov_task_tax`),
@@ -951,7 +961,7 @@ export const gov_tasks = {
     slave: { // Replace Slaves
         name: loc(`gov_task_slave`),
         req(){
-            return checkCityRequirements('slave_market') && global.race['slaver'] && global.city['slave_pen'] ? true : false;
+            return !global.race['orbit_decayed'] && checkCityRequirements('slave_market') && global.race['slaver'] && global.city['slave_pen'] ? true : false;
         },
         task(){
             let cashCap = global.resource.Money.max * (global.race.governor.config.slave.reserve / 100);

--- a/src/main.js
+++ b/src/main.js
@@ -10,7 +10,7 @@ import { defineIndustry, checkControlling, garrisonSize, armyRating, govTitle, g
 import { actions, updateDesc, setChallengeScreen, addAction, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, evoProgress, housingLabel, updateQueueNames, wardenLabel, setPlanet, resQueue, bank_vault, start_cataclysm, raceList, orbitDecayed, postBuild } from './actions.js';
 import { renderSpace, fuel_adjust, int_fuel_adjust, zigguratBonus, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay } from './portal.js';
-import { syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, storehouseMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift } from './truepath.js';
+import { syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, storehouseMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift, drawMap } from './truepath.js';
 import { arpa, buildArpa } from './arpa.js';
 import { events, eventList } from './events.js';
 import { govern, govActive } from './governor.js';
@@ -9052,6 +9052,10 @@ function longLoop(){
                             }
                         }
                     });
+                }
+
+                if ($('#mapCanvas').length > 0) {
+                    drawMap();
                 }
             }
 

--- a/src/races.js
+++ b/src/races.js
@@ -6,7 +6,7 @@ import { vBind, clearElement, removeFromQueue, removeFromRQueue, calc_mastery, g
 import { setResourceName } from './resources.js';
 import { highPopAdjust } from './prod.js';
 import { buildGarrison } from './civics.js';
-import { govActive } from './governor.js';
+import { govActive, removeTask } from './governor.js';
 import { unlockAchieve } from './achieve.js';
 import { actions, checkTechQualifications } from './actions.js';
 
@@ -4343,21 +4343,12 @@ function adjustFood() {
     let disabledCity = [], disabledTech = [];
 
     if (!global.race['artifical']) {
-        setPurgatory('tech','agriculture');
-        setPurgatory('tech','farm');
-        setPurgatory('tech','hunting');
-        setPurgatory('tech','s_lodge');
-        setPurgatory('tech','wind_plant');
-        setPurgatory('tech','compost');
-        setPurgatory('tech','soul_eater');
-        setPurgatory('city','silo');
-        setPurgatory('city','farm');
-        setPurgatory('city','mill');
-        setPurgatory('city','windmill');
-        setPurgatory('city','smokehouse');
-        setPurgatory('city','lodge');
-        setPurgatory('city','compost');
-        setPurgatory('city','soul_well');
+        ['agriculture','farm','hunting','s_lodge','wind_plant','compost','soul_eater'].forEach(function (tech){
+            setPurgatory('tech',tech);
+        });
+        ['silo','farm','mill','windmill','smokehouse','lodge','compost','soul_well'].forEach(function (city){
+            setPurgatory('city',city);
+        });
 
         if (altLodge) {
             checkPurgatory('tech','s_lodge');
@@ -4450,8 +4441,9 @@ function adjustFood() {
         }
     }
 
+
     let jobEnabled = [], jobDisabled = [];
-    if (farmersEnabled && global.tech['agriculture'] >= 1 && global.city['farm'].count > 0) {
+    if (!global.race['orbit_decayed'] && farmersEnabled && global.tech['agriculture'] >= 1 && global.city['farm'].count > 0) {
         jobEnabled.push('farmer');
     }
     else {
@@ -4465,7 +4457,7 @@ function adjustFood() {
         jobDisabled.push('hunter');
         jobEnabled.push('unemployed');
     }
-    if (lumberEnabled) {
+    if (!global.race['orbit_decayed'] && lumberEnabled) {
         jobEnabled.push('lumberjack');
     }
     else {
@@ -4611,13 +4603,8 @@ export function cleanAddTrait(trait){
                 global.civic.foreign[`gov${i}`].sab = 0;
                 global.civic.foreign[`gov${i}`].act = 'none';
             }
-            if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-                Object.keys(global.race.governor.tasks).forEach(function (task){
-                    if (global.race.governor.tasks[task] === 'spy' || global.race.governor.tasks[task] === 'spyop'){
-                        global.race.governor.tasks[task] = 'none';
-                    }
-                });
-            }
+            removeTask('spy');
+            removeTask('spyop');
             break;
         case 'noble':
             if (global.civic.taxes.tax_rate < 10) {
@@ -4785,26 +4772,14 @@ export function cleanRemoveTrait(trait,rank){
             global.resource.Slave.amount = 0;
             global.resource.Slave.max = 0;
             global.resource.Slave.display = false;
-            if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-                for (let i=0; i<global.race.governor.tasks.length; i++){
-                    if (global.race.governor.tasks[`t${i}`] === 'slave'){
-                        global.race.governor.tasks[`t${i}`] = 'none';
-                    }
-                }
-            }
+            removeTask('slave');
             break;
         case 'cannibalize':
             removeFromQueue(['city-s_alter']);
             removeFromRQueue(['sacrifice']);
             setPurgatory('tech','sacrifice');
             delete global.city['s_alter'];
-            if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-                for (let i=0; i<global.race.governor.tasks.length; i++){
-                    if (global.race.governor.tasks[`t${i}`] === 'sacrifice'){
-                        global.race.governor.tasks[`t${i}`] = 'none';
-                    }
-                }
-            }
+            removeTask('sacrifice');
             break;
         case 'magnificent':
             removeFromQueue(['city-shrine']);
@@ -4818,13 +4793,7 @@ export function cleanRemoveTrait(trait,rank){
         case 'hooved':
             removeFromQueue(['city-horseshoe', 'space-horseshoe']);
             global.resource.Horseshoe.display = false;
-            if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-                for (let i=0; i<global.race.governor.tasks.length; i++){
-                    if (global.race.governor.tasks[`t${i}`] === 'horseshoe'){
-                        global.race.governor.tasks[`t${i}`] = 'none';
-                    }
-                }
-            }
+            removeTask('horseshoe');
             break;
         case 'slow':
             save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));

--- a/src/space.js
+++ b/src/space.js
@@ -909,7 +909,7 @@ const spaceProjects = {
                 Wrought_Iron(offset){ return spaceCostMultiplier('fabrication', offset, 1200, 1.32); }
             },
             effect(){
-                let c_worker = global.race['cataclysm'] || global.race['orbit_decayed'] ? `<div>${loc('city_cement_plant_effect1',[1])}</div>` : ``;
+                let c_worker = global.race['cataclysm'] ? `<div>${loc('city_cement_plant_effect1',[jobScale(1)])}</div>` : ``;
                 let fab = global.race['cataclysm'] ? 5 : 2;
                 if (global.race['high_pop']){
                     fab = highPopAdjust(fab);
@@ -923,7 +923,7 @@ const spaceProjects = {
                     incrementStruct('fabrication');
                     if (global.space.spaceport.support < global.space.spaceport.s_max){
                         global.space['fabrication'].on++;
-                        global.civic.craftsman.max++;
+                        global.civic.craftsman.max += jobScale(1);
                     }
                     return true;
                 }
@@ -1357,7 +1357,7 @@ const spaceProjects = {
                 if (payCosts($(this)[0])){
                     global.space.spc_casino.count++;
                     if (!global.race['joyless']){
-                        global.civic.entertainer.max++;
+                        global.civic.entertainer.max += jobScale(1);
                         global.civic.entertainer.display = true;
                     }
                     if (global.city.powered && global.city.power >= $(this)[0].powered()){

--- a/src/tech.js
+++ b/src/tech.js
@@ -11,7 +11,7 @@ import { renderSpace } from './space.js';
 import { setOrbits } from './truepath.js';
 import { arpa } from './arpa.js';
 import { setPowerGrid } from './industry.js';
-import { defineGovernor } from './governor.js';
+import { defineGovernor, removeTask } from './governor.js';
 import { big_bang, cataclysm_end, descension, aiApocalypse } from './resets.js';
 
 const techs = {
@@ -2638,7 +2638,7 @@ const techs = {
         },
         effect: loc('tech_governor_effect'),
         action(){
-            if (payCosts($(this)[0]) && global.genes['governor']){
+            if (payCosts($(this)[0])){
                 global.settings.showGovernor = true;
                 return true;
             }
@@ -11664,13 +11664,8 @@ function uniteEffect(){
         global.civic.foreign[`gov${i}`].sab = 0;
         global.civic.foreign[`gov${i}`].act = 'none';
     }
-    if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-        for (let i=0; i<global.race.governor.tasks.length; i++){
-            if (global.race.governor.tasks[`t${i}`] === 'spy' || global.race.governor.tasks[`t${i}`] === 'spyop'){
-                global.race.governor.tasks[`t${i}`] = 'none';
-            }
-        }
-    }
+    removeTask('spy');
+    removeTask('spyop');
 }
 
 export function swissKnife(cheeseOnly,cheeseList){

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -2098,18 +2098,22 @@ function drawShips(){
                     }
                 },
                 setLoc(l,id){
-                    if (l !== global.space.shipyard.ships[id].location){
-                        let crew = shipCrewSize(global.space.shipyard.ships[id]);
-                        if (global.civic.garrison.workers - global.civic.garrison.crew >= crew){
+                    let ship = global.space.shipyard.ships[id];
+                    if (l !== ship.location){
+                        let crew = shipCrewSize(ship);
+                        let manned = ship.transit > 0 || ship.location !== 'spc_dwarf';
+                        if (manned || global.civic.garrison.workers - global.civic.garrison.crew >= crew){
                             let dest = calcLandingPoint(ship, l);
-                            let distance = transferWindow(global.space.shipyard.ships[id].xy,dest);
-                            let speed = shipSpeed(global.space.shipyard.ships[id]);
-                            global.space.shipyard.ships[id].location = l;
-                            global.space.shipyard.ships[id].transit = Math.round(distance / speed);
-                            global.space.shipyard.ships[id].dist = Math.round(distance / speed);
-                            global.space.shipyard.ships[id].origin = deepClone(ship.xy);
-                            global.space.shipyard.ships[id].destination = {x: dest.x, y: dest.y};
-                            global.civic.garrison.crew += crew;
+                            let distance = transferWindow(ship.xy,dest);
+                            let speed = shipSpeed(ship);
+                            ship.location = l;
+                            ship.transit = Math.round(distance / speed);
+                            ship.dist = Math.round(distance / speed);
+                            ship.origin = deepClone(ship.xy);
+                            ship.destination = {x: dest.x, y: dest.y};
+                            if (!manned){
+                                global.civic.garrison.crew += crew;
+                            }
                             drawShips();
                             clearPopper(`ship${id}loc${l}`);
                         }

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -2512,7 +2512,8 @@ function xShift(id){
     return 0;
 }
 
-function drawMap(scale, translatePos) {
+var mapScale, mapShift;
+export function drawMap() {
     let canvas = document.getElementById("mapCanvas");
     let ctx = canvas.getContext("2d");
     canvas.width = canvas.getBoundingClientRect().width;
@@ -2521,8 +2522,8 @@ function drawMap(scale, translatePos) {
     ctx.save();
     ctx.fillStyle = "#000000";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.translate(translatePos.x, translatePos.y);
-    ctx.scale(scale, scale);
+    ctx.translate(mapShift.x, mapShift.y);
+    ctx.scale(mapScale, mapScale);
 
     // Calculate positions
     let planetLocation = {};
@@ -2531,15 +2532,12 @@ function drawMap(scale, translatePos) {
     }
 
     // Draw orbits
-    ctx.lineWidth = 1 / scale;
+    ctx.lineWidth = 1 / mapScale;
     ctx.strokeStyle = "#c0c0c0";
     for (let [id, planet] of Object.entries(spacePlanetStats)) {
-        if (global.race['orbit_decayed'] && id === 'spc_home'){
-            continue;
-        }
         if (!planet.moon && planet.orbit !== -2) {
             ctx.beginPath();
-            if (planet.belt){
+            if (planet.belt || (global.race['orbit_decayed'] && id === 'spc_home')){
                 ctx.setLineDash([0.01, 0.01]);
             }
             else {
@@ -2627,7 +2625,7 @@ function drawMap(scale, translatePos) {
     ctx.shadowColor = 'rgba(0, 0, 0, 0.5)';
 
     ctx.fillStyle = "#009aff";
-    ctx.font = `${20 / scale}px serif`;
+    ctx.font = `${20 / mapScale}px serif`;
     // Ship names
     for (let ship of global.space.shipyard.ships) {
         if (ship.transit > 0) {
@@ -2636,7 +2634,7 @@ function drawMap(scale, translatePos) {
     }
 
     ctx.fillStyle = "#ffa500";
-    ctx.font = `${25 / scale}px serif`;
+    ctx.font = `${25 / mapScale}px serif`;
     // Planet names
     for (let [id, planet] of Object.entries(spacePlanetStats)) {
         if (actions.space[id] && global.settings.space[id.substring(4)]){
@@ -2674,65 +2672,65 @@ function drawMap(scale, translatePos) {
 
 function buildSolarMap(parentNode) {
     let currentNode = $(`<div style="margin-top: 10px; margin-bottom: 10px;"></div>`).appendTo(parentNode);
-    let scale = 20.0;
-    let translatePos = {};
     let canvasOffset = {};
     let dragOffset = {};
     let mouseDown = false;
+    mapShift = {};
+    mapScale = 20.0;
 
     currentNode.append(
       $(`<canvas id="mapCanvas" style="width: 100%; height: 75vh"></canvas>`)
         .on("mouseup mouseover mouseout", () => mouseDown = false)
         .on("mousedown", (e) => {
             mouseDown = true;
-            dragOffset.x = e.clientX - translatePos.x;
-            dragOffset.y = e.clientY - translatePos.y;
+            dragOffset.x = e.clientX - mapShift.x;
+            dragOffset.y = e.clientY - mapShift.y;
         })
         .on("mousemove", (e) => {
             if (mouseDown) {
-                translatePos.x = e.clientX - dragOffset.x;
-                translatePos.y = e.clientY - dragOffset.y;
-                drawMap(scale, translatePos);
+                mapShift.x = e.clientX - dragOffset.x;
+                mapShift.y = e.clientY - dragOffset.y;
+                drawMap();
             }
         })
         .on("wheel", (e) => {
             if(e.originalEvent.deltaY < 0) {
-                scale /= 0.8;
-                translatePos.x = canvasOffset.x + (translatePos.x - canvasOffset.x) / 0.8;
-                translatePos.y = canvasOffset.y + (translatePos.y - canvasOffset.y) / 0.8;
-                drawMap(scale, translatePos);
+                mapScale /= 0.8;
+                mapShift.x = canvasOffset.x + (mapShift.x - canvasOffset.x) / 0.8;
+                mapShift.y = canvasOffset.y + (mapShift.y - canvasOffset.y) / 0.8;
+                drawMap();
             }
             else {
-                scale *= 0.8;
-                translatePos.x = canvasOffset.x + (translatePos.x - canvasOffset.x) * 0.8;
-                translatePos.y = canvasOffset.y + (translatePos.y - canvasOffset.y) * 0.8;
-                drawMap(scale, translatePos);
+                mapScale *= 0.8;
+                mapShift.x = canvasOffset.x + (mapShift.x - canvasOffset.x) * 0.8;
+                mapShift.y = canvasOffset.y + (mapShift.y - canvasOffset.y) * 0.8;
+                drawMap();
             }
             return false;
         }),
       $(`<input type="button" value="+" style="position: absolute; width: 30px; height: 30px; top: 32px; right: 2px;">`)
         .on("click", () => {
-            scale /= 0.8;
-            translatePos.x = canvasOffset.x + (translatePos.x - canvasOffset.x) / 0.8;
-            translatePos.y = canvasOffset.y + (translatePos.y - canvasOffset.y) / 0.8;
-            drawMap(scale, translatePos);
+            mapScale /= 0.8;
+            mapShift.x = canvasOffset.x + (mapShift.x - canvasOffset.x) / 0.8;
+            mapShift.y = canvasOffset.y + (mapShift.y - canvasOffset.y) / 0.8;
+            drawMap();
         }),
       $(`<input type="button" value="-" style="position: absolute; width: 30px; height: 30px; top: 64px; right: 2px;">`)
         .on("click", () => {
-            scale *= 0.8;
-            translatePos.x = canvasOffset.x + (translatePos.x - canvasOffset.x) * 0.8;
-            translatePos.y = canvasOffset.y + (translatePos.y - canvasOffset.y) * 0.8;
-            drawMap(scale, translatePos);
+            mapScale *= 0.8;
+            mapShift.x = canvasOffset.x + (mapShift.x - canvasOffset.x) * 0.8;
+            mapShift.y = canvasOffset.y + (mapShift.y - canvasOffset.y) * 0.8;
+            drawMap();
         })
     );
 
     let bounds = document.getElementById("mapCanvas").getBoundingClientRect();
     canvasOffset.x = bounds.width / 2;
     canvasOffset.y = bounds.height / 2;
-    translatePos.x = canvasOffset.x;
-    translatePos.y = canvasOffset.y;
+    mapShift.x = canvasOffset.x;
+    mapShift.y = canvasOffset.y;
 
-    drawMap(scale, translatePos);
+    drawMap();
 }
 
 function solarModal(){

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -21,8 +21,6 @@ export function renderAchievePage(zone){
 }
 
 const universeExclusives = {
-    biome_hellscape: ['standard', 'micro', 'heavy', 'antimatter', 'magic'],
-    biome_eden: ['evil'],
     cross: ['antimatter'],
     vigilante: ['evil'],
     squished: ['micro'],


### PR DESCRIPTION
On impact:
Slave governor is hidden. (And slightly refactored task removal. It was duplicated too many times around code...)
All nanite productions and trades are unassigned, to prevent going over post-impact cap.
Wiped city buildings in purgatory, to prevent restoring them after mutations shenanigans.
City and moon buildings removed from queue on decay, to prevent getting 20 ghostly(yet functional) apartments.
Impact timer is actually getting removed.
Smelter UI added to industries tab.
Chrysotile UI removed from industries tab.

Other:
Switching mimic won't re-enable lumberjacks and farmers.
Removed duplicated cement workers tooltip.
Added few missing jobScale().
TP ships won't ask for more crew if they already dispatched and manned..
Eden\Hellscape achievements shown in wiki in all universes.

Last two aren't fixes, so they committed separately.
Added auto update for solar map. It redraws map every 5s when it open, no player input needed.
Earth doesn't gets annihilated to nothing after impact, it leaves some remains on map: dash line, same as for asteroid belts.