### PR TITLE
More OD fixes

### DIFF
--- a/src/achieve.js
+++ b/src/achieve.js
@@ -569,10 +569,7 @@ export function checkAchievements(){
         }
     }
 
-    if (eventActive('firework') && ( 
-        (!global.race['cataclysm'] && global.city.firework.on > 0) || 
-        (global.race['cataclysm'] && global.space.firework.on > 0) 
-        )){
+    if (eventActive('firework') && global[global.race['cataclysm'] || global.race['orbit_decayed'] ? 'space' : 'city'].firework.on > 0){
         unlockFeat('firework',global.race.universe === 'micro' ? true : false);
     }
 
@@ -2529,7 +2526,7 @@ export function drawStats(){
     let hallowed = getHalloween();
     if (hallowed.active){
         let trick = '';
-        if (global.stats.cfood >= 13 || global.race['cataclysm']){
+        if (global.stats.cfood >= 13 || global.race['cataclysm'] || global.race['orbit_decayed']){
             trick = `<span>${trickOrTreat(7,12,true)}</span>`;
         }
         stats.append(`<div><span class="has-text-warning">${loc("achieve_stats_trickortreat")}</span> {{ s.cfood | format }} ${trick}</div>`);

--- a/src/events.js
+++ b/src/events.js
@@ -312,7 +312,7 @@ export const events = {
         effect(){
             global.tech['quaked'] = 1;
             drawTech();
-            return loc('event_quake',[global.race['cataclysm'] ? races[global.race.species].solar.red : races[global.race.species].home]);
+            return loc('event_quake',[global.race['cataclysm'] || global.race['orbit_decayed'] ? races[global.race.species].solar.red : races[global.race.species].home]);
         }
     },
     doom: {
@@ -633,7 +633,7 @@ export const events = {
         },
         type: 'minor',
         condition(){
-            if (!global.race['cataclysm'] && global.city.calendar.temp !== 2){
+            if (!global.race['cataclysm'] && !global.race['orbit_decayed'] && global.city.calendar.temp !== 2){
                 return true;
             }
             return false;
@@ -650,7 +650,7 @@ export const events = {
         },
         type: 'minor',
         condition(){
-            if (!global.race['cataclysm'] && global.city.calendar.temp !== 0){
+            if (!global.race['cataclysm'] && !global.race['orbit_decayed'] && global.city.calendar.temp !== 0){
                 return true;
             }
             return false;
@@ -708,7 +708,7 @@ export const events = {
         },
         type: 'minor',
         condition(){
-            if (!global.race['cataclysm'] && global.city.calendar.weather !== 0){
+            if (!global.race['cataclysm'] && !global.race['orbit_decayed'] && global.city.calendar.weather !== 0){
                 return true;
             }
             return false;
@@ -724,7 +724,7 @@ export const events = {
         },
         type: 'minor',
         condition(){
-            if (!global.race['cataclysm'] && global.city.calendar.weather !== 1){
+            if (!global.race['cataclysm'] && !global.race['orbit_decayed'] && global.city.calendar.weather !== 1){
                 return true;
             }
             return false;

--- a/src/functions.js
+++ b/src/functions.js
@@ -56,10 +56,8 @@ export function popover(id,content,opts){
             if (opts.hasOwnProperty('in') && typeof opts['in'] === 'function'){
                 opts['in']({ this: this, popper: popper, id: `popper` });
             }
-            if (eventActive('firework') && (
-                (!global.race['cataclysm'] && !global.race['orbit_decayed'] && global.city.firework.on > 0) ||
-                ((global.race['cataclysm'] || global.race['orbit_decayed']) && global.space.firework.on > 0)
-                )){
+
+            if (eventActive('firework') && global[global.race['cataclysm'] || global.race['orbit_decayed'] ? 'space' : 'city'].firework.on > 0){
                 $(popper).append(`<span class="pyro"><span class="before"></span><span class="after"></span></span>`);
             }
         });

--- a/src/industry.js
+++ b/src/industry.js
@@ -1242,13 +1242,13 @@ export function gridEnabled(c_action,region,p0,p1){
     let isOk = false;
     switch (region){
         case 'city':
-            isOk = global.race['cataclysm'] ? false : checkCityRequirements(p1);
+            isOk = global.race['cataclysm'] || global.race['orbit_decayed'] ? false : checkCityRequirements(p1);
             break;
         case 'portal':
             isOk = checkRequirements(fortressTech(),p0,p1);
             break;
         default:
-            isOk = checkSpaceRequirements(region,p0,p1);
+            isOk = p0 === 'spc_moon' && global.race['orbit_decayed'] ? false : checkSpaceRequirements(region,p0,p1);
             break;
     }
     return global[region][p1] && isOk && checkPowerRequirements(c_action) ? true : false;

--- a/src/main.js
+++ b/src/main.js
@@ -2972,7 +2972,7 @@ function fastLoop(){
             if (global.race['artifical'] || (global.race['spongy'] && global.city.calendar.weather === 0)){
                 // Do Nothing
             }
-            else if (global.race['parasite'] && global.city.calendar.wind === 0 && !global.race['cataclysm']){
+            else if (global.race['parasite'] && global.city.calendar.wind === 0 && !global.race['cataclysm'] && !global.race['orbit_decayed']){
                 // Do Nothing
             }
             else {
@@ -3009,7 +3009,7 @@ function fastLoop(){
                     lowerBound *= biomes.taiga.vars()[1];
                 }
                 let base = global.city.ptrait.includes('toxic') ? global['resource'][global.race.species].amount * planetTraits.toxic.vars()[1] : global['resource'][global.race.species].amount;
-                if (global.race['parasite'] && global.race['cataclysm']){
+                if (global.race['parasite'] && (global.race['cataclysm'] || global.race['orbit_decayed'])){
                     lowerBound = Math.round(lowerBound / 5);
                     base *= 3;
                 }
@@ -6699,7 +6699,7 @@ function midLoop(){
         }
         if (global.space['garage']){
             let multiplier = global.tech['particles'] >= 4 ? 1 + (global.tech['supercollider'] / 20) : 1;
-            multiplier *= global.tech['world_control'] || global.race['cataclysm'] || global.race['orbit_decayed'] ? 2 : 1;
+            multiplier *= global.tech['world_control'] || global.race['cataclysm'] ? 2 : 1;
             if (global.tech['shelving'] && global.tech.shelving >= 3){ multiplier *= 1.5; }
             multiplier *= global.stats.achieve['blackhole'] ? 1 + (global.stats.achieve.blackhole.l * 0.05) : 1;
             let h_multiplier = global.tech['shelving'] && global.tech.shelving >= 2 ? multiplier * 3 : multiplier;

--- a/src/space.js
+++ b/src/space.js
@@ -1977,12 +1977,6 @@ const spaceProjects = {
                 if (payCosts($(this)[0])){
                     messageQueue(loc('space_dwarf_mission_action',[races[global.race.species].solar.dwarf]),'info',false,['progress']);
                     global.space['elerium_contain'] = { count: 0, on: 0 };
-                    if (global.race['truepath']){
-                        global.settings.space.titan = true;
-                        global.settings.space.enceladus = true;
-                        global.space['titan_spaceport'] = { count: 0, on: 0, support: 0, s_max: 0 };
-                        global.space['electrolysis'] = { count: 0, on: 0, support: 0, s_max: 0 };
-                    }
                     return true;
                 }
                 return false;

--- a/src/space.js
+++ b/src/space.js
@@ -807,7 +807,7 @@ const spaceProjects = {
                     incrementStruct('garage');
                     let multiplier = global.tech['particles'] >= 4 ? 1 + (global.tech['supercollider'] / 20) : 1;
                     let containers = global.tech['particles'] >= 4 ? 20 + global.tech['supercollider'] : 20;
-                    if (global.tech['world_control'] || global.race['cataclysm'] || global.race['orbit_decayed']){
+                    if (global.tech['world_control'] || global.race['cataclysm']){
                         multiplier *= 2;
                         containers += 10;
                     }

--- a/src/tech.js
+++ b/src/tech.js
@@ -10717,6 +10717,10 @@ const techs = {
         effect: loc('tech_long_range_probes_effect'),
         action(){
             if (payCosts($(this)[0])){
+                global.settings.space.titan = true;
+                global.settings.space.enceladus = true;
+                global.space['titan_spaceport'] = { count: 0, on: 0, support: 0, s_max: 0 };
+                global.space['electrolysis'] = { count: 0, on: 0, support: 0, s_max: 0 };
                 return true;
             }
             return false;

--- a/src/wiki/events.js
+++ b/src/wiki/events.js
@@ -235,7 +235,7 @@ function mainEventsPage(content){
         infoBoxBuilder(mainContent, { name: 'quake_condition', template: 'events', label: loc('wiki_events_quake'), paragraphs: 2, break: [2], h_level: 2 }, section);
         infoBoxBuilder(mainContent, { name: 'quake_examples', template: 'events', label: loc('wiki_events_quake'), h_level: 2, 
             examples: [
-                loc('event_quake',[global.race['cataclysm'] ? races[global.race.species].solar.red : races[global.race.species].home])
+                loc('event_quake',[global.race['cataclysm'] || global.race['orbit_decayed'] ? races[global.race.species].solar.red : races[global.race.species].home])
             ]
         }, section);
         sideMenu('add',`major-events`,`quake`,loc('wiki_events_quake'));

--- a/src/wiki/tech.js
+++ b/src/wiki/tech.js
@@ -1420,7 +1420,7 @@ const extraInformation = {
         loc(`wiki_tech_job_unlock`,[loc(`job_crystal_miner`)])
     ],
     ley_lines: [
-        loc(`wiki_tech_building_unlock`,[global.race['cataclysm'] ? loc(`space_red_pylon`) : loc(`city_pylon`)])
+        loc(`wiki_tech_building_unlock`,[global.race['cataclysm'] || global.race['orbit_decayed'] ? loc(`space_red_pylon`) : loc(`city_pylon`)])
     ],
     rituals: [
         loc(`wiki_tech_rituals`)


### PR DESCRIPTION
Parasite works same as in cataclysm
Minor weather events disabled
Fireworks feat can be earned after impact
Halloween alt-trick used after impact, as there's no food to click
Quake event refer to Red after impact, same as in cata
Lay Lines wiki entry refer to Cracked Pylon after impact
Power grid doesn't show city and moon after impact
Garage *not* buffed after impact. Currently garage tooltip buffs storage, and container. In game - only storage buffed, but not containers. But in fact it don't need any decay checks at all, as there's unification check which works just fine in OD, unlike cata.

And also moved titan region unlock to long range probes techs. So it won't show empty regions right after reaching belt, it'll unlock at the same time when titan mission becomes actually available. Region was added to game *before* required tech, that must be the reason of such weird behavior.