### PR TITLE
Fix decay's resource colours being swapped

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10652,7 +10652,7 @@ function diffCalc(res,period){
     let el = $(`#res${res} .diff`);
     if (global.race['decay']){
         if (global.resource[res].diff < 0){
-            if (global.resource[res].diff < breakdown.p.consume[res][loc('evo_challenge_decay')]){
+            if (global.resource[res].diff >= breakdown.p.consume[res][loc('evo_challenge_decay')]){
                 if (!el.hasClass('has-text-warning')){
                     el.removeClass('has-text-danger');
                     el.addClass('has-text-warning');


### PR DESCRIPTION
Currently, it's `gas-text-danger` (red) if the total is only negative due to decay, and `has-text-warning` otherwise. This is likely intended to be the opposite.