### PR TITLE
potential bugfix to events

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -964,18 +964,21 @@ export function eventList(type){
                             isOk = false;
                         }
                         break;
+
                     case 'high_tax_rate':
-                        if (global.civic.taxes.tax_rate <= [events[event].reqs[req]]){
+                        // there are currently no events with the high_tax_rate requirement
+                        if (global.civic.taxes.tax_rate <= events[event].reqs[req]){
                             isOk = false;
                         }
                         break;
                     case 'low_morale':
-                        if (global.city.morale.current >= [events[event].reqs[req]]){
+                        if (global.city.morale.current >= events[event].reqs[req]){
                             isOk = false;
                         }
                         break;
                     case 'biome':
-                        if (global.city.biome !== [events[event].reqs[req]]){
+                        // there are currently no events with the biome requirement
+                        if (global.city.biome !== events[event].reqs[req]){
                             isOk = false;
                         }
                         break;


### PR DESCRIPTION
Comparison opperators with objects can always yeild the same result. I think the brackets around "events[event].reqs[req]" may have been a typo that potentially prevents the "tax revolt" event from ever occuring. 

The "high tax rate" condition, and the "biome" condition don't seem to have any event cases, and could be removed or commented out if I am not mistaken.

