### PR TITLE
[Bug] Fix quarantine not working while in firework event

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4187,7 +4187,7 @@ export function buildTemplate(key, region){
                 wiki: false,
                 reqs: { mining: 3 },
                 condition(){
-                    return eventActive(`firework`) && (global.tech['cement'] || global.race['flier']);
+                    return eventActive(`firework`) && global[region].firework && (global.tech['cement'] || global.race['flier']);
                 },
                 cost: {
                     Money(){ return global[region].firework.count === 0 ? 50000 : 0; },


### PR DESCRIPTION
Quarantine closed the portal, and firework no longer exist, therefore a unchecked access to firework will cause a null pointer error and not allow the save to be loaded in. Only soft reset can solve this problem, and you just can't complete these task while the firework event is going on.