### PR TITLE
Highlight items in build queue on hover

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6261,7 +6261,7 @@ export function setAction(c_action,action,type,old,prediction){
         if (prediction){ clss = ' precog'; }
         else if (c_action['aura'] && c_action.aura()){ clss = ` ${c_action.aura()}`; }
         let active = c_action['highlight'] ? (c_action.highlight() ? `<span class="is-sr-only">${loc('active')}</span>` : `<span class="is-sr-only">${loc('not_active')}</span>`) : '';
-        element = $(`<a class="button is-dark${cst}${clss}"${data} v-on:click="action" role="link"><span class="aTitle" v-html="$options.filters.title(title)"></span>${active}</a><a role="button" v-on:click="describe" class="is-sr-only">{{ title }} description</a>`);
+        element = $(`<a class="button is-dark${cst}${clss}"${data} v-on:click="action" v-on:mouseenter="mouse_enter" v-on:mouseleave="mouse_leave" role="link"><span class="aTitle" v-html="$options.filters.title(title)"></span>${active}</a><a role="button" v-on:click="describe" class="is-sr-only">{{ title }} description</a>`);
     }
     parent.append(element);
 
@@ -6408,6 +6408,19 @@ export function setAction(c_action,action,type,old,prediction){
             },
             repairMax(){
                 return c_action.repair();
+            },
+            mouse_enter () {
+                const title = this.title;
+                $('.buildList .queued span[class^="res-"]').each(function () {
+                    if (this.innerText === title) {
+                        $(this).addClass('hl-ex');
+                    }
+                });
+            },
+            mouse_leave () {
+                $('.buildList .queued span.hl-ex').each(function () {
+                    $(this).removeClass('hl-ex');
+                });
             }
         },
         filters: {

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2447,7 +2447,7 @@ function addProject(parent,project){
         let buy = $('<div class="buy"></div>');
         current.append(buy);
 
-        buy.append($(`<button :aria-label="loc('queue') + ' ' + projectName()" class="button" @click="queue('${project}')">${loc('queue')}</button>`));
+        buy.append($(`<button :aria-label="loc('queue') + ' ' + projectName()" class="button" @click="queue('${project}')" @mouseenter="mouse_enter" @mouseleave="mouse_leave">${loc('queue')}</button>`));
         buy.append($(`<button :aria-label="arpaProjectSRCosts('1','${project}')" class="button x1" @click="build('${project}',1)">1%</button>`));
         buy.append($(`<button :aria-label="arpaProjectSRCosts('10','${project}')" class="button x10" @click="build('${project}',10)">10%</button>`));
         buy.append($(`<button :aria-label="arpaProjectSRCosts('25','${project}')" class="button x25" @click="build('${project}',25)">25%</button>`));
@@ -2511,6 +2511,18 @@ function addProject(parent,project){
                         }
                     });
                     return cost;
+                },
+                mouse_enter () {
+                    $('.buildList .queued span').each(function () {
+                        if (this.innerText === title) {
+                            $(this).addClass('hl-ex');
+                        }
+                    });
+                },
+                mouse_leave () {
+                    $('.buildList .queued span.hl-ex').each(function () {
+                        $(this).removeClass('hl-ex');
+                    });
                 }
             },
             filters: {

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1353,6 +1353,10 @@ Misc ---------> Main template
             .hl-cna {
                 color: @disabled ;
             }
+
+            .hl-ex {
+                color: @has-text-advanced !important;
+            }
         }
 
         // .msgQueue


### PR DESCRIPTION
When I have many items in the build queue, I sometimes end up adding to the queue in duplicate, as I miss that I've already queued a particular building. This pull request highlights items already in the build queue when hovered in the main pane.

I've recycled an existing colour for 'has text advanced', but this can be swapped for something more specific if preferred.

Fixes #1130
Closes #1129