### PR TITLE
ARPA: don't sometimes srSpeak() Javascript code for descriptions

### DIFF
--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2324,7 +2324,7 @@ function addProject(parent,project){
                     buildArpa(pro,num,true);
                 },
                 srDesc(){
-                    return srSpeak(arpaProjects[project].desc);
+                    return srSpeak(typeof arpaProjects[project].desc === 'string' ? arpaProjects[project].desc : arpaProjects[project].desc());
                 },
                 srLevel(){
                     return srSpeak(arpaProjects[project].effect());


### PR DESCRIPTION
Supercolliders, railroads ETC export their description as a function which wasn't being called.