### PR TITLE
Bunch of fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1837,7 +1837,7 @@ export const actions = {
                 generated *= global.city.ptrait.includes('trashed') ? planetTraits.trashed.vars()[0] : 1;
                 generated = +(generated).toFixed(2);
                 let store = BHStorageMulti(spatialReasoning(200));
-                let wood = global.race['kindling_kindred'] ? `` : `<div class="has-text-caution">${loc('city_compost_heap_effect2',[0.5,global.resource.Lumber.name])}</div>`;
+                let wood = global.race['kindling_kindred'] || global.race['smoldering'] ? `` : `<div class="has-text-caution">${loc('city_compost_heap_effect2',[0.5,global.resource.Lumber.name])}</div>`;
                 return `<div>${loc('city_compost_heap_effect',[generated])}</div><div>${loc('city_compost_heap_effect3',[store])}</div>${wood}`;
             },
             switchable(){ return true; },
@@ -6916,7 +6916,7 @@ export function orbitDecayed(){
             }
             if (global.race['casting']){
                 Object.keys(global.race.casting).forEach(function (c){
-                    global.race.casting[0] = 0;
+                    global.race.casting[c] = 0;
                 });
             }
         }
@@ -8072,7 +8072,6 @@ function cataclysm(){
         global.resource.Copper.display = true;
         global.resource.Iron.display = true;
         global.resource.Aluminium.display = true;
-        global.resource.Cement.display = true;
         global.resource.Coal.display = true;
         global.resource.Oil.display = true;
         global.resource.Uranium.display = true;
@@ -8089,6 +8088,11 @@ function cataclysm(){
         global.resource.Crates.display = true;
         global.resource.Containers.display = true;
 
+        if (!global.race['flier']){
+            global.resource.Cement.display = true;
+            global.resource.Cement.max = 75000;
+            global.resource.Cement.amount = 75000;
+        }
         if (!global.race['kindling_kindred'] && !global.race['smoldering']){
             global.resource.Lumber.display = true;
             global.resource.Plywood.display = true;
@@ -8128,8 +8132,6 @@ function cataclysm(){
         global.resource.Steel.amount = 75000;
         global.resource.Aluminium.max = 75000;
         global.resource.Aluminium.amount = 75000;
-        global.resource.Cement.max = 75000;
-        global.resource.Cement.amount = 75000;
         global.resource.Titanium.max = 75000;
         global.resource.Titanium.amount = 75000;
         global.resource.Coal.max = 10000;

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -609,7 +609,7 @@ export const genePool = {
         grant: ['plasma',2],
         cost: { Plasmid(){ return 165; } },
         action(){
-            if (payCrispr('mitosis')){
+            if (payCrispr('metaphase')){
                 return true;
             }
             return false;

--- a/src/industry.js
+++ b/src/industry.js
@@ -1145,35 +1145,32 @@ function loadPylon(parent,bind){
     let spellTypes = $('<div class="pylon wrap"></div>');
     parent.append(spellTypes);
 
-    let ritualList = [];
-    if (global.race['orbit_decayed']){
-        ritualList = ['miner','science','factory','army','hunting','crafting'];
+    let ritualList = ['science','army','hunting'];
+
+    if (!global.race['detritivore'] && !global.race['carnivore'] && !global.race['soul_eater'] && !global.race['artifical'] && !global.race['unfathomable'] && !global.race['cataclysm'] && !global.race['orbit_decayed']) {
+        ritualList.push('farmer');
     }
-    else if (global.race['cataclysm']){
-        ritualList = ['science','factory','army','hunting','crafting'];
+    if (!global.race['cataclysm']) {
+        ritualList.push('miner');
     }
-    else if (global.race['unfathomable']){
-        ritualList = ['miner','lumberjack','science','factory','army','hunting','crafting'];
+    if (!global.race['kindling_kindred'] && !global.race['smoldering'] && !global.race['evil'] && !global.race['cataclysm'] && !global.race['orbit_decayed']) {
+        ritualList.push('lumberjack');
     }
-    else {
-        ritualList = ['farmer','miner','lumberjack','science','factory','army','hunting','crafting'];
+    if (!global.race['flier']) {
+        ritualList.push('factory');
+    }
+    if (global.tech.magic >= 4) {
+        ritualList.push('crafting');
     }
 
     if (global.tech['magic'] && global.tech.magic >= 3){
         ritualList.forEach(function (spell){
-            if (
-                (spell !== 'crafting' && spell !== 'lumberjack' && spell !== 'farmer') ||
-                (spell === 'farmer' && !global.race['detritivore'] && !global.race['carnivore'] && !global.race['soul_eater'] && !global.race['artifical']) ||
-                (spell === 'lumberjack' && !global.race['kindling_kindred'] && !global.race['smoldering'] && !global.race['evil']) ||
-                (spell === 'crafting' && global.tech.magic >= 4)
-                ){
-                let cast = $(`<span :aria-label="buildLabel('${spell}') + ariaCount('${spell}')" class="current ${spell}">${loc(`modal_pylon_spell_${spell}`)} {{ ${spell} }}</span>`);
-                let sub = $(`<span role="button" class="sub" @click="subSpell('${spell}')" aria-label="Stop casting '${spell}' ritual"><span>&laquo;</span></span>`);
-                let add = $(`<span role="button" class="add" @click="addSpell('${spell}')" aria-label="Cast '${spell}' ritual"><span>&raquo;</span></span>`);
-                spellTypes.append(sub);
-                spellTypes.append(cast);
-                spellTypes.append(add);
-            }
+            let cast = $(`<span :aria-label="buildLabel('${spell}') + ariaCount('${spell}')" class="current ${spell}">${loc(`modal_pylon_spell_${spell}`)} {{ ${spell} }}</span>`);
+            let sub = $(`<span role="button" class="sub" @click="subSpell('${spell}')" aria-label="Stop casting '${spell}' ritual"><span>&laquo;</span></span>`);
+            let add = $(`<span role="button" class="add" @click="addSpell('${spell}')" aria-label="Cast '${spell}' ritual"><span>&raquo;</span></span>`);
+            spellTypes.append(sub);
+            spellTypes.append(cast);
+            spellTypes.append(add);
         });
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -896,7 +896,7 @@ function fastLoop(){
         }
     }
     if (global.city.ptrait.includes('mellow')){
-        breakdown.p['Global'][loc('planet_mellow_bd')] = '-10%';
+        breakdown.p['Global'][loc('planet_mellow_bd')] = '-' + (100 - (planetTraits.mellow.vars()[2] * 100)) + '%';
         global_multiplier *= planetTraits.mellow.vars()[2];
     }
     if (global.city.ptrait.includes('ozone') && global.city['sun']){
@@ -3092,7 +3092,7 @@ function fastLoop(){
                 if (global.race['detritivore']){
                     if (global.city['compost']){
                         let operating = global.city.compost.on;
-                        if (!global.race['kindling_kindred']){
+                        if (!global.race['kindling_kindred'] && !global.race['smoldering']){
                             let lumberIncrement = 0.5;
                             let lumber_cost = operating * lumberIncrement;
 
@@ -4600,8 +4600,8 @@ function fastLoop(){
             }
             let salFathom = fathomCheck('salamander');
             if (salFathom > 0){
-                iron_smelter *= 1.2 * salFathom;
-                iridium_smelter *= 1.2 * salFathom;
+                iron_smelter *= 1 + (0.2 * salFathom);
+                iridium_smelter *= 1 + (0.2 * salFathom);
             }
 
             if (iridium_smelter < 1){ iridium_smelter = 1; }
@@ -4681,7 +4681,7 @@ function fastLoop(){
                     steel_smelter *= 1 + (dirtVal / 100);
                 }
                 if (salFathom > 0){
-                    steel_smelter *= 1.2 * salFathom;
+                    steel_smelter *= 1 + (0.2 * salFathom);
                 }
 
                 let smelter_output = steel_smelter * steel_base * production('psychic_boost','Steel');
@@ -5689,7 +5689,7 @@ function fastLoop(){
                     delta *= 1 + (refinery / 100);
 
                     breakdown.p['Aluminium'][`${global.race['cataclysm'] || global.race['orbit_decayed'] ? loc('space_red_mine_title') : loc('job_miner')}+2`] = base + 'v';
-                    if (global.race['cataclysm'] || global.race['orbit_decayed'] && base > 0 && zigVal > 0){
+                    if ((global.race['cataclysm'] || global.race['orbit_decayed']) && base > 0 && zigVal > 0){
                         delta *= zigVal;
                         breakdown.p['Aluminium'][`ᄂ${loc('space_red_ziggurat_title')}`] = ((zigVal - 1) * 100) + '%';
                     }

--- a/src/portal.js
+++ b/src/portal.js
@@ -2378,7 +2378,7 @@ export function bloodwar(){
 
     let wendFathom = fathomCheck('wendigo');
     if (wendFathom > 0){
-        gem_chance = Math.round(gem_chance * ((100 - traits.ghostly.vars(1)[2]) / 100 * wendFathom));
+        gem_chance = Math.round(gem_chance * ((100 - (traits.ghostly.vars(1)[2] * wendFathom)) / 100));
     }
 
     if (gem_chance < 12){

--- a/src/races.js
+++ b/src/races.js
@@ -5071,7 +5071,7 @@ export function cleanAddTrait(trait){
             break;
         case 'sappy':
             if (global.civic.d_job === 'quarry_worker'){
-                global.civic.d_job = 'unemployed';
+                global.civic.d_job = global.race['carnivore'] || global.race['soul_eater'] ? 'hunter' : 'unemployed';
             }
             global.civic.quarry_worker.display = false;
             global.civic.quarry_worker.workers = 0;
@@ -5191,6 +5191,7 @@ export function cleanAddTrait(trait){
             else {
                 window.location.reload();
             }
+            break;
         case 'hyper':
             save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
             if (webWorker.w){
@@ -5200,6 +5201,7 @@ export function cleanAddTrait(trait){
             else {
                 window.location.reload();
             }
+            break;
         case 'calm':
             if (global.tech['primitive'] >= 3) {
                 checkPurgatory('city','meditation',{ count: 0 });
@@ -5387,6 +5389,7 @@ export function cleanRemoveTrait(trait,rank){
             else {
                 window.location.reload();
             }
+            break;
         case 'hyper':
             save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
             if (webWorker.w){
@@ -5396,6 +5399,7 @@ export function cleanRemoveTrait(trait,rank){
             else {
                 window.location.reload();
             }
+            break;
         case 'calm':
             removeFromQueue(['city-meditation']);
             global.resource.Zen.display = false;

--- a/src/resets.js
+++ b/src/resets.js
@@ -612,6 +612,9 @@ export function descension(){
     if (webWorker.w){
         webWorker.w.terminate();
     }
+    if (!global['sim']){
+        save.setItem('evolveBak',LZString.compressToUTF16(JSON.stringify(global)));
+    }
     clearSavedMessages();
 
     tagEvent('reset',{

--- a/src/space.js
+++ b/src/space.js
@@ -881,8 +881,8 @@ const spaceProjects = {
                 }
 
                 let decayed = global.race['orbit_decayed'] ? `<div>${loc('city_mine_effect1',[jobScale(1)])}</div><div>${loc('city_coal_mine_effect1',[jobScale(1)])}</div>` : '';
-                let cat_stone = global.race['cataclysm'] || global.race['orbit_decayed'] && !global.race['sappy'] ? `<div>${loc('space_red_mine_effect',[+(production('red_mine','stone')).toFixed(2),global.resource.Stone.name])}</div>` : ``;
-                let cat_asbestos = global.race['cataclysm'] || global.race['orbit_decayed'] && global.race['smoldering'] ? `<div>${loc('space_red_mine_effect',[+(production('red_mine','asbestos')).toFixed(2),global.resource.Chrysotile.name])}</div>` : ``;
+                let cat_stone = (global.race['cataclysm'] || global.race['orbit_decayed']) && !global.race['sappy'] ? `<div>${loc('space_red_mine_effect',[+(production('red_mine','stone')).toFixed(2),global.resource.Stone.name])}</div>` : ``;
+                let cat_asbestos = (global.race['cataclysm'] || global.race['orbit_decayed']) && global.race['smoldering'] ? `<div>${loc('space_red_mine_effect',[+(production('red_mine','asbestos')).toFixed(2),global.resource.Chrysotile.name])}</div>` : ``;
                 let cat_alum = global.race['cataclysm'] || global.race['orbit_decayed'] ? `<div>${loc('space_red_mine_effect',[+(production('red_mine','aluminium')).toFixed(2),global.resource.Aluminium.name])}</div>` : ``;
                 return `<div class="has-text-caution">${loc('space_used_support',[planetName().red])}</div>${decayed}<div>${loc('space_red_mine_effect',[copper,global.resource.Copper.name])}</div><div>${loc('space_red_mine_effect',[titanium,global.resource.Titanium.name])}</div>${rival}${cat_asbestos}${cat_stone}${cat_alum}`;
             },
@@ -1011,7 +1011,7 @@ const spaceProjects = {
             effect(){
                 let food = +(production('biodome','food')).toFixed(2);
                 let cat_fd = global.race['cataclysm'] || global.race['orbit_decayed'] ? `<div>${loc('produce',[+(production('biodome','cat_food')).toFixed(2),global.resource.Food.name])}</div>` : ``;
-                let cat_wd = (global.race['cataclysm'] || global.race['orbit_decayed']) && !global.race['kindling_kindred'] ? `<div>${loc('space_red_mine_effect',[+(production('biodome','lumber')).toFixed(2),global.resource.Lumber.name])}</div>` : ``;
+                let cat_wd = (global.race['cataclysm'] || global.race['orbit_decayed']) && !global.race['kindling_kindred'] && !global.race['smoldering'] ? `<div>${loc('space_red_mine_effect',[+(production('biodome','lumber')).toFixed(2),global.resource.Lumber.name])}</div>` : ``;
                 let pop = global.tech.mars >= 6 ? 0.1 : 0.05;
                 let fLabel = global.race['artifical'] ? loc('city_transmitter_effect',[spatialReasoning(500)]) : loc('plus_max_resource',[spatialReasoning(100), loc('resource_Food_name')]);
                 let sig_cap = global.race['artifical'] || global.race['orbit_decayed'] ? `<div>${fLabel}</div` : '';
@@ -2523,7 +2523,7 @@ const interstellarProjects = {
                 if (global.tech.science >= 15){
                     know *= 1 + ((global.race['cataclysm'] || global.race['orbit_decayed'] ? support_on['exotic_lab'] : global.city.wardenclyffe.count) * 0.02);
                 }
-                if (global.race['cataclysm'] || global.race['orbit_decayed'] && p_on['s_gate'] && gal_on['scavenger']){
+                if ((global.race['cataclysm'] || global.race['orbit_decayed']) && p_on['s_gate'] && gal_on['scavenger']){
                     know *= 1 + (gal_on['scavenger'] * +(piracy('gxy_alien2') * 0.75).toFixed(1));
                 }
                 if (global.tech['science'] >= 21){

--- a/src/tech.js
+++ b/src/tech.js
@@ -4853,9 +4853,6 @@ const techs = {
             return `<div>${loc('tech_demonic_infusion_effect')}</div><div class="has-text-special">${loc('tech_demonic_infusion_effect2',[calcPrestige('descend').artifact])}</div>`;
         },
         action(){
-            if (!global['sim']){
-                save.setItem('evolveBak',LZString.compressToUTF16(JSON.stringify(global)));
-            }
             if (payCosts($(this)[0])){
                 descension();
             }

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -371,7 +371,7 @@ function featDesc(feat,showFlair){
             });
         }
         let checked = `<div class="flexed wide">`;    
-        Object.keys(races).sort((a,b) => races[a].name.localeCompare(races[b].name)).forEach(function (key){
+        Object.keys(races).sort((a,b) => (races[a].name || 'Zombie').localeCompare(races[b].name)).forEach(function (key){
             if (key !== 'protoplasm' && (key !== 'custom' || (key === 'custom' && global.stats.achieve['ascended']))){
                 if (species[key] && species[key] >= 1){
                     checked = checked + `<span class="wide iclr${species[key]}">${races[key].name}</span>`;


### PR DESCRIPTION
Fixes:

Wendigo thralls greatly increase soul gems drop rate depending on how few you have above 0
Salamander thralls greatly reduce smelting output. Rate breaks even at 83 thralls
Slow, hyper and calm behave very strangely if removed. The zen display may show up if you don't have calm and buildings may vanish if you have calm.
Witch hunter reset does not create a backup.
The equilibrium feat on the wiki may cause errors if you don't have a custom, depending on your browser.
Mimicing plants as demons can cause quarry workers to become unemployed instead of set to hunter, permanently locking them out of use and reducing morale.
Being fungi with imitate heat causes composting bins to still take wood which you can't gather.
Mellow always shows as -10% production in the tooltip even when rejuvenated.
Metaphase crispr upgrade has the same cost as the mitosis crispr upgrade (90 while it should be 165)
Biodomes in orbital decay say that they create lumber, even if you have smoldering.
Cataclysm or orbital decay red miners show chrysotile gains in the tooltip even if you don't have smoldering.
Starting cataclysm as an avian race still shows cement in your resource list.
Avians still have access to the cement ritual in magic.

