### PR TITLE
Get noble trait level when adjusting tax

### DIFF
--- a/src/civics.js
+++ b/src/civics.js
@@ -952,8 +952,8 @@ function adjustTax(a,n){
                 let cap = taxCap(false);
                 if (global.race['noble']){
                     global.civic.taxes.tax_rate += inc;
-                    if (global.civic.taxes.tax_rate > (global.civic.govern.type === 'oligarchy' ? 40 : 20)){
-                        global.civic.taxes.tax_rate = global.civic.govern.type === 'oligarchy' ? 40 : 20;
+                    if (global.civic.taxes.tax_rate > (global.civic.govern.type === 'oligarchy' ? traits.noble.vars()[1] + 20 : traits.noble.vars()[1])){
+                        global.civic.taxes.tax_rate = global.civic.govern.type === 'oligarchy' ? traits.noble.vars()[1] + 20 : traits.noble.vars()[1];
                     }
                 }
                 else if (global.civic.taxes.tax_rate < cap){


### PR DESCRIPTION
Tax rate for noble was hardcoded, which ignored the rank 2 and 3 increase in max tax rate.