### PR TITLE
use global unicode for up/down arrows in hell stats tab

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -4770,7 +4770,7 @@ function drawHellAnalysis(){
                     return loc('hell_analysis_start',[start.year, start.day]);
                 },
                 dropdownLabel(open){
-                    return open ? '⮝' : '⮟';
+                    return open ? '▲' : '▼';
                 }
             }
         });


### PR DESCRIPTION
Tiny fix. The expand/close toggle icons are broken on Mac because they're not valid unicode. This replaces them with unicode.

Before:
<img width="583" alt="image" src="https://github.com/pmotschmann/Evolve/assets/1193333/aef6d5f3-dd60-4775-889f-341d570d780d">

After:
<img width="642" alt="image" src="https://github.com/pmotschmann/Evolve/assets/1193333/1f369b78-58c1-40f3-aaee-5d7c11823677">

