### PR TITLE
Format date as fixed-length string when exporting save to file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,12 @@ export function mainVue(){
                     URL.revokeObjectURL(a.href);
                 };
                 const date = new Date();
-                downloadToFile(window.exportGame(), `evolve-${date.getFullYear()}-${date.getMonth()+1}-${date.getDate()}-${date.getHours()}-${date.getMinutes()}.txt`, 'text/plain');
+                const year = date.getFullYear();
+                const month = (date.getMonth() + 1);
+                const day = date.getDate();
+                const hour = date.getHours();
+                const minute = date.getMinutes();
+                downloadToFile(window.exportGame(), `evolve-${year}-${month}-${day}-${hour}-${minute}.txt`, 'text/plain');
             },
             importStringFile(){ 
                 let file = document.getElementById("stringPackFile").files[0];

--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,10 @@ export function mainVue(){
                 };
                 const date = new Date();
                 const year = date.getFullYear();
-                const month = (date.getMonth() + 1);
-                const day = date.getDate();
-                const hour = date.getHours();
-                const minute = date.getMinutes();
+                const month = (date.getMonth() + 1).toFixed(0).padStart(2, '0');
+                const day = date.getDate().toFixed(0).padStart(2, '0');
+                const hour = date.getHours().toFixed(0).padStart(2, '0');
+                const minute = date.getMinutes().toFixed(0).padStart(2, '0');
                 downloadToFile(window.exportGame(), `evolve-${year}-${month}-${day}-${hour}-${minute}.txt`, 'text/plain');
             },
             importStringFile(){ 


### PR DESCRIPTION
I have been periodically taking backups of my game state using the "Save as File" feature in the settings. Today I had cause to use these. I loaded in the last file in the directory where I've been storing these, and was confused to see that this was actually an older game than I remember saving last. Upon review, I had loaded a game from near the end of September, not a week or so ago (November). This was because I went to the last file in the list, when the files were sorted in alphabetic/lexicographical order - that's to say that "evolve-2023-9-..." was sorted after "evolve-2023-11...". I've now worked this out and renamed all the files to have a consistent length to avoid this situation in future.

This pull request changes the format so that numbers less than 10 are padded with a leading zero in the filename suggested by the game. The old format was `evolve-Y-M-D-H-M.txt` the new format is `evolve-YYYY-MM-DD-HH-MM.txt`.

Here's an example filename that the game produced earlier this year: `evolve-2023-8-3-16-8.txt`. This pull request would instead produce this filename for the same date/time: `evolve-2023-08-03-16-08.txt`