### PR TITLE
Convert slaves into a normal resource

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1348,12 +1348,11 @@ export const actions = {
             cost: {
                 Money(){ return 25000; },
             },
-            queue_complete(){ return global.city['slave_pen'] ? global.city.slave_pen.count * 4 - global.city.slave_pen.slaves : 0; },
+            queue_complete(){ return global.city['slave_pen'] ? global.city.slave_pen.count * 4 - global.resource.Slave.amount : 0; },
             action(){
-                if (global.city['slave_pen'] && global.city.slave_pen.count * 4 > global.city.slave_pen.slaves){
+                if (global.city['slave_pen'] && global.city.slave_pen.count * 4 > global.resource.Slave.amount){
                     if (payCosts($(this)[0])){
-                        global.city.slave_pen.slaves++;
-                        global.resource.Slave.amount = global.city.slave_pen.slaves;
+                        global.resource.Slave.amount++;
                         return true;
                     }
                 }
@@ -1714,14 +1713,13 @@ export const actions = {
             },
             effect(){
                 let max = global.city['slave_pen'] ? global.city.slave_pen.count * 4 : 4;
-                let slaves = global.city['slave_pen'] ? global.city.slave_pen.slaves : 0;
+                let slaves = global.city['slave_pen'] ? global.resource.Slave.amount : 0;
                 return `<div>${loc('city_slave_pen_effect',[4])}</div><div>${loc('city_slave_pen_effect2',[slaves,max])}</div>`;
             },
             action(){
                 if (payCosts($(this)[0])){
                     global.city['slave_pen'].count++;
                     global.resource.Slave.display = true;
-                    global.resource.Slave.amount = global.city.slave_pen.slaves;
                     global.resource.Slave.max = global.city.slave_pen.count * 4;
                     return true;
                 }

--- a/src/civics.js
+++ b/src/civics.js
@@ -1776,14 +1776,13 @@ function war_campaign(gov){
 
         if (global.race['slaver'] && global.city['slave_pen']){
             let max = global.city.slave_pen.count * 4;
-            if (max > global.city.slave_pen.slaves){
+            if (max > global.resource.Slave.amount){
                 let slaves = Math.floor(seededRandom(0,global.civic.garrison.tactic + 2,true));
-                if (slaves + global.city.slave_pen.slaves > max){
-                    slaves = max - global.city.slave_pen.slaves;
+                if (slaves + global.resource.Slave.amount > max){
+                    slaves = max - global.resource.Slave.amount;
                 }
                 if (slaves > 0){
-                    global.city.slave_pen.slaves += slaves;
-                    global.resource.Slave.amount = global.city.slave_pen.slaves;
+                    global.resource.Slave.amount += slaves;
                     messageQueue(loc('civics_garrison_capture',[slaves]),'success',false,['combat']);
                 }
             }

--- a/src/events.js
+++ b/src/events.js
@@ -913,9 +913,8 @@ function slaveLoss(type,string){
         },
         type: type,
         effect(){
-            if (global.city['slave_pen'] && global.city.slave_pen.slaves > 0){
-                global.city.slave_pen.slaves--;
-                global.resource.Slave.amount = global.city.slave_pen.slaves;
+            if (global.city['slave_pen'] && global.resource.Slave.amount > 0){
+                global.resource.Slave.amount--;
                 return loc(`event_slave_${string}`);
             }
             else {

--- a/src/governor.js
+++ b/src/governor.js
@@ -1044,7 +1044,7 @@ export const gov_tasks = {
             }
             if ( $(this)[0].req() && global.resource.Money.amount >= slaveCost && (global.resource.Money.diff >= slaveCost || global.resource.Money.amount + global.resource.Money.diff >= cashCap) ){
                 let max = global.city.slave_pen.count * 4;
-                if (max > global.city.slave_pen.slaves){
+                if (max > global.resource.Slave.amount){
                     actions.city.slave_market.action();
                 }
             }

--- a/src/main.js
+++ b/src/main.js
@@ -858,7 +858,7 @@ function fastLoop(){
         global_multiplier *= 1 + (bonus / 100);
     }
     if (global.race['slaver'] && global.city['slave_pen'] && global.city['slave_pen']){
-        let bonus = (global.city.slave_pen.slaves * traits.slaver.vars()[0]);
+        let bonus = (global.resource.Slave.amount * traits.slaver.vars()[0]);
         breakdown.p['Global'][loc('trait_slaver_bd')] = bonus+'%';
         global_multiplier *= 1 + (bonus / 100);
     }
@@ -7875,8 +7875,8 @@ function midLoop(){
             caps['Slave'] = global.city.slave_pen.count * 4;
             bd_Slave[loc('city_slave_pen')] = global.city.slave_pen.count * 4 + 'v';
 
-            if (caps['Slave'] < global.city.slave_pen.slaves){
-                global.city.slave_pen.slaves = caps['Slave'];
+            if (caps['Slave'] < global.resource.Slave.amount){
+                global.resource.Slave.amount = caps['Slave'];
             }
         }
         if (global.race['calm'] && global.city['meditation']) {

--- a/src/races.js
+++ b/src/races.js
@@ -5119,7 +5119,7 @@ export function cleanAddTrait(trait){
         case 'slaver':
             checkPurgatory('tech','slaves');
             if (global.tech['slaves'] >= 1) {
-                checkPurgatory('city','slave_pen',{ count: 0, slaves: 0 });
+                checkPurgatory('city','slave_pen',{ count: 0 });
                 if (global.city['slave_pen'].count > 0 && !global.race['orbit_decayed']) {
                     global.resource.Slave.display = true;
                 }

--- a/src/tech.js
+++ b/src/tech.js
@@ -6847,7 +6847,8 @@ const techs = {
         effect: loc('tech_slave_pens_effect'),
         action(){
             if (payCosts($(this)[0])){
-                global.city['slave_pen'] = { count: 0, slaves: 0 };
+                global.city['slave_pen'] = { count: 0 };
+                global.resource.Slave.amount = 0;
                 return true;
             }
             return false;

--- a/src/vars.js
+++ b/src/vars.js
@@ -1168,6 +1168,13 @@ if (convertVersion(global['version']) < 103002){
     }
 }
 
+if (convertVersion(global['version']) < 103010){
+    if (global.city.hasOwnProperty('slave_pen') && global.city.slave_pen.hasOwnProperty('slaves')){
+        global.resource.Slave.amount = global.city.slave_pen.slaves;
+        delete global.city.slave_pen.slaves;
+    }
+}
+
 global['version'] = '1.3.10';
 delete global['revision'];
 global['beta'] = 3;


### PR DESCRIPTION
Currently, slaves are stored as a count on the slave pen structure, and they are mirrored as a global resource for display purposes. This causes a value mismatch when a tax riot occurs, where slaves appear to be killed but are not. Change all references to the slave pen version of slave count into the global resource version.