### PR TITLE
Fix priority inversion of DNA sequencer and build queues

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11497,7 +11497,9 @@ function longLoop(){
 }
 
 function buildGene(){
-    if (global.resource.Knowledge.amount >= 200000 && global.resource.Knowledge.amount >= global.resource.Knowledge.max - 10000){
+    // Reduce size of Knowledge buffer when daily production is under 10000 to avoid jumping in front of the research queue
+    let buffer = global.resource.Knowledge.diff < 10000 ? global.resource.Knowledge.diff : 10000;
+    if (global.resource.Knowledge.amount >= 200000 && global.resource.Knowledge.amount >= global.resource.Knowledge.max - buffer){
         global.resource.Knowledge.amount -= 200000;
         let gene = global.genes['synthesis'] ? sythMap[global.genes['synthesis']] : 1;
         global.resource.Genes.amount += gene;


### PR DESCRIPTION
The conditions for the DNA sequencer and the build/research queues to consume the Knowledge resource are different. As a result, structs and techs that require Knowledge may never build when automatic sequencing is enabled. Specifically, this may occur when Knowledge production less than 10k per day.

To allow queues to function for structs and techs near the Knowledge cap at that time, set the DNA sequencer buffer size to the lesser of 10,000 and the Knowledge production value.

Fixes issues #322 and #672.