### PR TITLE
Allow all non-Micro universes to improve Evolve Adept perk

### DIFF
--- a/src/achieve.js
+++ b/src/achieve.js
@@ -807,6 +807,18 @@ export function checkAchievements(){
     }
 }
 
+export function checkAdept(){
+    let rank = 0;
+    ['whitehole','eviltwin','canceled','heavy','pw_apocalypse'].forEach(function(x){
+        if (global.stats.achieve[x]){
+            rank = Math.max(global.stats.achieve[x].l, rank);
+        }
+    });
+
+    rank = global.stats.feat['adept'] ? Math.min(rank, global.stats.feat['adept']) : 0;
+    return rank;
+}
+
 function checkBigAchievement(frag, name, num, level){
     if (!global.stats.achieve[name] || global.stats.achieve[name].l < level){
         let total = 0;
@@ -2465,13 +2477,13 @@ export const perkList = {
     adept: {
         name: loc(`perk_adept`),
         desc(wiki){
-            let rank = global.stats.feat['adept'] && global.stats.achieve['whitehole'] && global.stats.achieve.whitehole.l > 0 ? Math.min(global.stats.achieve.whitehole.l,global.stats.feat['adept']) : 1;
+            let rank = checkAdept() || 1;
             let res = wiki ? "100/200/300/400/500" : rank * 100;
             let cap = wiki ? "60/120/180/240/300" : rank * 60;
             return loc("achieve_perks_adept",[res,cap]);
         },
         active(){
-            return global.stats.feat['adept'] && global.stats.achieve['whitehole'] && global.stats.achieve.whitehole.l > 0 ? true : false;
+            return checkAdept() > 0;
         },
         notes: [
             loc(`wiki_perks_progress_note1`,[50,loc(`wiki_resets_blackhole`)]),

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,7 @@
 import { global, save, seededRandom, webWorker, keyMultiplier, keyMap, srSpeak, sizeApproximation, p_on, support_on, gal_on, quantum_level, tmp_vars, setupStats } from './vars.js';
 import { loc } from './locale.js';
 import { timeCheck, timeFormat, vBind, popover, clearPopper, flib, tagEvent, clearElement, costMultiplier, darkEffect, genCivName, powerModifier, powerCostMod, calcPrestige, adjustCosts, modRes, messageQueue, buildQueue, format_emblem, shrineBonusActive, calc_mastery, calcPillar, calcGenomeScore, getShrineBonus, eventActive, easterEgg, getHalloween, trickOrTreat, deepClone, hoovedRename } from './functions.js';
-import { unlockAchieve, challengeIcon, alevel, universeAffix } from './achieve.js';
+import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from './achieve.js';
 import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck } from './races.js';
 import { defineResources, galacticTrade, spatialReasoning, resource_values, initResourceTabs, drawResourceTab, marketItem, containerItem, tradeSummery } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
@@ -7662,8 +7662,8 @@ function sentience(){
         'challenge': alevel() - 1
     });
 
-    if (global.stats.feat['adept'] && global.stats.achieve['whitehole'] && global.stats.achieve.whitehole.l > 0){
-        let rank = Math.min(global.stats.achieve.whitehole.l,global.stats.feat['adept']);
+    if (global.stats.feat['adept']){
+        let rank = checkAdept();
         global.resource.Food.amount += rank * 100;
         global.resource.Stone.max += rank * 60;
         global.resource.Stone.amount += rank * 100;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level } from './vars.js';
 import { loc } from './locale.js';
-import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat } from './achieve.js';
+import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat, checkAdept } from './achieve.js';
 import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone } from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
@@ -7470,8 +7470,8 @@ function midLoop(){
             caps['Elerium'] += 999;
         }
 
-        if (global.stats.feat['adept'] && global.stats.achieve['whitehole'] && global.stats.achieve.whitehole.l > 0){
-            let rank = Math.min(global.stats.achieve.whitehole.l,global.stats.feat['adept']);
+        if (global.stats.feat['adept']){
+            let rank = checkAdept();
             caps['Lumber'] += rank * 60;
             caps['Stone'] += rank * 60;
         }


### PR DESCRIPTION
The Evolve Novice through Grandmaster feats all depend on the achievement level of some number of achievements, as well as the highest completed challenge level of the matching reset tier. Unlike all of the other reset tiers, Black Hole / Vacuum Collapse resets have unique achievements for each universe, so the White Hole achievement level in the Standard universe cannot increase as a result of resets in non-Standard, non-Micro universes.

Change the perk effect of Evolve Adept to consider the black hole / vacuum collapse achievements from the Evil, Antimatter, Heavy, and Magic universes on equal standing to White Hole. Micro is excluded.