### PR TITLE
Adding accelerated time for time the system was suspended/hibernated, two bugfixes of accelerated time

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -173,10 +173,12 @@ export function gameLoop(act){
     }
 }
 
-export function calcATime(){
+// Adds accelerated time if enough time has passed since `global.stats.current`. Returns true if there was accelerated
+// time added. If the parameter is true, it will only add the time if a threshold of 120s has been reached.
+export function calcATime(onlyIfSufficientTimeDiff){
     let dt = Date.now();
     let timeDiff = dt - global.stats.current;
-    if (global.stats.hasOwnProperty('current') && (timeDiff >= 120000 || global.settings.at > 0)){
+    if (global.stats.hasOwnProperty('current') && (timeDiff >= 120000 || !onlyIfSufficientTimeDiff && global.settings.at > 0)){
         if (global.settings.at > 11520){
             global.settings.at = 0;
         }
@@ -187,6 +189,9 @@ export function calcATime(){
             global.settings.at = 11520;
         }
         atrack.t = global.settings.at;
+        return true;
+    } else {
+        return false;
     }
 }
 

--- a/src/functions.js
+++ b/src/functions.js
@@ -126,46 +126,28 @@ export function gameLoop(act){
             break;
         case 'start':
             {
-                let main_timer = 250;
-                let mid_timer = 1000;
-                let long_timer = 5000;
-                if (global.race['slow']){
-                    let slow = 1 + (traits.slow.vars()[0] / 100);
-                    main_timer = Math.floor(main_timer * slow);
-                    mid_timer = Math.floor(mid_timer * slow);
-                    long_timer = Math.floor(long_timer * slow);
-                }
-                if (global.race['hyper']){
-                    let fast = 1 - (traits.hyper.vars()[0] / 100);
-                    main_timer = Math.floor(main_timer * fast);
-                    mid_timer = Math.floor(mid_timer * fast);
-                    long_timer = Math.floor(long_timer * fast);
-                }
-                webWorker.mt = main_timer;
-
                 addATime(Date.now());
 
-                if (atrack.t > 0){
-                    main_timer = Math.ceil(main_timer * 0.5);
-                    mid_timer = Math.ceil(mid_timer * 0.5);
-                    long_timer = Math.ceil(long_timer * 0.5);
-                }
+                const timers = loopTimers();
+
+                // Used to calculate resource increase.
+                webWorker.mt = timers.webWorkerMainTimer;
 
                 if (webWorker.w){
-                    webWorker.w.postMessage({ loop: 'short', period: main_timer });
-                    webWorker.w.postMessage({ loop: 'mid', period: mid_timer });
-                    webWorker.w.postMessage({ loop: 'long', period: long_timer });
+                    webWorker.w.postMessage({ loop: 'short', period: timers.mainTimer });
+                    webWorker.w.postMessage({ loop: 'mid', period: timers.midTimer });
+                    webWorker.w.postMessage({ loop: 'long', period: timers.longTimer });
                 }
                 else {
                     intervals['main_loop'] = setInterval(function(){
                         fastLoop();
-                    }, main_timer);
+                    }, timers.mainTimer);
                     intervals['mid_loop'] = setInterval(function(){
                         midLoop();
-                    }, mid_timer);
+                    }, timers.midTimer);
                     intervals['long_loop'] = setInterval(function(){
                         longLoop();
-                    }, long_timer);
+                    }, timers.longTimer);
                 }
 
                 webWorker.s = true;
@@ -173,19 +155,56 @@ export function gameLoop(act){
     }
 }
 
+// Computes the relative to default duration of a single loop (common for all three loop types).
+// Note that these values are not tied to the time_multiplier from fastLoop - the relative speed of time in the game
+// is controlled by loop lengths.
+function loopTimers(){
+    // Here come any speed modifiers not related to accelerated time.
+    let modifier = 1.0;
+    if (global.race['slow']){
+        modifier *= 1 + (traits.slow.vars()[0] / 100);
+    }
+    if (global.race['hyper']){
+        modifier *= 1 - (traits.hyper.vars()[0] / 100);
+    }
+
+    // Main loop takes 250ms without any modifiers.
+    const webWorkerMainTimer = Math.floor(250 * modifier);
+    // Mid loop takes 1000ms without any modifiers.
+    const baseMidTimer = 4 * webWorkerMainTimer;
+    // Long loop (game day) takes 5000ms without any modifiers.
+    const baseLongTimer = 20 * webWorkerMainTimer;
+    // The constant by which the time is accelerated when atrack.t > 0.
+    const timeAccelerationFactor = 2;
+
+    const aTimeMultiplier = atrack.t > 0 ? 1 / timeAccelerationFactor : 1;
+    return {
+        webWorkerMainTimer,
+        mainTimer: Math.ceil(webWorkerMainTimer * aTimeMultiplier),
+        midTimer: Math.ceil(baseMidTimer * aTimeMultiplier),
+        longTimer: Math.ceil(baseLongTimer * aTimeMultiplier),
+        baseLongTimer,
+        timeAccelerationFactor,
+    };
+}
+
 // Adds accelerated time if enough time has passed since `global.stats.current`. Returns true if there was accelerated
 // time added. If the parameter is true, it will only add the time if a threshold of 120s has been reached.
-export function addATime(date){
+export function addATime(currentTimestamp){
     // The second case is used for the initialization of atrack.t.
-    if (exceededATimeThreshold(date) || global.stats.hasOwnProperty('current') && global.settings.at > 0){
-        let timeDiff = date - global.stats.current;
+    if (exceededATimeThreshold(currentTimestamp) || global.stats.hasOwnProperty('current') && global.settings.at > 0){
+        let timeDiff = currentTimestamp - global.stats.current;
         // Removing any accelerated time if the value is larger than the cap.
         if (global.settings.at > 11520){
             global.settings.at = 0;
         }
         // Accelerated time is added only if it is over the threshold.
         if (timeDiff >= 120000){
-            global.settings.at += Math.floor(timeDiff / 3333);
+            const timers = loopTimers();
+            const gameDayDuration = timers.baseLongTimer;
+            // The number of days during which the time is accelerated (at) should take as long as 2 / 3 of paused time.
+            // at * gameDayDuration / timeAccelerationFactor = 2 / 3 * timeDiff
+            global.settings.at += Math.floor(2 / 3 * timeDiff * timers.timeAccelerationFactor / gameDayDuration);
         }
         // Accelerated time is capped at 8*60*60/2.5 game days.
         if (global.settings.at > 11520){
@@ -193,13 +212,13 @@ export function addATime(date){
         }
         atrack.t = global.settings.at;
         // Updating the current date so that it won't be counted twice (e.g., when unpausing).
-        global.stats.current = date;
+        global.stats.current = currentTimestamp;
     }
 }
 
 // Takes the current Date.now, returns whether the minimum threshold to count accelerated time has passed.
-export function exceededATimeThreshold(date){
-    return global.stats.hasOwnProperty('current') && date - global.stats.current >= 120000;
+export function exceededATimeThreshold(currentTimestamp){
+    return global.stats.hasOwnProperty('current') && currentTimestamp - global.stats.current >= 120000;
 }
 
 window.exportGame = function exportGame(){

--- a/src/functions.js
+++ b/src/functions.js
@@ -173,7 +173,7 @@ export function gameLoop(act){
     }
 }
 
-function calcATime(){
+export function calcATime(){
     let dt = Date.now();
     let timeDiff = dt - global.stats.current;
     if (global.stats.hasOwnProperty('current') && (timeDiff >= 120000 || global.settings.at > 0)){

--- a/src/functions.js
+++ b/src/functions.js
@@ -158,7 +158,7 @@ export function gameLoop(act){
 // Computes the relative to default duration of a single loop (common for all three loop types).
 // Note that these values are not tied to the time_multiplier from fastLoop - the relative speed of time in the game
 // is controlled by loop lengths.
-function loopTimers(){
+export function loopTimers(){
     // Here come any speed modifiers not related to accelerated time.
     let modifier = 1.0;
     if (global.race['slow']){

--- a/src/main.js
+++ b/src/main.js
@@ -11468,8 +11468,14 @@ function longLoop(){
 
     // Checking if a substantial amount of time elapsed since last longLoop, indicating system suspension,
     // hibernation or something similar (the threshold is 120s and is checked within calcATime).
-    // If a substantial amount of time elapsed, accelerated time is appropriately increased.
-    calcATime();
+    if (calcATime(true)){
+        // If a substantial amount of time elapsed, accelerated time is appropriately increased in `calcATime`.
+        // We then restart the loop to update the refresh rate, unless paused.
+        if (!global.settings.pause){
+            gameLoop('stop');
+            gameLoop('start');
+        }
+    }
 
     // Save game state
     global.stats['current'] = Date.now();

--- a/src/main.js
+++ b/src/main.js
@@ -11495,18 +11495,19 @@ function longLoop(){
         drawAchieve();
     }
 
+    const currentTimestamp = date.valueOf();
     // Checking if a substantial amount of time elapsed since last longLoop, indicating system suspension,
     // hibernation or something similar (the threshold is the same as for counting accelerated time during pause).
     let restartNeeded = false;
-    if (!global.settings.pause && exceededATimeThreshold(date)){
-        // Adding accelerated time based on last current time which is updated in longLoop below.
-        addATime(date);
+    if (!global.settings.pause && exceededATimeThreshold(currentTimestamp)){
+        // Adding accelerated time based on last current time which is updated below.
+        addATime(currentTimestamp);
         // The restart is needed to update the duration of the loop interval.
         restartNeeded = true;
     }
 
     // Save game state
-    global.stats['current'] = date;
+    global.stats['current'] = currentTimestamp;
     if (!global.race.hasOwnProperty('geck')){
         save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level } from './vars.js';
 import { loc } from './locale.js';
 import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat } from './achieve.js';
-import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone } from './functions.js';
+import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, calcATime } from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, loadServants} from './jobs.js';
@@ -11465,6 +11465,11 @@ function longLoop(){
         $(`body`).removeClass('fool');
         drawAchieve();
     }
+
+    // Checking if a substantial amount of time elapsed since last longLoop, indicating system suspension,
+    // hibernation or something similar (the threshold is 120s and is checked within calcATime).
+    // If a substantial amount of time elapsed, accelerated time is appropriately increased.
+    calcATime();
 
     // Save game state
     global.stats['current'] = Date.now();

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,36 @@
 import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level } from './vars.js';
 import { loc } from './locale.js';
 import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat } from './achieve.js';
-import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, calcATime } from './functions.js';
+import {
+    gameLoop,
+    vBind,
+    popover,
+    clearPopper,
+    flib,
+    tagEvent,
+    timeCheck,
+    arpaTimeCheck,
+    timeFormat,
+    powerModifier,
+    modRes,
+    initMessageQueue,
+    messageQueue,
+    calc_mastery,
+    calcPillar,
+    darkEffect,
+    calcQueueMax,
+    calcRQueueMax,
+    buildQueue,
+    shrineBonusActive,
+    getShrineBonus,
+    eventActive,
+    easterEggBind,
+    trickOrTreatBind,
+    powerGrid,
+    deepClone,
+    addATime,
+    exceededATimeThreshold
+} from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, loadServants} from './jobs.js';
@@ -11467,18 +11496,17 @@ function longLoop(){
     }
 
     // Checking if a substantial amount of time elapsed since last longLoop, indicating system suspension,
-    // hibernation or something similar (the threshold is 120s and is checked within calcATime).
-    if (calcATime(true)){
-        // If a substantial amount of time elapsed, accelerated time is appropriately increased in `calcATime`.
-        // We then restart the loop to update the refresh rate, unless paused.
-        if (!global.settings.pause){
-            gameLoop('stop');
-            gameLoop('start');
-        }
+    // hibernation or something similar (the threshold is the same as for counting accelerated time during pause).
+    let restartNeeded = false;
+    if (!global.settings.pause && exceededATimeThreshold(date)){
+        // Adding accelerated time based on last current time which is updated in longLoop below.
+        addATime(date);
+        // The restart is needed to update the duration of the loop interval.
+        restartNeeded = true;
     }
 
     // Save game state
-    global.stats['current'] = Date.now();
+    global.stats['current'] = date;
     if (!global.race.hasOwnProperty('geck')){
         save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
     }
@@ -11496,14 +11524,19 @@ function longLoop(){
     if (global.settings.pause && webWorker.s){
         gameLoop('stop');
     }
+
     if (atrack.t > 0){
         atrack.t--;
         global.settings.at--;
         if (global.settings.at <= 0 || atrack.t <= 0){
             global.settings.at = 0;
-            gameLoop('stop');
-            gameLoop('start');
+            restartNeeded = true;
         }
+    }
+
+    if (restartNeeded){
+        gameLoop('stop');
+        gameLoop('start');
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,8 @@ import {
     powerGrid,
     deepClone,
     addATime,
-    exceededATimeThreshold
+    exceededATimeThreshold,
+    loopTimers
 } from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
@@ -520,7 +521,7 @@ vBind({
             return universe === 'standard' || universe === 'bigbang' ? '' : universe_types[universe].name;
         },
         remain(at){
-            let minutes = Math.ceil(at * 2.5 / 60);
+            let minutes = Math.ceil(at * loopTimers().longTimer / 60000);
             if (minutes > 0){
                 let hours = Math.floor(minutes / 60);
                 minutes -= hours * 60;

--- a/src/main.js
+++ b/src/main.js
@@ -1,37 +1,7 @@
 import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level } from './vars.js';
 import { loc } from './locale.js';
 import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat } from './achieve.js';
-import {
-    gameLoop,
-    vBind,
-    popover,
-    clearPopper,
-    flib,
-    tagEvent,
-    timeCheck,
-    arpaTimeCheck,
-    timeFormat,
-    powerModifier,
-    modRes,
-    initMessageQueue,
-    messageQueue,
-    calc_mastery,
-    calcPillar,
-    darkEffect,
-    calcQueueMax,
-    calcRQueueMax,
-    buildQueue,
-    shrineBonusActive,
-    getShrineBonus,
-    eventActive,
-    easterEggBind,
-    trickOrTreatBind,
-    powerGrid,
-    deepClone,
-    addATime,
-    exceededATimeThreshold,
-    loopTimers
-} from './functions.js';
+import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, addATime, exceededATimeThreshold, loopTimers } from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, loadServants} from './jobs.js';


### PR DESCRIPTION
Added `calcATime()` in the longLoop so that accelerated time is added wheneever the loop took longer than the threshold from `calcATime` (currently 120s), indicating that there was system suspension, hibernation or something similar that made the game essentially pause. Before, the accelerated time was not given for that time. This fixes #972. It was tested with system hibernation.