### PR TITLE
Capitalize tab name

### DIFF
--- a/strings/strings.json
+++ b/strings/strings.json
@@ -6115,7 +6115,7 @@
   "interstellar_mass_ejector": "Mass Ejector",
   "interstellar_mass_ejector_effect": "Eject mass into the black hole to enlarge it",
   "interstellar_mass_ejector_flair": "This is a good idea, this is fine",
-  "interstellar_mass_ejector_msg": "A new tab is available under \"resources\"",
+  "interstellar_mass_ejector_msg": "A new tab is available under \"Resources\"",
   "interstellar_mass_ejector_active": "%0 Active",
   "interstellar_mass_ejector_per": "Mass per unit",
   "interstellar_mass_ejector_vol": "Volume Ejecting",


### PR DESCRIPTION
Possible missing capitalization also present in PL and ES translations.