### PR TITLE
Fix breakdown for cultural centers during Aquarius

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6863,7 +6863,7 @@ function fastLoop(){
             breakdown.p['Money'][loc('tech_cultural_center')] = Math.round(revenue) + 'v';
             if (astroSign === 'aquarius'){
                 revenue *= 1 + (astroVal('aquarius')[0] / 100);
-                revenue[`ᄂ${loc('sign_aquarius')}`] = astroVal('aquarius')[0] + '%';
+                breakdown.p['Money'][`ᄂ${loc('sign_aquarius')}`] = astroVal('aquarius')[0] + '%';
             }
             modRes('Money', +(revenue * time_multiplier * global_multiplier * hunger).toFixed(2));
             rawCash += revenue * global_multiplier * hunger;


### PR DESCRIPTION
A bug introduced in f10954c10... will break resource display when any Cultural Center structs have been built in Tau Ceti, only while the Zodiac sign is Aquarius. The commit fixes the assignment LHS for the breakdown text of the Aquarius bonus.

The behavior of Tourist Centers is already correct and does not need to be fixed.

Uncaught TypeError: Cannot create property 'ᄂAquarius' on number '420'