### PR TITLE
Fix incorrect display of additions for Aquarius sign

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6981,7 +6981,7 @@ function fastLoop(){
             rawCash += cash * global_multiplier * hunger;
         }
 
-        if (global.city['tourist_center']){
+        if (global.city['tourist_center'] && global.city['tourist_center'].on){
             let tourism = 0;
             let amp = global.tech['monument'] && global.tech.monument >= 3 && p_on['s_gate'] ? 3 : 1;
             if (global.city['amphitheatre']){


### PR DESCRIPTION
fix a problem after #1034 and #1035.
In Tauceti, reasearching Isolation Protocol or running in the mode Lone Survivor will cause closing all tourist centers and losing income, with `global.city['tourist_center']` is not an empty object. It would causes the income impact from Aquarius sign incorrect display below income Taxes or Casino. Adding `global.city['tourist_center'].on` as a condition could fix the problem.
