### PR TITLE
Fix a variety of issues related to the Gravity Well challenge

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3945,12 +3945,15 @@ export const actions = {
                 return `<div>${label}</div><div class="has-text-special">${loc('star_dock_genesis_effect2',[gains.plasmid,plasmidType])}</div><div class="has-text-special">${loc('star_dock_genesis_effect3',[gains.phage])}</div>`;
             },
             action(){
-                global.tech['genesis'] = 7;
-                clearPopper(`starDock-prep_ship`);
-                clearElement($('#modalBox'));
-                let c_action = actions.space.spc_gas.star_dock;
-                drawModal(c_action,'star_dock');
-                return true;
+                if (payCosts($(this)[0])) {
+                    global.tech['genesis'] = 7;
+                    clearPopper(`starDock-prep_ship`);
+                    clearElement($('#modalBox'));
+                    let c_action = actions.space.spc_gas.star_dock;
+                    drawModal(c_action,'star_dock');
+                    return true;
+                }
+                return false;
             },
         },
         launch_ship: {

--- a/src/civics.js
+++ b/src/civics.js
@@ -1981,7 +1981,7 @@ function lootModify(val,gov){
         loot *= darkEffect('evil');
     }
     if (global.race['gravity_well']){
-        loot *= 0.25 + (0.75 * darkEffect('heavy'));
+        loot *= 1 - (0.75 * darkEffect('heavy'));
     }
 
     switch(global.civic.garrison.tactic){

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -3880,7 +3880,7 @@ a {
 }
 
 .modal .action {
-    .main .content .action();
+    &:extend(.main .content .action all);
 }
 
 .modal .actionSpace {

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -37,7 +37,8 @@ const universeExclusives = {
     pass: ['magic'],
     fullmetal: ['magic'],
     soul_sponge: ['magic'],
-    nightmare: ['magic']
+    nightmare: ['magic'],
+    escape_velocity: ['heavy']
 };
 
 const achieveDescData = {

--- a/src/wiki/challenges.js
+++ b/src/wiki/challenges.js
@@ -402,13 +402,13 @@ export function challengesPage(content){
         }
 
         {   // Gravity Well
-            let witch = infoBoxBuilder(modes,{ name: 'modes_gravity_well', template: 'challenges', paragraphs: 6, break: [4], h_level: 2,
+            let gravity = infoBoxBuilder(modes,{ name: 'modes_gravity_well', template: 'challenges', paragraphs: 6, break: [4], h_level: 2,
                 para_data: {
                     1: [loc(`evo_challenge_gravity_well`)],
                 }
             });
-            addAchievements(witch,false,['escape_velocity']);
-            addRequirements(witch,[
+            addAchievements(gravity,false,['escape_velocity']);
+            addRequirements(gravity,[
                 {
                     text: `wiki_challenges_reqs_reset`,
                     subreqs: [


### PR DESCRIPTION
Four changes are included:

1. The achievement "Escape Velocity" should appear as Heavy Gravity exclusive in the achievements page of the wiki.
2. The action "Prep Ship" now has a cost, so it should charge the cost before granting its effects.
3. The challenge "Gravity Well" has a reduced combat loot effect, but the scaling is currently from no penalty at 0 Dark Energy to 75% penalty at infinite DE. Change the scaling to the reverse direction: 75% penalty at 0 DE and no penalty at infinite DE.
4. Fix CSS property inheritance for action buttons in modals. This means that, for example, buttons will darken when no resources are available, and the text will turn red if not enough storage is available.