### PR TITLE
Attempted fix for pet event string issues

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -866,14 +866,14 @@ export const events = {
         effect(){
             if (global.race['pet']){
                 let interaction = Math.rand(0,10);
-                return loc(`event_${global.race.pet.type}_interaction${interaction}`,[global.race.pet.name]);
+                return loc(`event_${global.race.pet.type}_interaction${interaction}`,[loc(`event_${global.race.pet.type}_name${global.race.pet.name}`)]);
             }
             else {
                 global.race['pet'] = {
                     type: Math.rand(0,2) === 0 ? 'cat' : 'dog',
                     name: Math.rand(0,10)
                 };
-                return loc(`event_pet_${global.race.pet.type}`,[loc(`event_cat_name${global.race.pet.name}`)]);
+                return loc(`event_pet_${global.race.pet.type}`,[loc(`event_${global.race.pet.type}_name${global.race.pet.name}`)]);
             }
         }
     },


### PR DESCRIPTION
Currrently when you get the new pet minor event chain, the initial "you found the pet" event displays a cat name for it even if the pet is a dog, and follow-up "your pet did a pet thing" events display your pet's name as the numerical value of the naming variable instead of with an actual name string (screenshot evidence attached, from reddit posts by users NPCnoName1213 and digibo). Hopefully this fixes both; lmk if there are any errors in the code since I'm admittedly not 100% familiar with the structure here >_>
<img width="646" alt="Screen Shot 2024-01-31 at 6 50 50 AM" src="https://github.com/pmotschmann/Evolve/assets/106144712/a383abbf-d45c-45fa-b27e-bd6f1318c2b7">
![o0RGgF8](https://github.com/pmotschmann/Evolve/assets/106144712/ecfb6dbd-15ee-4fe0-9144-62a527746735)
