### PR TITLE
Automatically compile and update static assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,0 +1,34 @@
+name: Build static assets
+
+on:
+  push:
+
+jobs:
+  build-assets:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the changed files back to the repository.
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - run: npm run build
+    - run: npm run less
+    - run: npm run wiki
+    - run: npm run wiki-less
+
+    - uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: Update compiled assets


### PR DESCRIPTION
Ideally compiled assets aren't checked into the repository, and are only ever used / needed on the production instance / website. Meanwhile, I've seen at least a few instances where the compiled assets aren't updated when the corresponding source files are changed. This pull request automates this step. If the assets are already up-to-date, then nothing will happen. If the assets are outdated, this workflow will add a new commit to the branch updating the assets.

This doesn't solve the merge conflict issue with having compiled assets committed to the repository, but it does lighten the burden on new contributors of keeping the assets updated. It should also avoid the problem which we have in adcc3c2441ab0932af16e989053d246fd5cf6daa where a merge conflict was accidentally committed. Luckily the resultant file is still parsed and valid CSS is extracted, so the website isn't completely broken in this instance.

https://github.com/pmotschmann/Evolve/blob/fe8740e4c0f6d4a14c8563b52a7c7b2dddb600f7/evolve/evolve.css#L1