### PR TITLE
Hunting Lodge requirements cleanup (to fix Soul Eater issue)

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -930,8 +930,7 @@ const techs = {
         reqs: { housing: 1, currency: 1 },
         grant: ['s_lodge',1],
         condition(){
-            return (((global.race.species === 'wendigo' || global.race['detritivore']) && !global.race['carnivore'] && !global.race['herbivore'])
-              || (global.race['carnivore'] && global.race['soul_eater']) || global.race['artifical'] || global.race['unfathomable']) ? true : false;
+            return (global.race['carnivore'] || global.race['detritivore'] || global.race['artifical'] || global.race['soul_eater'] || global.race['unfathomable']) ? true : false;
         },
         cost: {
             Knowledge(){ return global.race['artifical'] ? 10000 : 180; }


### PR DESCRIPTION
Compared to the rest of the non-agricultural-eaters' alt tech tree, Hunting Lodge/alt_lodge has a much more convoluted set of condition requirements, with the unfortunate side effect that non-Wendigo soul eaters (i.e., Demonic species and Mimics thereof) aren't accounted for properly in it and thus are locked out of the secondary small housing entirely (causing issues such as #1063 ). This replaces said spaghetti conditions with a more straightforward set taken from one of the other techs in the chain (Wind Plant) to hopefully give those poor demons their houses back.