### PR TITLE
Add missing save file upgrade logic

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -1393,7 +1393,7 @@ if (!global.settings['showAchieve']){
     global.settings['showAchieve'] = false;
 }
 if (!global.settings['locale']){
-    global.settings['locale'] = 'en-us';
+    global.settings['locale'] = 'en-US';
 }
 if (typeof global.settings.pause === 'undefined'){
     global.settings['pause'] = false;

--- a/src/vars.js
+++ b/src/vars.js
@@ -201,6 +201,12 @@ if (convertVersion(global['version']) < 4003 && global.stats['achieve']){
     });
 }
 
+if (convertVersion(global['version']) < 4010){
+    if (global.stats['achieve'] && global.stats.achieve['doomed']){
+        global.stats['portals'] = 1;
+    }
+}
+
 if (convertVersion(global['version']) < 4028 && global.stats['achieve'] && global.stats.achieve['genus_demonic']){
     global.stats.achieve['biome_hellscape'] = global.stats.achieve['genus_demonic'];
 }
@@ -456,6 +462,12 @@ if (convertVersion(global['version']) < 8003){
 if (convertVersion(global['version']) < 8017){
     if (global.city['garrison']){
         global.city.garrison['on'] = global.city['garrison'].count;
+    }
+}
+
+if (convertVersion(global['version']) < 9000){
+    if (global.settings && global.settings.showCity){
+        global.settings.showCiv = global.settings.showCity;
     }
 }
 


### PR DESCRIPTION
Commit https://github.com/pmotschmann/Evolve/commit/28b4e46200b0a4ccc87558194ee3e8ee9c59533a in version 1.3.0 beta 8 simplified the initialization routines
for various structures to use loops. These loops set all values to 0 or
false. However, custom save upgrade logic existed for two values, and
this logic was lost in the transition.

1. In 0.9.0, the showCiv property was created. It was seeded with
   the value of showCity for old saves. Currently, loading a save from
   prior to 0.9.0 will unconditionally set showCiv to false, so post-
   sentience saves will fail to show the main tab and cannot naturally
   recover without a soft reset, a prestige reset, or save file editing.

2. In approximately 0.4.9 / 0.4.10, the counter for demonic invasions
   was created. Older save files that have the Doomed achievement
   initialized this counter to 1, so restore this logic as well.

Separately, the default locale is currently 'en-US', but this was only partially updated in https://github.com/pmotschmann/Evolve/commit/b7e7a9c086c4c1328de5f4c917f2313d50b66ed2.
Save files currently attempt to set the default locale to 'en-us', which
causes the locale selection box not to show any option as selected.
This commit changes the default locale for upgrades to 'en-US'.


I tested the effects of the first and third changes with another user's save file,
attached. The Civilization tab appears, but it has to be manually selected,
which may be acceptable, as this most likely matches the previous behavior.
I did not specifically test the change associated with the demonic invasion counter.

[Evolve_Save_-_2019-05-24.txt](https://github.com/pmotschmann/Evolve/files/14298881/Evolve_Save_-_2019-05-24.txt)
