### PR TITLE
Prevent exploits to assign too many crafters on Scarletite and Quantium

### DIFF
--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,4 +1,4 @@
-import { global, keyMultiplier, p_on, support_on } from './vars.js';
+import { global, keyMultiplier, p_on, support_on, tmp_vars } from './vars.js';
 import { vBind, clearElement, popover, darkEffect, eventActive, easterEgg } from './functions.js';
 import { loc } from './locale.js';
 import { racialTrait, servantTrait, races, traits, biomes, planetTraits, fathomCheck } from './races.js';
@@ -689,16 +689,28 @@ export function craftsmanCap(res){
 }
 
 export function limitCraftsmen(res){
-    if (global.city.foundry[res]){
-        let cap = craftsmanCap(res);
-        if (cap < global.city.foundry[res]){
-            let diff = global.city.foundry[res] - cap;
-            global.civic.craftsman.workers -= diff;
-            global.city.foundry.crafting -= diff;
-            global.city.foundry[res] -= diff;
+    // Remember previous crafter limits and refresh UI later on if they change
+    if (!tmp_vars.hasOwnProperty('craftsman_cap')){
+        tmp_vars.craftsman_cap = {};
+    }
 
-            loadFoundry();
-        }
+    let cap = craftsmanCap(res);
+    let refresh = false;
+    if (cap < global.city.foundry[res]){
+        let diff = global.city.foundry[res] - cap;
+        global.civic.craftsman.workers -= diff;
+        global.city.foundry.crafting -= diff;
+        global.city.foundry[res] -= diff;
+        refresh = true;
+    }
+    else if (tmp_vars['craftsman_cap'].hasOwnProperty(res) && cap != tmp_vars['craftsman_cap'][res]){
+        refresh = true;
+    }
+    tmp_vars['craftsman_cap'][res] = cap;
+
+    // Refresh UI when the cap changes due to power balancing
+    if (refresh){
+        loadFoundry();
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, c
 import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, addATime, exceededATimeThreshold, loopTimers } from './functions.js';
 import { races, traits, racialTrait, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
-import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, loadServants} from './jobs.js';
+import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
 import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement } from './actions.js';
@@ -9243,6 +9243,11 @@ function midLoop(){
             if (global.civic[job].max === -1 && global.civic[job].display && job !== 'unemployed' && job !== 'scavenger'){
                 not_scavanger_jobs_avail++;
             }
+        });
+
+        // Limit craftsmen for resources that require specific structs. Combined craftsman worker limits are done below.
+        ['Scarletite','Quantium'].forEach(function (res){
+            limitCraftsmen(res);
         });
 
         Object.keys(lCaps).forEach(function (job){

--- a/src/portal.js
+++ b/src/portal.js
@@ -3,7 +3,7 @@ import { vBind, clearElement, popover, clearPopper, timeFormat, powerCostMod, sp
 import { unlockAchieve, alevel, universeAffix } from './achieve.js';
 import { traits, races, fathomCheck } from './races.js';
 import { defineResources, spatialReasoning } from './resources.js';
-import { loadFoundry, jobScale } from './jobs.js';
+import { loadFoundry, jobScale, limitCraftsmen } from './jobs.js';
 import { armyRating, govCivics, garrisonSize } from './civics.js';
 import { payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, updateDesc } from './actions.js';
 import { checkRequirements, incrementStruct, astrialProjection, ascendLab } from './space.js';
@@ -746,15 +746,7 @@ const fortressModules = {
                 loadFoundry();
             },
             postPower(on){
-                if (!on){
-                    if (global.portal.hell_forge.on < global.city.foundry.Scarletite){
-                        let diff = global.city.foundry.Scarletite - global.portal.hell_forge.on;
-                        global.civic.craftsman.workers -= diff;
-                        global.city.foundry.crafting -= diff;
-                        global.city.foundry.Scarletite -= diff;
-                    }
-                }
-                loadFoundry();
+                limitCraftsmen('Scarletite');
             }
         },
         inferno_power: {

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -3,7 +3,7 @@ import { vBind, clearElement, popover, clearPopper, messageQueue, powerCostMod, 
 import { races, traits } from './races.js';
 import { spatialReasoning } from './resources.js';
 import { armyRating, garrisonSize } from './civics.js';
-import { jobScale, job_desc, loadFoundry } from './jobs.js';
+import { jobScale, job_desc, loadFoundry, limitCraftsmen } from './jobs.js';
 import { production, highPopAdjust } from './prod.js';
 import { actions, payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, buildTemplate, casinoEffect, housingLabel } from './actions.js';
 import { fuel_adjust, int_fuel_adjust, spaceTech, renderSpace, checkRequirements, planetName } from './space.js';
@@ -717,6 +717,12 @@ const outerTruth = {
                     return true;
                 }
                 return false;
+            },
+            post(){
+                loadFoundry();
+            },
+            postPower(on){
+                limitCraftsmen('Quantium');
             }
         },
         operating_base: {
@@ -2224,6 +2230,10 @@ const tauCetiModules = {
                     messageQueue(loc('tau_plague4',[loc('tab_tauceti')]),'info',false,['progress']);
                     drawTech();
                 }
+                loadFoundry();
+            },
+            postPower(on){
+                limitCraftsmen('Quantium');
             }
         },
         tauceti_casino: {


### PR DESCRIPTION
The resources Scarletite and Quantium have limited craftsman slots, unlike other crafted resources. There are various loopholes that allow too many crafters to produce these resources. This commit plugs the holes. In addition, it fixes some UI errors where the panel to assign craftsmen did not refresh with the correct limits.

Scarletite
1. Infernal forge checks power on request status but not whether the forges are actually powered (for craftsman cap only; smelting is correct)
2. Infernal forge immediately removes crafters when manually powered off, but if the game is paused, then they can be reassigned again before the limit is decreased

Quantium
1. Manually powering down buildings does not remove crafters and does not refresh the UI
2. Loss of power or support does not remove crafters and does not refresh the UI

This change adds a routine check for available crafter slots to midLoop. It's performed immediately prior to the usual check to remove excess worker population from unavailable jobs. Also, manually powering on or off the zero gravity lab or infectious disease lab will update the UI and remove excess craftsmen.

I tested the changes to the zero gravity lab and the infernal forge. I didn't test the infectious disease lab on account of not having a post-isolation save file.

First save file: false path, can check Scarletite
[evolve-2024-02-10-19-59.txt](https://github.com/pmotschmann/Evolve/files/14301612/evolve-2024-02-10-19-59.txt)

Second save file: other user's true path, can check Zero Gravity Labs
[quantium crafters.txt](https://github.com/pmotschmann/Evolve/files/14301609/quantium.crafters.txt)