### PR TITLE
unlocking Wagons for Demonic races, take 2 (non-lodge edition)

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -161,7 +161,7 @@ const techs = {
         era: 'civilized',
         reqs: { transport: 1 },
         condition(){
-            return global.tech['farm'] || global.tech['s_lodge'] || (global.tech['hunting'] && global.tech.hunting >= 2) ? true : false;
+            return global.tech['farm'] || global.tech['s_lodge'] || (global.tech['hunting'] && global.tech.hunting >= 2) || (global.race['soul_eater'] && !global.race.species === 'wendigo' && global.tech.housing >= 1 && global.tech.currency >= 1) ? true : false;
         },
         grant: ['transport',2],
         trait: ['gravity_well'],


### PR DESCRIPTION
Since demons' lack of hunting lodges turned out to be intentional, this takes the more direct route for fixing #1063 by adding a demon-specific (well, really "souleater-but-not-wendigo"-specific) alt unlock condition to the wagon tech itself. As there wasn't really a good tech option around the same level as farmhouses/lodges to replace those as the extra prereq, I went for making it require the same techs you'd normally need to get to lodges (Housing and Currency) instead.