### PR TITLE
Minor fixes to worker scaling in odd situations

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1987,7 +1987,7 @@ export const actions = {
                     if (global.race['chameleon']){
                         gain -= global.city.garrison.count;
                     }
-                    global.civic['garrison'].max += gain;
+                    global.civic['garrison'].max += jobScale(gain);
                     global.city['garrison'].count++;
                     global.city['garrison'].on++;
                     global.resource.Furs.display = true;
@@ -3125,7 +3125,8 @@ export const actions = {
             action(){
                 if (payCosts($(this)[0])){
                     global.city['amphitheatre'].count++;
-                    global.civic.entertainer.max += jobScale(1);
+                    let athVal2 = govActive('athleticism',1);
+                    global.civic.entertainer.max += jobScale(athVal2 ? athVal2 : 1);
                     global.civic.entertainer.display = true;
                     return true;
                 }
@@ -3198,6 +3199,7 @@ export const actions = {
                 if (payCosts($(this)[0])){
                     if (global.genes['ancients'] && global.genes['ancients'] >= 2){
                         global.civic.priest.display = true;
+                        global.civic.priest.max += jobScale(1);
                     }
                     global.city['temple'].count++;
                     return true;
@@ -3395,7 +3397,7 @@ export const actions = {
                     global['resource']['Knowledge'].max += gain;
                     global.city.university.count++;
                     global.civic.professor.display = true;
-                    global.civic.professor.max = global.city.university.count;
+                    global.civic.professor.max = jobScale(global.city.university.count);
                     return true;
                 }
                 return false;
@@ -3573,7 +3575,7 @@ export const actions = {
                     let gain = 1000;
                     global.city.wardenclyffe.count++;
                     global.civic.scientist.display = true;
-                    global.civic.scientist.max = global.city.wardenclyffe.count;
+                    global.civic.scientist.max += jobScale(1);
                     if (powerOnNewStruct($(this)[0])){
                         gain = global.tech['science'] >= 7 ? 2500 : 2000;
                     }
@@ -8184,16 +8186,16 @@ function cataclysm(){
         if (!global.race['flier']){
             global.tech['cement'] = 5;
             global.civic.cement_worker.display = true;
-            global.civic.cement_worker.max = 1;
-            global.civic.cement_worker.workers = 1;
+            global.civic.cement_worker.max = jobScale(1);
+            global.civic.cement_worker.workers = jobScale(1);
         }
 
-        global.civic.colonist.max = 4;
-        global.civic.colonist.workers = 4;
-        global.civic.space_miner.max = 3;
-        global.civic.space_miner.workers = 2;
-        global.civic.professor.max = 1;
-        global.civic.professor.workers = 1;
+        global.civic.colonist.max = jobScale(4);
+        global.civic.colonist.workers = jobScale(4);
+        global.civic.space_miner.max = jobScale(3);
+        global.civic.space_miner.workers = jobScale(2);
+        global.civic.professor.max = jobScale(1);
+        global.civic.professor.workers = jobScale(1);
 
         global.city.calendar.day++;
         global.city.market.active = true;

--- a/src/civics.js
+++ b/src/civics.js
@@ -1053,7 +1053,7 @@ export function govCivics(f,v){
     }
 }
 
-function mercCost(){
+export function mercCost(){
     let cost = Math.round((1.24 ** global.civic.garrison.workers) * 75) - 50;
     if (cost > 25000){
         cost = 25000;

--- a/src/portal.js
+++ b/src/portal.js
@@ -95,6 +95,7 @@ const fortressModules = {
                 if (payCosts($(this)[0])){
                     incrementStruct('carport','portal');
                     global.civic.hell_surveyor.display = true;
+                    global.civic.hell_surveyor.max += jobScale(1);
                     global.resource.Infernite.display = true;
                     if (!global.tech['infernite']){
                         global.tech['infernite'] = 1;
@@ -646,11 +647,12 @@ const fortressModules = {
                     incrementStruct('archaeology','portal');
                     global.civic.archaeologist.display = true;
                     if (powerOnNewStruct($(this)[0])){
-                        if (global.civic[global.civic.d_job].workers > 0){
-                            let hired = global.civic[global.civic.d_job].workers - jobScale(2) < 0 ? global.civic[global.civic.d_job].workers : jobScale(2);
-                            global.civic[global.civic.d_job].workers -= hired;
-                            global.civic.archaeologist.workers += hired;
-                        }
+                        let hiredMax = jobScale(2);
+                        global.civic.archaeologist.max += hiredMax;
+
+                        let hired = Math.min(hiredMax, global.civic[global.civic.d_job].workers);
+                        global.civic[global.civic.d_job].workers -= hired;
+                        global.civic.archaeologist.workers += hired;
                     }  
                     return true;
                 }

--- a/src/portal.js
+++ b/src/portal.js
@@ -4,7 +4,7 @@ import { unlockAchieve, alevel, universeAffix } from './achieve.js';
 import { traits, races, fathomCheck } from './races.js';
 import { defineResources, spatialReasoning } from './resources.js';
 import { loadFoundry, jobScale } from './jobs.js';
-import { armyRating, govCivics, garrisonSize } from './civics.js';
+import { armyRating, govCivics, garrisonSize, mercCost } from './civics.js';
 import { payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, updateDesc } from './actions.js';
 import { checkRequirements, incrementStruct, astrialProjection, ascendLab } from './space.js';
 import { production } from './prod.js';
@@ -2120,17 +2120,7 @@ export function buildFortress(parent,full){
                 let repeats = keyMultiplier();
                 let canBuy = true;
                 while (canBuy && repeats > 0){
-                    let cost = Math.round((1.24 ** global.civic.garrison.workers) * 75) - 50;
-                    if (cost > 25000){
-                        cost = 25000;
-                    }
-                    if (global.civic.garrison.m_use > 0){
-                        cost *= 1.1 ** global.civic.garrison.m_use;
-                    }
-                    if (global.race['brute']){
-                        cost = cost / 2;
-                    }
-                    cost = Math.round(cost);
+                    let cost = mercCost();
                     if (global.civic['garrison'].workers < global.civic['garrison'].max && global.resource.Money.amount >= cost){
                         global.resource.Money.amount -= cost;
                         global.civic['garrison'].workers++;

--- a/src/space.js
+++ b/src/space.js
@@ -655,11 +655,13 @@ const spaceProjects = {
                     global.civic.colonist.display = true;
                     if (powerOnNewStruct($(this)[0])){
                         global.resource[global.race.species].max += jobScale(1);
-                        if (global.civic[global.civic.d_job].workers > 0){
-                            let hired = global.civic[global.civic.d_job].workers - jobScale(1) < 0 ? global.civic[global.civic.d_job].workers : jobScale(1);
-                            global.civic[global.civic.d_job].workers -= hired;
-                            global.civic.colonist.workers += hired;
-                        }
+
+                        let hiredMax = jobScale(1);
+                        global.civic.colonist.max += hiredMax;
+
+                        let hired = Math.min(hiredMax, global.civic[global.civic.d_job].workers);
+                        global.civic[global.civic.d_job].workers -= hired;
+                        global.civic.colonist.workers += hired;
                     }
                     return true;
                 }
@@ -1069,7 +1071,7 @@ const spaceProjects = {
                     global.city.university.count++;
                     global.space.red_university.count = global.city.university.count;
                     global.civic.professor.display = true;
-                    global.civic.professor.max = global.city.university.count;
+                    global.civic.professor.max = jobScale(global.city.university.count);
                     return true;
                 }
                 return false;
@@ -1184,6 +1186,7 @@ const spaceProjects = {
                     incrementStruct('ziggurat');
                     if (global.genes['ancients'] && global.genes['ancients'] >= 4){
                         global.civic.priest.display = true;
+                        global.civic.priest.max += jobScale(1);
                     }
                     if (global.race['cataclysm']){
                         unlockAchieve('iron_will',false,1);
@@ -1868,14 +1871,12 @@ const spaceProjects = {
                         global.tech['asteroid'] = 3;
                     }
                     if (powerOnNewStruct($(this)[0])){
-                        if (global.civic[global.civic.d_job].workers > 0){
-                            let hired = jobScale(3);
-                            if (global.civic[global.civic.d_job].workers - hired < 0){
-                                hired = global.civic[global.civic.d_job].workers;
-                            }
-                            global.civic[global.civic.d_job].workers -= hired;
-                            global.civic.space_miner.workers += hired;
-                        }
+                        let hiredMax = jobScale(3);
+                        global.civic.space_miner.max += hiredMax;
+
+                        let hired = Math.min(hiredMax, global.civic[global.civic.d_job].workers);
+                        global.civic[global.civic.d_job].workers -= hired;
+                        global.civic.space_miner.workers += hired;
                     }
                     if (global.race['orbit_decay'] && global.race.orbit_decay > global.stats.days + 1000){
                         global.race.orbit_decay = global.stats.days + 1000;
@@ -2540,6 +2541,10 @@ const interstellarProjects = {
                     incrementStruct('laboratory','interstellar');
                     if (powerOnNewStruct($(this)[0])){
                         global.resource.Knowledge.max += 10000;
+                        if (global.tech.science >= 16){
+                            global.civic.scientist.display = true;
+                            global.civic.scientist.max += jobScale(1);
+                        }
                     }
                     return true;
                 }
@@ -3338,6 +3343,7 @@ const interstellarProjects = {
                 if (payCosts($(this)[0])){
                     incrementStruct('stellar_forge','interstellar');
                     if (powerOnNewStruct($(this)[0])){
+                        global.civic.craftsman.max += jobScale(2);
                         if (global.tech['star_forge'] >= 2){
                             global.city.smelter.cap += 2;
                             global.city.smelter.Star += 2;
@@ -4793,7 +4799,12 @@ const galaxyProjects = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('resort','galaxy');
-                    powerOnNewStruct($(this)[0]);
+                    if (powerOnNewStruct($(this)[0])){
+                        if (!global.race['joyless']){
+                            global.civic.entertainer.max += jobScale(2);
+                            global.civic.entertainer.display = true;
+                        }
+                    }
                     return true;
                 }
                 return false;

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -188,11 +188,13 @@ const outerTruth = {
                     global.civic.titan_colonist.display = true;
                     if (powerOnNewStruct($(this)[0])){
                         global.resource[global.race.species].max += jobScale(1);
-                        if (global.civic[global.civic.d_job].workers > 0){
-                            let hired = global.civic[global.civic.d_job].workers - jobScale(1) < 0 ? global.civic[global.civic.d_job].workers : jobScale(1);
-                            global.civic[global.civic.d_job].workers -= hired;
-                            global.civic.titan_colonist.workers += hired;
-                        }
+
+                        let hiredMax = jobScale(1);
+                        global.civic.titan_colonist.max += hiredMax;
+
+                        let hired = Math.min(hiredMax, global.civic[global.civic.d_job].workers);
+                        global.civic[global.civic.d_job].workers -= hired;
+                        global.civic.titan_colonist.workers += hired;
                     }
                     return true;
                 }
@@ -1556,12 +1558,13 @@ const tauCetiModules = {
                         global.tauceti.orbital_station.on++;
                         global.tauceti.colony.on++;
                         global.tauceti.mining_pit.on++;
-                        let jRequest = jobScale(4);
-                        if (global.civic[global.civic.d_job].workers < jRequest){
-                            jRequest = global.civic[global.civic.d_job].workers;
-                        }
-                        global.civic.pit_miner.workers += jRequest;
-                        global.civic[global.civic.d_job].workers -= jRequest;
+
+                        let hiredMax = jobScale(4);
+                        global.civic.pit_miner.max += hiredMax;
+
+                        let hired = Math.min(hiredMax, global.civic[global.civic.d_job].workers);
+                        global.civic[global.civic.d_job].workers -= hired;
+                        global.civic.pit_miner.workers += hired;
                     }
                     if (global.settings.tabLoad){
                         drawShips();


### PR DESCRIPTION
This is a bundle of minor fixes, mostly for things that get fixed during the main processing loops.

The following fixes do something meaningful.
1. Mercenary prices could be different in the Civics tab and in the Hell tab. Share the civics function as a single point of truth.
2. When beginning the Cataclysm scenario, use high population scaled values for initial population allocation, so that insects do not need to wait for 3/4 or more of their starting population to grow at the start of the scenario.

The following fixes only have an effect between construction of a structure and the next refresh of the same value in the game's main loop. The values are written as the usual numbers, but the values are high-pop scaled with jobScale().
3. When building a barracks, add high-pop scaling to the increase in max garrison size.
4. When building a stadium, increase the maximum number of entertainers by 2 instead of 1.
5. When building a temple after unlocking the ancients:2 CRISPR, increase the priest cap by 1.
6. When building a university, use high-pop scaling when deciding the new maximum number of professors.
7. When building a red planet university, use high-pop scaling when deciding the new maximum number of professors.
8. When building a wardenclyffe, don't assume that tech "Scientific Expeditions" has not yet been researched. Increase the scientist count by 1 instead of setting the count to the number of wardenclyffes.
9. When building a surveyor carport, increase the maximum number of surveyors by 1.
10. When building an archaeology dig that gets powered on, increase the maximum number of archaeologists by 2.
11. When building a living quarters that gets powered on, increase the maximum number of colonists by 1.
12. When building a ziggurat after unlocking the ancients:2 CRISPR, increase the priest cap by 1.
13. When building a space station that gets powered on, increase the maximum number of space miners by 3.
14. When building a laboratory that gets powered on after researching "Scientific Expeditions", increase the maximum number of scientists by 1.
15. When building a stellar forge that gets powered on, increase the maximum number of craftsmen by 2.
16. When building a resort that gets powered on, increase the maximum number of entertainers by 2, unless Joyless is in effect.
17. When building a Titan colony, increase the maximum number of Titan colonists by 1.
18. When dismantling a ship at Tau Ceti, increase the maximum number of pit miners by 4.


Currently, I have tested only changes 3, 4, and 6. They work as expected.