### PR TITLE
Fix for Luxury goods income with high pop or colonies

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3975,10 +3975,10 @@ function fastLoop(){
                 breakdown.p.consume.Furs[loc('city_factory')] = -(fur_cost);
                 modRes('Furs', -(fur_cost * time_multiplier));
 
-                let demand = global.resource[global.race.species].amount * f_rate.Lux.demand[assembly] * eff;
+                let demand = highPopAdjust(global.resource[global.race.species].amount) * f_rate.Lux.demand[assembly] * eff;
                 demand = luxGoodPrice(demand);
 
-                let delta = workDone * demand * tauBonus;
+                let delta = workDone * demand;
                 if (global.race['gravity_well']){ delta = teamster(delta); }
                 FactoryMoney = delta * hunger;
 


### PR DESCRIPTION
Fixed income from luxury goods not being affected by high population, causing insects to get 4x money compared to other races.
Fixed income from luxury goods being affected by colonies twice in isolation, giving a +125% bonus instead of a +50% bonus.

WARNING: These changes have a mayor impact on the balance. Severely nerfing money gain for insect races and any race during Isolation or Lone Survivor.