### PR TITLE
Fix backup save for Demonic Infusion reset (issue #1044)

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -5052,7 +5052,8 @@ const techs = {
             return `<div>${loc('tech_demonic_infusion_effect')}</div><div class="has-text-special">${loc('tech_demonic_infusion_effect2',[calcPrestige('descend').artifact])}</div>`;
         },
         action(){
-            if (payCosts($(this)[0])){
+            // Check affordability without paying the 1000 pop and Demonic Essence to avoid breaking the backup save
+            if (checkAffordable($(this)[0])){
                 descension();
             }
             return false;


### PR DESCRIPTION
Currently, the Demonic Infusion technology charges its costs like normal, then immediately initiates the reset. The reset logic takes a backup save as usual.

This causes the backup save to be taken after subtracting 1000 population and the Demonic Essence. In particular, there isn't any way to get another Demonic Essence, so it is impossible to repeat the Demonic Infusion reset after restoring the backup save.

I tested the following with this patch:
- The tech button does nothing when clicked with under 1000 population
- The backup save does not charge resources (pop, knowledge, demonic essence) when restored
- The prestige resources shown on the evolution screen are the same with and without the change, as expected

It looks like the way that the DI reset is performed from inside the call stack for a technology button causes some errors for cost-checking functions in the JavaScript console, though the errors don't seem to cause any real issue. The errors are the same with and without this change.