### PR TITLE
Fix for humpback using the wrong values for boosting jobs

### DIFF
--- a/src/races.js
+++ b/src/races.js
@@ -4623,11 +4623,11 @@ export function racialTrait(workers,type){
         }
     }
     if (global.race['humpback'] && (type === 'miner' || type === 'lumberjack')){
-        modifier *= 1 + (traits.humpback.vars()[0] / 100);
+        modifier *= 1 + (traits.humpback.vars()[1] / 100);
     }
     let kamelFathom = fathomCheck('kamel');
     if (kamelFathom > 0 && (type === 'miner' || type === 'lumberjack')){
-        modifier *= 1 + (traits.humpback.vars(1)[0] / 100 * kamelFathom);
+        modifier *= 1 + (traits.humpback.vars(1)[1] / 100 * kamelFathom);
     }
     if (global.city.ptrait.includes('magnetic') && type === 'miner'){
         modifier *= planetTraits.magnetic.vars()[2];


### PR DESCRIPTION
Humpback currently uses the starvation modifier (0.5) instead of the production modifier (20) to boost the jobs that it affects.
This PR fixes it.