### PR TITLE
Support automatic power-on option for additional structures

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -3628,9 +3628,7 @@ const interstellarProjects = {
                         if (global.interstellar.stargate.count >= 200){
                             global.tech['stargate'] = 4;
                             global.interstellar['s_gate'] = { count: 1, on: 0 };
-                            if (global.city.power >= interstellarProjects.int_blackhole.s_gate.powered()){
-                                global.interstellar['s_gate'].on++;
-                            }
+                            powerOnNewStruct($(interstellarProjects.int_blackhole.s_gate)[0]);
                             deepSpace();
                             clearPopper();
                         }

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -523,9 +523,7 @@ const outerTruth = {
                         if (global.space.ai_core.count >= 100){
                             global.tech['titan_ai_core'] = 1;
                             global.space['ai_core2'] = { count: 1, on: 0 };
-                            if (global.city.power >= outerTruth.spc_titan.ai_core2.powered()){
-                                global.space.ai_core2.on++;
-                            }
+                            powerOnNewStruct($(outerTruth.spc_titan.ai_core2)[0]);
                             renderSpace();
                             drawTech();
                         }
@@ -1560,8 +1558,7 @@ const tauCetiModules = {
                     global.tauceti.mining_pit.count++;
                     global.civic.pit_miner.display = true;
                     global.resource.Materials.display = true;
-                    if (global.city.powered && global.city.power >= tauCetiModules.tau_home.orbital_station.powered()){
-                        global.tauceti.orbital_station.on++;
+                    if (powerOnNewStruct($(tauCetiModules.tau_home.orbital_station)[0])){
                         global.tauceti.colony.on++;
                         global.tauceti.mining_pit.on++;
 
@@ -2961,8 +2958,7 @@ const tauCetiModules = {
             action(){
                 if (payCosts($(this)[0])){
                     global.tauceti.ore_refinery.count++;
-                    if (global.city.powered && global.city.power >= $(this)[0].powered()){
-                        global.tauceti.ore_refinery.on++;
+                    if (powerOnNewStruct($(this)[0])){
                         global.city.smelter.cap += global.tech['isolation'] ? 12 : 2;
                         global.city.smelter.Steel += global.tech['isolation'] ? 12 : 2;
                         if (global.race['evil']) {


### PR DESCRIPTION
The following 4 structures are expected to automatically power on when built, but the automatic power-on switch toggle (#1010) does not cause them to ignore power requirements.

False path:
- Stargate

True path:
- AI Supercore
- Tau Ceti: Orbital Station (when dismantling the explorer ship)
- Tau Ceti: Ore Refinery

I tested all 4 changes individually by confirming that the automatic power-on setting is ineffective for them without this patch and effective with this patch.

Other structures that always require manual intervention, such as the World Collider and the Ascension Machine, are not affected.