### PR TITLE
Fix power cost modifier for high-tech farms

### DIFF
--- a/src/truepath.js
+++ b/src/truepath.js
@@ -1814,7 +1814,7 @@ const tauCetiModules = {
                 return desc;
             },
             support(){ return 1; },
-            powered(){ return powerModifier(global.tech['isolation'] ? 1 : 4); },
+            powered(){ return powerCostMod(global.tech['isolation'] ? 1 : 4); },
             action(){
                 if (payCosts($(this)[0])){
                     global.tauceti.tau_farm.count++;


### PR DESCRIPTION
The function powerModifier (for power generators) is being used to scale the power cost of high-tech farms, but the function powerCostMod (for power consumers) should be used instead.