### PR TITLE
Screen reader: make more menus usable

### DIFF
--- a/src/industry.js
+++ b/src/industry.js
@@ -1398,7 +1398,7 @@ function loadReplicator(parent,bind){
                 values += `<b-dropdown-item aria-role="listitem" v-on:click="setVal('${res}')" data-val="${res}" v-show="avail('${res}')">${global.resource[res].name}</b-dropdown-item>`;
             });
 
-            content.append(`<div><b-dropdown :triggers="['hover']" aria-role="list" :scrollable="true" :max-height="200" class="dropList">
+            content.append(`<div><b-dropdown :triggers="['hover', 'click']" aria-role="list" :scrollable="true" :max-height="200" class="dropList">
                 <button class="button is-info" slot="trigger">
                     <span>{{ res | resName }}</span>
                 </button>${values}

--- a/src/portal.js
+++ b/src/portal.js
@@ -3542,7 +3542,7 @@ export function drawMechLab(){
             sizes += `<b-dropdown-item aria-role="listitem" v-on:click="setSize('${size}')" class="size r0 a${idx}" data-val="${size}">${loc(`portal_mech_size_${size}`)}</b-dropdown-item>`;
         });
 
-        options.append(`<b-dropdown :triggers="['hover']" aria-role="list">
+        options.append(`<b-dropdown :triggers="['hover', 'click']" aria-role="list">
             <button class="button is-info" slot="trigger">
                 <span>${loc(`portal_mech_size`)}: {{ b.size | slabel }}</span>
                 <b-icon icon="menu-down"></b-icon>
@@ -3554,7 +3554,7 @@ export function drawMechLab(){
             chassis += `<b-dropdown-item aria-role="listitem" v-on:click="setType('${val}')" class="chassis r0 a${idx}" data-val="${val}">${loc(`portal_mech_chassis_${val}`)}</b-dropdown-item>`;
         });
 
-        options.append(`<b-dropdown :triggers="['hover']" aria-role="list">
+        options.append(`<b-dropdown :triggers="['hover', 'click']" aria-role="list">
             <button class="button is-info" slot="trigger">
                 <span>${loc(`portal_mech_type`)}: {{ b.chassis | clabel }}</span>
                 <b-icon icon="menu-down"></b-icon>
@@ -3567,7 +3567,7 @@ export function drawMechLab(){
                 weapons += `<b-dropdown-item aria-role="listitem" v-on:click="setWep('${val}',${i})" class="weapon r${i} a${idx}" data-val="${val}">${loc(`portal_mech_weapon_${val}`)}</b-dropdown-item>`;
             });
 
-            options.append(`<b-dropdown :triggers="['hover']" aria-role="list" v-show="vis(${i})">
+            options.append(`<b-dropdown :triggers="['hover', 'click']" aria-role="list" v-show="vis(${i})">
                 <button class="button is-info" slot="trigger">
                     <span>${loc(`portal_mech_weapon`)}: {{ b.hardpoint[${i}] || 'laser' | wlabel }}</span>
                     <b-icon icon="menu-down"></b-icon>
@@ -3582,7 +3582,7 @@ export function drawMechLab(){
                 equip += `<b-dropdown-item aria-role="listitem" v-on:click="setEquip('${val}',${i})" class="equip r${i} a${idx}" data-val="${val}">{{ '${val}' | equipment }}</b-dropdown-item>`;
             });
 
-            options.append(`<b-dropdown :triggers="['hover']" aria-role="list" v-show="eVis(${i})">
+            options.append(`<b-dropdown :triggers="['hover', 'click']" aria-role="list" v-show="eVis(${i})">
                 <button class="button is-info" slot="trigger">
                     <span>${loc(`portal_mech_equipment`)}: {{ b.equip[${i}] || 'shields' | equipment }}</span>
                     <b-icon icon="menu-down"></b-icon>

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -3686,7 +3686,7 @@ export function drawShipYard(){
                 values += `<b-dropdown-item aria-role="listitem" v-on:click="setVal('${k}','${v}')" class="${k} a${idx}" data-val="${v}" v-show="avail('${k}','${idx}','${v}')">${loc(`outer_shipyard_${k}_${v}`)}</b-dropdown-item>`;
             });
 
-            options.append(`<b-dropdown :triggers="['hover']" aria-role="list">
+            options.append(`<b-dropdown :triggers="['hover', 'click']" aria-role="list">
                 <button class="button is-info" slot="trigger">
                     <span>${loc(`outer_shipyard_${k}`)}: {{ b.${k} | lbl('${k}') }}</span>
                 </button>${values}
@@ -4417,7 +4417,7 @@ function drawShips(){
 
         let location = ship.location === 'tauceti' ? loc('tech_era_tauceti') : typeof spaceRegions[ship.location].info.name === 'string' ? spaceRegions[ship.location].info.name : spaceRegions[ship.location].info.name();
 
-        let dispatch = `<b-dropdown id="ship${i}loc" :triggers="['hover']" aria-role="list" scrollable position="is-bottom-left">
+        let dispatch = `<b-dropdown id="ship${i}loc" :triggers="['hover', 'click']" aria-role="list" scrollable position="is-bottom-left">
             <button class="button is-info" slot="trigger">
                 <span>${location}</span>
             </button>${values}


### PR DESCRIPTION
The Truepath ship constructor, mech constructor and industry tab > matter replicater menus all have to be hovered on with the mouse in order to open them. Screen readers have a key to make that happen, but it must often be pressed multiple times and the mouse can somehow move away while you're scrolling through the menu, closing it and making you try again.  This allows pressing enter on such a button to open its menu. Hovering still appears to work.

Fixes #1065