### PR TITLE
Unlocking wagons for Demonic races, slight fix for not wendigo check

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -161,7 +161,7 @@ const techs = {
         era: 'civilized',
         reqs: { transport: 1 },
         condition(){
-            return global.tech['farm'] || global.tech['s_lodge'] || (global.tech['hunting'] && global.tech.hunting >= 2) || (global.race['soul_eater'] && !global.race.species === 'wendigo' && global.tech.housing >= 1 && global.tech.currency >= 1) ? true : false;
+            return global.tech['farm'] || global.tech['s_lodge'] || (global.tech['hunting'] && global.tech.hunting >= 2) || (global.race['soul_eater'] && global.race.species !== 'wendigo' && global.tech.housing >= 1 && global.tech.currency >= 1) ? true : false;
         },
         grant: ['transport',2],
         trait: ['gravity_well'],


### PR DESCRIPTION
#1075 attempted to fix #1063 by adding a demonic-specific alt unlock for the wagon tech. This did not actually fix the problem because the not wendigo check `!global.race.species === 'wendigo'` is always false due to the not operator being applied to `global.race.species` instead of the boolean result. Switching to a strict inequality fixes this and matches the style of other inequality checks in the file.