### PR TITLE
fix the MAD wiki calculator and the synth MAD penalty

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1401,7 +1401,7 @@ export function getResetConstants(type, inputs){
             rc.k_inc = 100000;
             rc.k_mult = 1.1;
             rc.plasmid_cap = 150;
-            if (inputs.synth){
+            if (inputs.synth === true || inputs.synth.val === true){
                 rc.pop_divisor = 5;
                 rc.k_inc = 125000;
                 rc.plasmid_cap = 100;
@@ -1477,7 +1477,7 @@ export function calcPrestige(type,inputs){
     };
 
     if (!inputs) { inputs = {}; }
-    if (inputs.synth !== undefined) inputs.synth = races[global.race.species].type === 'synthetic';
+    if (inputs.synth === undefined) inputs.synth = races[global.race.species].type === 'synthetic';
     let challenge = inputs.genes;
     let universe = inputs.uni;
     universe = universe || global.race.universe;


### PR DESCRIPTION
Fixed 2 bugs, in the first when getResetConstants is called by the wiki, inputs.synth is an object, making if (inputs.synth) always true, this means that the mad calculator is always using the synth constants. 
The second is that in calcPrestige inputs.synth is always undefined when called by the game so the synth penalty is never applied when triggering a mad
Fixes #1120 

