### PR TITLE
Improve tab refresh behavior

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7435,6 +7435,7 @@ function sentience(){
             global.settings.msgFilters.research_queue.unlocked = true;
             global.settings.msgFilters.research_queue.vis = true;
         }
+        // No need to check for civTab setting because it was set to another tab above
         if (global.settings.tabLoad){
             $(`#resQueue`).removeAttr('style');
         }

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,7 +3,7 @@ import { loc } from './locale.js';
 import { timeCheck, timeFormat, vBind, popover, clearPopper, flib, tagEvent, clearElement, costMultiplier, darkEffect, genCivName, powerModifier, powerCostMod, calcPrestige, adjustCosts, modRes, messageQueue, buildQueue, format_emblem, shrineBonusActive, calc_mastery, calcPillar, calcGenomeScore, getShrineBonus, eventActive, easterEgg, getHalloween, trickOrTreat, deepClone, hoovedRename } from './functions.js';
 import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from './achieve.js';
 import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck } from './races.js';
-import { defineResources, galacticTrade, spatialReasoning, resource_values, initResourceTabs, drawResourceTab, marketItem, containerItem, tradeSummery } from './resources.js';
+import { defineResources, unlockCrates, unlockContainers, galacticTrade, spatialReasoning, resource_values, initResourceTabs, drawResourceTab, marketItem, containerItem, tradeSummery } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
 import { loadIndustry, defineIndustry, nf_resources, gridDefs } from './industry.js';
 import { govEffect, defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating } from './civics.js';
@@ -2228,15 +2228,7 @@ export const actions = {
             },
             action(){
                 if (payCosts($(this)[0])){
-                    if (global.resource.Crates.display === false){
-                        messageQueue(loc('city_storage_yard_msg'),'info',false,['progress']);
-                    }
                     global.city['storage_yard'].count++;
-                    global.settings.showResources = true;
-                    global.settings.showStorage = true;
-                    if (!global.settings.showMarket) {
-                        global.settings.marketTabs = 1;
-                    }
                     let cap = global.tech.container >= 3 ? 20 : 10;
                     if (global.stats.achieve['pathfinder'] && global.stats.achieve.pathfinder.l >= 1){
                         cap += 10;
@@ -2248,14 +2240,10 @@ export const actions = {
                         cap *= 2;
                     }
                     global.resource.Crates.max += cap;
+                    // A freight yard is always required, so this is the only struct that can unlock crates
+                    // Any scenario where a freight yard is unnecessary will begin with crates unlocked
                     if (!global.resource.Crates.display){
-                        global.resource.Crates.display = true;
-                        clearElement($('#resources'));
-                        defineResources();
-                        if (global.settings.tabLoad){
-                            drawResourceTab('storage');
-                            defineGovernor();
-                        }
+                        unlockCrates();
                     }
                     return true;
                 }
@@ -2289,12 +2277,7 @@ export const actions = {
             },
             action(){
                 if (payCosts($(this)[0])){
-                    if (global.resource.Containers.display === false){
-                        messageQueue(loc('city_warehouse_msg'),'info',false,['progress']);
-                    }
                     global.city['warehouse'].count++;
-                    global.settings.showResources = true;
-                    global.settings.showStorage = true;
                     let cap = global.tech['steel_container'] >= 2 ? 20 : 10;
                     if (global.stats.achieve['pathfinder'] && global.stats.achieve.pathfinder.l >= 2){
                         cap += 10;
@@ -2307,12 +2290,7 @@ export const actions = {
                     }
                     global.resource.Containers.max += cap;
                     if (!global.resource.Containers.display){
-                        global.resource.Containers.display = true;
-                        clearElement($('#resources'));
-                        defineResources();
-                        if (global.settings.tabLoad){
-                            drawResourceTab('storage');
-                        }
+                        unlockContainers();
                     }
                     return true;
                 }
@@ -3039,20 +3017,17 @@ export const actions = {
             },
             action(){
                 if (payCosts($(this)[0])){
-                    if (global.resource.Containers.display === false){
-                        messageQueue(loc('city_warehouse_msg'),'info',false,['progress']);
-                        global.resource.Containers.display = true;
-                        clearElement($('#resources'));
-                        defineResources();
-                    }
                     global.city['wharf'].count++;
                     global.city.market.mtrade += 2;
-                    let vol = global.tech['world_control'] ? 15 : 10
+                    let vol = global.tech['world_control'] ? 15 : 10;
                     if (global.tech['particles'] && global.tech['particles'] >= 2){
                         vol *= 2;
                     }
                     global.resource.Crates.max += vol;
                     global.resource.Containers.max += vol;
+                    if (!global.resource.Containers.display){
+                        unlockContainers();
+                    }
                     return true;
                 }
                 return false;

--- a/src/governor.js
+++ b/src/governor.js
@@ -278,6 +278,9 @@ export function govern(){
 }
 
 export function defineGovernor(){
+    if (!global.settings.tabLoad && (global.settings.civTabs !== 2 || global.settings.govTabs !== 0)){
+        return;
+    }
     if (global.genes['governor'] && global.tech['governor']){
         clearElement($('#r_govern1'));
         if (global.race.hasOwnProperty('governor') && !global.race.governor.hasOwnProperty('candidates')){

--- a/src/portal.js
+++ b/src/portal.js
@@ -2,13 +2,13 @@ import { global, seededRandom, keyMultiplier, p_on, gal_on, spire_on, quantum_le
 import { vBind, clearElement, popover, clearPopper, timeFormat, powerCostMod, spaceCostMultiplier, messageQueue, powerModifier, calcPillar, deepClone, popCost, calcPrestige } from './functions.js';
 import { unlockAchieve, alevel, universeAffix } from './achieve.js';
 import { traits, races, fathomCheck } from './races.js';
-import { defineResources, spatialReasoning } from './resources.js';
+import { spatialReasoning, unlockContainers } from './resources.js';
 import { loadFoundry, jobScale, limitCraftsmen } from './jobs.js';
 import { armyRating, govCivics, garrisonSize, mercCost } from './civics.js';
 import { payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, updateDesc } from './actions.js';
 import { checkRequirements, incrementStruct, astrialProjection, ascendLab } from './space.js';
 import { production } from './prod.js';
-import { govActive } from './governor.js';
+import { govActive, defineGovernor } from './governor.js';
 import { descension } from './resets.js';
 import { loadTab } from './index.js';
 import { loc } from './locale.js';
@@ -686,8 +686,12 @@ const fortressModules = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('arcology','portal');
+
                     if (powerOnNewStruct($(this)[0])){
                         global['resource'][global.race.species].max += 8;
+                    }
+                    if (!global.resource.Containers.display){
+                        unlockContainers();
                     }
                     return true;
                 }
@@ -1286,8 +1290,6 @@ const fortressModules = {
                     if (!global.settings.portal.spire){
                         global.settings.portal.spire = true;
                         global.settings.showCargo = true;
-                        clearElement($('#resources'));
-                        defineResources();
                         global.tech['hell_spire'] = 1;
                         global.portal['purifier'] = { count: 0, on: 0, support: 0, s_max: 0, supply: 0, sup_max: 100, diff: 0 };
                         global.portal['port'] = { count: 0, on: 0 };
@@ -1620,6 +1622,7 @@ const fortressModules = {
                     if (global.portal.mechbay.count === 1){
                         messageQueue(loc('portal_mechbay_unlocked'),'info',false,['progress','hell']);
                         drawMechLab();
+                        defineGovernor();
                     }
                     return true;
                 }

--- a/src/races.js
+++ b/src/races.js
@@ -5,7 +5,7 @@ import { setJobName, jobScale, loadFoundry } from './jobs.js';
 import { vBind, clearElement, popover, removeFromQueue, removeFromRQueue, calc_mastery, gameLoop, getEaster, getHalloween, randomKey, modRes } from './functions.js';
 import { setResourceName, atomic_mass } from './resources.js';
 import { buildGarrison, govEffect } from './civics.js';
-import { govActive, removeTask } from './governor.js';
+import { govActive, removeTask, defineGovernor } from './governor.js';
 import { unlockAchieve } from './achieve.js';
 import { highPopAdjust, teamster } from './prod.js';
 import { actions, checkTechQualifications } from './actions.js';
@@ -5123,6 +5123,9 @@ export function cleanAddTrait(trait){
                 if (global.city['slave_pen'].count > 0 && !global.race['orbit_decayed']) {
                     global.resource.Slave.display = true;
                 }
+                if (global.tech['slaves'] >= 2) {
+                    defineGovernor();
+                }
             }
             break;
         case 'cannibalize':
@@ -5136,6 +5139,7 @@ export function cleanAddTrait(trait){
                     mine: 0,
                     harvest: 0,
                 };
+                defineGovernor();
             }
             break;
         case 'magnificent':
@@ -5194,6 +5198,7 @@ export function cleanAddTrait(trait){
             if (!global.race.hasOwnProperty('shoecnt')){
                 global.race['shoecnt'] = 0;
             }
+            defineGovernor();
             break;
         case 'slow':
             save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));
@@ -5371,6 +5376,7 @@ export function cleanRemoveTrait(trait,rank){
             global.resource.Slave.max = 0;
             global.resource.Slave.display = false;
             removeTask('slave');
+            defineGovernor();
             break;
         case 'cannibalize':
             removeFromQueue(['city-s_alter']);
@@ -5378,6 +5384,7 @@ export function cleanRemoveTrait(trait,rank){
             setPurgatory('tech','sacrifice');
             delete global.city['s_alter'];
             removeTask('sacrifice');
+            defineGovernor();
             break;
         case 'magnificent':
             removeFromQueue(['city-shrine']);
@@ -5392,6 +5399,7 @@ export function cleanRemoveTrait(trait,rank){
             removeFromQueue(['city-horseshoe', 'space-horseshoe']);
             global.resource.Horseshoe.display = false;
             removeTask('horseshoe');
+            defineGovernor();
             break;
         case 'slow':
             save.setItem('evolved',LZString.compressToUTF16(JSON.stringify(global)));

--- a/src/resources.js
+++ b/src/resources.js
@@ -1,9 +1,9 @@
 import { global, tmp_vars, keyMultiplier, breakdown, sizeApproximation, p_on, support_on } from './vars.js';
-import { vBind, clearElement, modRes, flib, calc_mastery, calcPillar, eventActive, easterEgg, trickOrTreat, popover, harmonyEffect, darkEffect, hoovedRename } from './functions.js';
+import { vBind, clearElement, modRes, flib, calc_mastery, calcPillar, eventActive, easterEgg, trickOrTreat, popover, harmonyEffect, darkEffect, hoovedRename, messageQueue } from './functions.js';
 import { traits, fathomCheck } from './races.js';
 import { hellSupression } from './portal.js';
 import { syndicate } from './truepath.js';
-import { govActive } from './governor.js';
+import { govActive, defineGovernor } from './governor.js';
 import { govEffect } from './civics.js';
 import { highPopAdjust, production, teamster } from './prod.js';
 import { loc } from './locale.js';
@@ -564,6 +564,9 @@ export function initResourceTabs(tab){
 
 export function drawResourceTab(tab){
     if (tab === 'market'){
+        if (!global.settings.tabLoad && (global.settings.civTabs !== 4 || global.settings.marketTabs !== 0)){
+            return;
+        }
         initResourceTabs('market');
         if (tmp_vars.hasOwnProperty('resource')){
             Object.keys(tmp_vars.resource).forEach(function(name){
@@ -579,6 +582,9 @@ export function drawResourceTab(tab){
         tradeSummery();
     }
     else if (tab === 'storage'){
+        if (!global.settings.tabLoad && (global.settings.civTabs !== 4 || global.settings.marketTabs !== 1)){
+            return;
+        }
         initResourceTabs('storage');
         if (tmp_vars.hasOwnProperty('resource')){
             Object.keys(tmp_vars.resource).forEach(function(name){
@@ -594,6 +600,9 @@ export function drawResourceTab(tab){
         tradeSummery();
     }
     else if (tab === 'ejector'){
+        if (!global.settings.tabLoad && (global.settings.civTabs !== 4 || global.settings.marketTabs !== 2)){
+            return;
+        }
         initResourceTabs('ejector');
         if (tmp_vars.hasOwnProperty('resource')){
             Object.keys(tmp_vars.resource).forEach(function(name){
@@ -605,6 +614,9 @@ export function drawResourceTab(tab){
         }
     }
     else if (tab === 'supply'){
+        if (!global.settings.tabLoad && (global.settings.civTabs !== 4 || global.settings.marketTabs !== 3)){
+            return;
+        }
         initResourceTabs('supply');
         if (tmp_vars.hasOwnProperty('resource')){
             Object.keys(tmp_vars.resource).forEach(function(name){
@@ -616,6 +628,9 @@ export function drawResourceTab(tab){
         }
     }
     else if (tab === 'alchemy'){
+        if (!global.settings.tabLoad && (global.settings.civTabs !== 4 || global.settings.marketTabs !== 4)){
+            return;
+        }
         initResourceTabs('alchemy');
         if (tmp_vars.hasOwnProperty('resource')){
             Object.keys(tmp_vars.resource).forEach(function(name){
@@ -2456,6 +2471,53 @@ function drawModal(name){
             });
         });
     });
+}
+
+function unlockStorage(){
+    // If this is the first resource subtab to unlock, then mark it as the visible subtab
+    if (!global.settings.showResources) {
+        global.settings.marketTabs = 1;
+    }
+
+    // Enable display for resource tab and storage subtab
+    global.settings.showResources = true;
+    global.settings.showStorage = true;
+
+    // Possibly draw or redraw the storage subtab
+    drawResourceTab('storage');
+
+    // Redraw the governor, who has actions to build and manage storage
+    defineGovernor();
+}
+
+// Crates are always initially unlocked by the Freight Yard building.
+// Other buildings that provide crates do not need to call this function.
+export function unlockCrates(){
+    if (!global.resource.Crates.display){
+        // Message about unlocking crates for the first time
+        messageQueue(loc('city_storage_yard_msg'),'info',false,['progress']);
+
+        // Enable display for crates
+        global.resource.Crates.display = true;
+
+        // Unlock the storage tab
+        unlockStorage();
+    }
+}
+
+// Containers are optional to clear the game, so every building that provides Containers might be the very first one.
+// All buildings that provide containers, not just the Container Port, should call this function.
+export function unlockContainers(){
+    if (!global.resource.Containers.display){
+        // Message about unlocking containers for the first time
+        messageQueue(loc('city_warehouse_msg'),'info',false,['progress']);
+
+        // Enable display for containers
+        global.resource.Containers.display = true;
+
+        // Unlock the storage tab
+        unlockStorage();
+    }
 }
 
 export function crateValue(){

--- a/src/tech.js
+++ b/src/tech.js
@@ -2874,7 +2874,8 @@ const techs = {
         },
         post(){
             calcRQueueMax();
-            if (global.settings.tabLoad){
+            // Research queue is always visible on the research tab, so sub-tab check is intentionally excluded
+            if (global.settings.tabLoad || global.settings.civTabs === 3){
                 $(`#resQueue`).removeAttr('style');
             }
         }

--- a/src/tech.js
+++ b/src/tech.js
@@ -4,7 +4,7 @@ import { vBind, clearElement, calcQueueMax, calcRQueueMax, calcPrestige, message
 import { unlockAchieve, alevel, universeAffix, unlockFeat } from './achieve.js';
 import { payCosts, housingLabel, wardenLabel, updateQueueNames, drawTech, fanaticism, checkAffordable, actions } from './actions.js';
 import { races, checkAltPurgatory, renderPsychicPowers } from './races.js';
-import { defineResources, drawResourceTab, resource_values, atomic_mass } from './resources.js';
+import { drawResourceTab, resource_values, atomic_mass } from './resources.js';
 import { loadFoundry, jobScale } from './jobs.js';
 import { buildGarrison, checkControlling, govTitle } from './civics.js';
 import { renderSpace, planetName, int_fuel_adjust } from './space.js';
@@ -3097,6 +3097,7 @@ const techs = {
         },
         post(){
             vBind({el: '#foreign'},'update');
+            defineGovernor();
         }
     },
     espionage: {
@@ -3123,6 +3124,7 @@ const techs = {
         },
         post(){
             vBind({el: '#foreign'},'update');
+            defineGovernor();
         }
     },
     spy_training: {
@@ -3244,6 +3246,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineGovernor();
         }
     },
     large_trades: {
@@ -4487,6 +4492,11 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            if (global.race['terrifying']){
+                defineGovernor();
+            }
         }
     },
     electricity: {
@@ -6872,6 +6882,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineGovernor();
         }
     },
     ceremonial_dagger: {
@@ -6975,6 +6988,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineGovernor();
         }
     },
     signing_bonus: {
@@ -10946,11 +10962,7 @@ const techs = {
             return false;
         },
         post(){
-            clearElement($('#resources'));
-            defineResources();
-            if (global.settings.tabLoad){
-                drawResourceTab('alchemy');
-            }
+            drawResourceTab('alchemy');
         }
     },
     transmutation: {
@@ -10975,10 +10987,6 @@ const techs = {
                 return true;
             }
             return false;
-        },
-        post(){
-            clearElement($('#resources'));
-            defineResources();
         }
     },
     secret_society: {
@@ -13434,6 +13442,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineGovernor();
         }
     },
     clone_degradation: {

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -1,7 +1,7 @@
 import { global, p_on, support_on, sizeApproximation, quantum_level } from './vars.js';
 import { vBind, clearElement, popover, clearPopper, messageQueue, powerCostMod, powerModifier, spaceCostMultiplier, deepClone, calcPrestige, flib, darkEffect, adjustCosts } from './functions.js';
 import { races, traits } from './races.js';
-import { spatialReasoning } from './resources.js';
+import { spatialReasoning, unlockContainers } from './resources.js';
 import { armyRating, garrisonSize } from './civics.js';
 import { jobScale, job_desc, loadFoundry, limitCraftsmen } from './jobs.js';
 import { production, highPopAdjust } from './prod.js';
@@ -790,6 +790,9 @@ const outerTruth = {
                     global.space.munitions_depot.count++;
                     global.resource.Crates.max += 25;
                     global.resource.Containers.max += 25;
+                    if (!global.resource.Containers.display){
+                        unlockContainers();
+                    }
                     return true;
                 }
                 return false;
@@ -1672,6 +1675,9 @@ const tauCetiModules = {
                 if (payCosts($(this)[0])){
                     global.tauceti.colony.count++;
                     powerOnNewStruct($(this)[0]);
+                    if (!global.resource.Containers.display){
+                        unlockContainers();
+                    }
                     return true;
                 }
                 return false;
@@ -2121,6 +2127,14 @@ const tauCetiModules = {
             action(){
                 if (payCosts($(this)[0])){
                     global.tauceti.repository.count++;
+
+                    let containers = 250;
+                    global.resource.Crates.max += containers;
+                    global.resource.Containers.max += containers;
+                    if (!global.resource.Containers.display){
+                        unlockContainers();
+                    }
+
                     let multiplier = tpStorageMultiplier('repository');
                     for (const res of $(this)[0].res()){
                         if (global.resource[res].display){


### PR DESCRIPTION
The code to refresh governor actions generally assumes that it is being executed on the tab where the action is made visible. However, Evolve has building and research queues, so these triggers might happen while the GUI is viewing any tab. Update the restrictions so that governor tasks are immediately refreshed even without Preload Tab Content enabled.

The defineGovernor() function now accordingly checks for its own visibility before it redraws the GUI.

Some completely missing governor tab refreshes, such as when adding or removing Slavery or Cannibalism, or when researching certain technologies, have also been added.

Additionally, remove various instances where the resource panel was deleted and redrawn, which seems to be legacy that isn't required anymore. This is especially nice when building Mass Ejectors, because those would redraw the resource sidebar every single time a new one was built, causing that part of the page to flash. The simple action of unlocking crates / containers is good enough to make those resources visible, to add the + buttons for per-resource storage management, and for the associated storage type to appear within the modal. I didn't experimentally confirm that alchemy is the same way.

Containers may be unlocked by any building that grants them, because, unlike crates, containers aren't mandatory to progress in the game. Add a variety of checks for this, so even a user whose first container is provided by a building other than the container port or wharf can get the proper unlocks.

I tested most of the early game stuff that doesn't rely on being in Magic. I didn't specifically test any of the changes in space or the changes related to alchemy. In both of those cases, the code changes generally follow the same format as something that I did test.