### PR TITLE
Fix issue where governor may deconstruct crates/containers into resources

### DIFF
--- a/src/governor.js
+++ b/src/governor.js
@@ -760,7 +760,7 @@ export const gov_tasks = {
                     let mat = global.race['kindling_kindred'] || global.race['smoldering'] ? (global.race['smoldering'] ? 'Chrysotile' : 'Stone') : 'Plywood';
                     let cost = global.race['kindling_kindred'] || global.race['smoldering'] ? 200 : 10;
                     let reserve = global.race.governor.config.storage.crt;
-                    if (global.resource[mat].amount + cost > reserve){
+                    if (global.resource[mat].amount > reserve + cost){
                         let build = Math.floor((global.resource[mat].amount - reserve) / cost);
                         crateGovHook('crate',build);
                     }
@@ -768,7 +768,7 @@ export const gov_tasks = {
                 if (checkCityRequirements('warehouse') && global.resource.Containers.display && global.resource.Containers.amount < global.resource.Containers.max){
                     let cost = 125;
                     let reserve = global.race.governor.config.storage.cnt;
-                    if (global.resource.Steel.amount + cost > reserve){
+                    if (global.resource.Steel.amount > reserve + cost){
                         let build = Math.floor((global.resource.Steel.amount - reserve) / cost);
                         crateGovHook('container',build);
                     }


### PR DESCRIPTION
The inequality for the Crate/Container Construction governor task is written incorrectly. Instead of being written to require that "at least 1" item can be built, it is written to require that "at least -1" item can be built. This patch corrects the inequality.

The functions in resources.js to build crates and containers will work "as expected" when the argument is a natural number, but they perform other behaviors when receiving arguments of -1 (delete item and refund resources) or 0 (use key multiplier to build).

Fixes #985.

Tested with the following save file.
[evolve-2024-04-26-19-40.txt](https://github.com/pmotschmann/Evolve/files/15129552/evolve-2024-04-26-19-40.txt)
