### PR TITLE
Fix partial fulfillment for >1 support structs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2086,9 +2086,10 @@ function fastLoop(){
                         let id = actions[sup.a][sup.r2][area_structs[i]].id;
                         let supportSize = actions[sup.a][sup.r2][area_structs[i]].hasOwnProperty('support') ? actions[sup.a][sup.r2][area_structs[i]].support() * -1 : 1;
                         let operating = global[sup.a][area_structs[i]].on;
+                        let remaining_support = global[sup.a][sup.s].s_max - used_support;
 
-                        if (used_support + (operating * supportSize) > global[sup.a][sup.s].s_max && !sup.oc){
-                            operating -= (used_support + operating) - global[sup.a][sup.s].s_max;
+                        if ((operating * supportSize > remaining_support) && !sup.oc){
+                            operating = Math.floor(remaining_support / supportSize);
                             $(`#${id} .on`).addClass('warn');
                             $(`#${id} .on`).prop('title',`ON ${operating}/${global[sup.a][area_structs[i]].on}`);
                         }


### PR DESCRIPTION
The code for distributing insufficient support to non-homeworld buildings does not correctly factor in cases where supportSize is different from 1. This causes situations where, for example, more than the total sum of support may be spent on Colonies on Tau Ceti, which results in negative support for the next building in the array, High-Tech Factories.

Keeping the same code structure where `(used_support + operating)` is fixed to `(used_support + operating * supportSize)` could still result in fractional building support, so I added a call to Math.floor() instead.

Tested with the following save file.
[negative support.txt](https://github.com/pmotschmann/Evolve/files/15141076/negative.support.txt)
