### PR TITLE
Strengthen checks to prevent missing workers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2710,7 +2710,7 @@ function fastLoop(){
                     if (total > global.resource[global.race.species].amount){
                         global.civic[job].workers -= total - global.resource[global.race.species].amount;
                     }
-                    if (global.civic[job].workers < 0){
+                    if (!global.civic[job].display || global.civic[job].workers < 0){
                         global.civic[job].workers = 0;
                     }
                 }
@@ -2749,7 +2749,7 @@ function fastLoop(){
         }
 
         Object.keys(job_desc).forEach(function (job){
-            if (job !== 'craftsman' && global.civic[job] && global.civic[job].workers < global.civic[job].assigned && global.civic[global.civic.d_job].workers > 0 && global.civic[job].workers < global.civic[job].max){
+            if (job !== 'craftsman' && global.civic[job] && global.civic[job].display && global.civic[job].workers < global.civic[job].assigned && global.civic[global.civic.d_job].workers > 0 && global.civic[job].workers < global.civic[job].max){
                 global.civic[job].workers++;
                 global.civic[global.civic.d_job].workers--;
             }
@@ -9258,7 +9258,7 @@ function midLoop(){
             if (global.civic[job].workers > global.civic[job].max && global.civic[job].max !== -1){
                 global.civic[job].workers = global.civic[job].max;
             }
-            else if (global.civic[job].workers < 0){
+            else if (!global.civic[job].display || global.civic[job].workers < 0){
                 global.civic[job].workers = 0;
             }
 
@@ -9714,6 +9714,7 @@ function midLoop(){
 
         if (global.race['kindling_kindred'] || global.race['smoldering']){
             global.civic.lumberjack.workers = 0;
+            global.civic.lumberjack.assigned = 0;
             global.resource.Lumber.crates = 0;
             global.resource.Lumber.containers = 0;
             global.resource.Lumber.trade = 0;

--- a/src/races.js
+++ b/src/races.js
@@ -4822,6 +4822,7 @@ function purgeLumber(){
     setPurgatory('tech','saw');
     global.civic.lumberjack.display = false;
     global.civic.lumberjack.workers = 0;
+    global.civic.lumberjack.assigned = 0;
     if (global.civic.d_job === 'lumberjack') {
         global.civic.d_job = global.race['carnivore'] || global.race['soul_eater'] ? 'hunter' : 'unemployed';
     }
@@ -5010,6 +5011,7 @@ function adjustFood() {
             }
             global.civic[jobEnabled[0]].workers += global.civic[job].workers;
             global.civic[job].workers = 0;
+            global.civic[job].assigned = 0;
             global.civic[job].display = false;
         }
     });
@@ -5079,6 +5081,7 @@ export function cleanAddTrait(trait){
             global.resource.Cement.display = false;
             global.civic.cement_worker.display = false;
             global.civic.cement_worker.workers = 0;
+            global.civic.cement_worker.assigned = 0;
             setPurgatory('tech','cement');
             setPurgatory('city','cement_plant');
             break;
@@ -5088,6 +5091,7 @@ export function cleanAddTrait(trait){
             }
             global.civic.quarry_worker.display = false;
             global.civic.quarry_worker.workers = 0;
+            global.civic.quarry_worker.assigned = 0;
             setResourceName('Stone');
             setPurgatory('tech','hammer');
             setPurgatory('city','rock_quarry');

--- a/src/vars.js
+++ b/src/vars.js
@@ -678,6 +678,7 @@ if (convertVersion(global['version']) < 100023){
             delete global.tech['axe']; delete global.tech['reclaimer']; delete global.tech['saw'];
             global.civic.lumberjack.display = false;
             global.civic.lumberjack.workers = 0;
+            global.civic.lumberjack.assigned = 0;
             if (global.civic.d_job === 'lumberjack') { global.civic.d_job = 'unemployed'; }
             if (global.race['casting']){
                 global.race.casting.total -= global.race.casting.lumberjack;


### PR DESCRIPTION
There have been reports that certain situations can cause workers to be stuck in limbo:
- Gaining the "Flier" trait via Mimic or Imitate when there are Cement Workers
- Quarry workers or other default jobs when impact occurs in Orbital Decay
- Possibly others...

This patch ensures that the the fastLoop does not set new workers on a job with "assigned" workers if the job is invisible and can no longer be fulfilled. It also adds some additional cases where the worker count for any invisible job is reset to 0, as a secondary protection. Finally, a few more cases where worker quantity is reset now also reset worker assignment to 0.