### PR TITLE
Highlight build queue on building mouseover

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5619,9 +5619,15 @@ export function setAction(c_action,action,type,old,prediction){
     popover(id,function(){ return undefined; },{
         in: function(obj){
             actionDesc(obj.popper,c_action,global[action][type],old,action,type);
+            $(`[id^=q${id}]`).each(function(){
+                $(this).addClass('hl-cna');
+            });
         },
         out: function(){
             vBind({el: `#popTimer`},'destroy');
+            $(`[id^=q${id}]`).each(function(){
+                $(this).removeClass('hl-cna');
+            });
         },
         attach: action === 'starDock' ? 'body .modal' : '#main',
         wide: c_action['wide']


### PR DESCRIPTION
When you go to add a building to the queue it can sometimes be hard to see if it's already there at a glance. This hopefully makes it easier.

![EvolveBuildQueueHighlight](https://github.com/pmotschmann/Evolve/assets/8031223/39fe4fd6-4456-4d36-9719-8ebfdd9c8a8a)
