### PR TITLE
Increase mercenary replenishment rate for high pop races

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10471,9 +10471,16 @@ function longLoop(){
             global.civic.garrison.protest--;
         }
 
-        let merc_bound = global.tech['mercs'] && global.tech['mercs'] >= 2 ? 3 : 4;
-        if (global.civic.garrison['m_use'] && global.civic.garrison.m_use > 0 && Math.rand(0,merc_bound) === 0){
-            global.civic.garrison.m_use--;
+        if (global.civic.garrison['m_use'] && global.civic.garrison.m_use > 0){
+            let merc_bound = global.tech['mercs'] && global.tech['mercs'] >= 2 ? 3 : 4;
+            let max_merc_roll = global.race['high_pop'] ? traits.high_pop.vars()[0] : 1;
+            let num_restore = 0;
+            for (let roll_num = 0; roll_num < max_merc_roll; roll_num++){
+                if (Math.rand(0, merc_bound) === 0){
+                    num_restore++;
+                }
+            }
+            global.civic.garrison.m_use = Math.max(0, global.civic.garrison.m_use - num_restore);
         }
 
         if (global.race['rainbow_active'] && global.race['rainbow_active'] > 1){


### PR DESCRIPTION
The exponential cost base for mercenaries is 1.1 for all races, regardless of high population scaling. This causes mercenaries to be extremely difficult to use on high population races, where the exponential cost increase is far greater than for normal races.

This patch multiplies the number of dice rolls to replenish the mercenary pool by the high population scaling factor. For example, with rank 1 high population (4x), the mercenary pool attempts to replenish up to 4 times per game day.

I tested with a random insect pillar save and quickly observed that multiple mercenaries could be replenished in one game day (depending on random number generation).