### PR TITLE
Fix Cataclysm scenario iridium mine production to reflect tooltip value

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5987,7 +5987,7 @@ function fastLoop(){
 
             if (global.race['cataclysm'] && support_on['iridium_mine']){
                 coal_base = support_on['iridium_mine'] * production('iridium_mine','coal');
-                coal_base *= global.civic.coal_miner.impact * production('psychic_boost','Coal');
+                coal_base *= production('psychic_boost','Coal');
                 breakdown.p['Coal'][loc('space_moon_iridium_mine_title')] = coal_base + 'v';
                 if (coal_base > 0){
                     breakdown.p['Coal'][`ᄂ${loc('space_red_ziggurat_title')}`] = ((zigVal - 1) * 100) + '%';


### PR DESCRIPTION
`global.civic.coal_miner.impact` is always 0.2 and is affecting iridium mine production of coal even though there are no coal miners in the scenario.

Resolves #1138 