### PR TITLE
Fix broken pageload after starting Cataclysm from Dial it to 11

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -1189,7 +1189,7 @@ if (convertVersion(global['version']) < 103011){
 }
 
 if (convertVersion(global['version']) < 103014){
-    if (global.race['cataclysm']){
+    if (global.race['cataclysm'] && !global.race['start_cataclysm']){
         global.civic.craftsman.display = true;
     }
     if (global.race['lone_survivor'] && ((global.tauceti['tau_factory'] && global.tauceti.tau_factory.count > 0) || (global.tauceti['womling_station'] && global.tauceti.womling_station.count > 0))){


### PR DESCRIPTION
#1154 added upgrade code to set `global.civic.craftsman.display = true` on old savegames inside Cataclysm. But this causes problems when that code runs on a page loaded immediately after "Dial it to 11", since that is considered to be inside Cataclysm, but global.civic isn't initialized yet.

This causes an error and causes the game to fail to load completely (white screen) and can only be worked around by deleting the savegame using browser devtools/etc.

![image](https://github.com/user-attachments/assets/bbe26b63-c8ee-4b81-ac2f-7a6d3f167295)

Since uninitialized saves with `start_cataclysm` active still have to be initialized, it's safe to skip that upgrade code. Tested by loading a pre-1.3.13a save inside Cata and doing a Dial to 11 (also checked to make sure crafting works).