### PR TITLE
Remove manual crafting cost discount from High Pop

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -17,7 +17,8 @@ export function enableDebug(){
             races: deepClone(races),
             traits: deepClone(traits),
             tradeRatio: deepClone(tradeRatio),
-            craftCost: deepClone(craftCost()),
+            craftCost: deepClone(craftCost(false)),
+            craftCostManual: deepClone(craftCost(true)),
             atomic_mass: deepClone(atomic_mass),
             f_rate: deepClone(f_rate),
             checkAffordable: deepClone(checkAffordable),
@@ -41,7 +42,8 @@ export function enableDebug(){
 export function updateDebugData(){
     if (global.settings.expose){
         window.evolve.global = deepClone(global);
-        window.evolve.craftCost = deepClone(craftCost()),
+        window.evolve.craftCost = deepClone(craftCost(false)),
+        window.evolve.craftCostManual = deepClone(craftCost(true)),
         window.evolve.breakdown = deepClone(breakdown);
     }
 }

--- a/src/debug.js
+++ b/src/debug.js
@@ -17,8 +17,7 @@ export function enableDebug(){
             races: deepClone(races),
             traits: deepClone(traits),
             tradeRatio: deepClone(tradeRatio),
-            craftCost: deepClone(craftCost(false)),
-            craftCostManual: deepClone(craftCost(true)),
+            craftCost: deepClone(craftCost(true)),
             atomic_mass: deepClone(atomic_mass),
             f_rate: deepClone(f_rate),
             checkAffordable: deepClone(checkAffordable),
@@ -43,7 +42,6 @@ export function updateDebugData(){
     if (global.settings.expose){
         window.evolve.global = deepClone(global);
         window.evolve.craftCost = deepClone(craftCost(false)),
-        window.evolve.craftCostManual = deepClone(craftCost(true)),
         window.evolve.breakdown = deepClone(breakdown);
     }
 }

--- a/src/debug.js
+++ b/src/debug.js
@@ -41,7 +41,7 @@ export function enableDebug(){
 export function updateDebugData(){
     if (global.settings.expose){
         window.evolve.global = deepClone(global);
-        window.evolve.craftCost = deepClone(craftCost(false)),
+        window.evolve.craftCost = deepClone(craftCost(true)),
         window.evolve.breakdown = deepClone(breakdown);
     }
 }

--- a/src/resources.js
+++ b/src/resources.js
@@ -168,7 +168,7 @@ export const supplyValue = {
     Scarletite: { in: 35, out: 250 }
 };
 
-export function craftCost(){
+export function craftCost(manual=false){
     let costs = {
         Plywood: [{ r: 'Lumber', a: 100 }],
         Brick: global.race['flier'] ? [{ r: 'Stone', a: 60 }] : [{ r: 'Cement', a: 40 }],
@@ -189,7 +189,7 @@ export function craftCost(){
             }
         });
     }
-    if (global.race['high_pop']){
+    if (global.race['high_pop'] && !manual){
         let rate = 1 / traits.high_pop.vars()[0];
         Object.keys(costs).forEach(function(res){
             for (let i=0; i<costs[res].length; i++){
@@ -873,7 +873,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
             craft(res,vol){
                 if (!global.race['no_craft']){
                     let craft_bonus = craftingRatio(res,'manual').multiplier;
-                    let craft_costs = craftCost();
+                    let craft_costs = craftCost(true);
                     let volume = Math.floor(global.resource[craft_costs[res][0].r].amount / craft_costs[res][0].a);
                     for (let i=1; i<craft_costs[res].length; i++){
                         let temp = Math.floor(global.resource[craft_costs[res][i].r].amount / craft_costs[res][i].a);
@@ -896,7 +896,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
             },
             craftCost(res,vol){
                 let costs = '';
-                let craft_costs = craftCost();
+                let craft_costs = craftCost(true);
                 for (let i=0; i<craft_costs[res].length; i++){
                     let num = vol * craft_costs[res][i].a * keyMultiplier();
                     costs = costs + `<div>${global.resource[craft_costs[res][i].r].name} ${num}</div>`;
@@ -918,7 +918,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
                 let bonus = +(craftingRatio(res,'manual').multiplier * 100).toFixed(0);
                 popper.append($(`<div class="has-text-info">${loc('manual_crafting_hover_bonus',[bonus.toLocaleString(),global.resource[res].name])}</div>`));
                 
-                let craft_costs = craftCost();
+                let craft_costs = craftCost(true);
                 let crafts = $(`<div><span class="has-text-success">${loc('manual_crafting_hover_craft')} </span></div>`);
                 let num_crafted = 0;
                 if (typeof vol !== 'number'){


### PR DESCRIPTION
High Population scales the cost of crafting input materials based on the population ratio. This patch retains the discount for automatic crafting while removing it for manual crafting. I did some cursory tests to see that it works.

Based on other feedback, the debug data table for scripts uses the newly updated manual crafting cost, not the unchanged automatic crafting cost.