### PR TITLE
Fix support calculation for gateway and remove fractional ships

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2312,8 +2312,10 @@ function fastLoop(){
                 if (global.galaxy[gateway_structs[i]]){
                     let operating = global.galaxy[gateway_structs[i]].on;
                     let id = actions.galaxy.gxy_gateway[gateway_structs[i]].id;
-                    if (used_support + operating > global.galaxy.starbase.s_max){
-                        operating -= (used_support + operating) - global.galaxy.starbase.s_max;
+                    let operating_cost = -(actions.galaxy.gxy_gateway[gateway_structs[i]].support());
+                    let max_operating = Math.floor((global.galaxy.starbase.s_max - used_support) / operating_cost);
+                    if (operating > max_operating){
+                        operating = max_operating;
                         $(`#${id} .on`).addClass('warn');
                         $(`#${id} .on`).prop('title',`ON ${operating}/${global.galaxy[gateway_structs[i]].on}`);
                     }
@@ -2321,7 +2323,7 @@ function fastLoop(){
                         $(`#${id} .on`).removeClass('warn');
                         $(`#${id} .on`).prop('title',`ON`);
                     }
-                    used_support += operating * -(actions.galaxy.gxy_gateway[gateway_structs[i]].support());
+                    used_support += operating * operating_cost;
                     gal_on[gateway_structs[i]] = operating;
                 }
                 else {


### PR DESCRIPTION
The support calculation for Andromeda ships in the Gateway system incorrectly provided too much support in cases when the lowest-priority ship receiving support was a Frigate, Cruiser, or Dreadnought.

For example, suppose that the Gateway System has 32.5 support and the following ships activated: 31 Bolognium Ship > 6 Dreadnought > 5 Cruiser Ship > 2 Frigate Ship

In this situation, we expect 31 Bolognium Ships (31 support), 0.3 Dreadnoughts (1.5 support), 0 Cruiser Ships, and 0 Frigate Ships to operate.

Actually, the game operates 31 Bolognium Ships (correct), 1.5 Dreadnoughts (too many), 0 Cruiser Ships, and 2 Frigate Ships. This is a total of 31 + 7.5 + 4 = 42.5 Gateway support. It prints that only 24.5 / 32.50 support is in use.

Fixing this issue causes some ugly rounding problems with fractional ships, especially in relationship to Cruiser Ships (3 support) that are being moved around. I chose to remove fractional ship support as part of the patch.

If we want to keep fractional ships, then fixing all of the rounding issues is probably feasible.