### PR TITLE
Check fuel usage for ships still en route to Ceres

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3705,7 +3705,7 @@ function fastLoop(){
                 Elerium: 0
             };
             global.space.shipyard.ships.forEach(function(ship){
-                if (ship.location !== 'spc_dwarf'){
+                if (ship.location !== 'spc_dwarf' || ship.transit !== 0){
                     let fuel = shipFuelUse(ship);
                     if (fuel.res && fuel.burn > 0){
                         if (fuel.burn * time_multiplier < global.resource[fuel.res].amount + (global.resource[fuel.res].diff > 0 ? global.resource[fuel.res].diff * time_multiplier : 0)){


### PR DESCRIPTION
Ships that are traveling to Ceres are treated as if they have already arrived, so they do not consume fuel or check whether fuel is available. Update the shipyard fuel check to include both location (Ceres) and remaining travel time (0) before skipping past the ship.

User-provided testcase from Discord attached. Many ships are traveling to Ceres, but the ones that require Helium-3 were out of fuel at some point (probably when they were redirected to Ceres), and they never check for fuel again, so they are stuck in place.

[evolve-2024-08-17-08-29.txt](https://github.com/user-attachments/files/16643912/evolve-2024-08-17-08-29.txt)
