### PR TITLE
Fix accidentally swapped Scientist/Wizard text

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3953,10 +3953,10 @@ function fastLoop(){
 
             breakdown.p['Knowledge'][loc('job_professor')] = professors_base + 'v';
             if (global.race.universe === 'magic'){
-                breakdown.p['Knowledge'][loc('job_scientist')] = scientist_base + 'v';
+                breakdown.p['Knowledge'][loc('job_wizard')] = scientist_base + 'v';
             }
             else {
-                breakdown.p['Knowledge'][loc('job_wizard')] = scientist_base + 'v';
+                breakdown.p['Knowledge'][loc('job_scientist')] = scientist_base + 'v';
             }
             breakdown.p['Knowledge'][loc('tau_red_womlings')] = womling + 'v';
             breakdown.p['Knowledge'][loc('hunger')] = ((hunger - 1) * 100) + '%';


### PR DESCRIPTION
One of the changes in #1123 was to add a switch between "Scientist" and "Wizard" in the Knowledge gain breakdown. Unfortunately the strings are reversed. This patch uses the correct string in each universe.