### PR TITLE
Fix interstellar industrial powerup assignments

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -1,4 +1,4 @@
-import { global, save, webWorker } from './vars.js';
+import { global, save, webWorker, p_on } from './vars.js';
 import { loc } from './locale.js';
 import { vBind, clearElement, calcQueueMax, calcRQueueMax, calcPrestige, messageQueue, clearPopper, popCost } from './functions.js';
 import { unlockAchieve, alevel, universeAffix, unlockFeat } from './achieve.js';
@@ -1499,6 +1499,12 @@ const techs = {
         effect: loc('tech_stellar_smelting_effect'),
         action(){
             if (payCosts($(this)[0])){
+                let num_forge_on = p_on['stellar_forge'];
+                let num_new_smelters = num_forge_on * 2;
+                global.city.smelter.cap += num_new_smelters;
+                global.city.smelter.Star += num_new_smelters;
+                global.city.smelter.StarCap += num_new_smelters;
+                global.city.smelter.Iron += num_new_smelters;
                 return true;
             }
             return false;


### PR DESCRIPTION
- When researching Stellar Smelting, automatically enable Star smelters
- When disassembling the Explorer Ship, assign 8 Pit Miners and not only 4
- Automatically staff new Mining Pits
- When building and powering a High-Tech Factory, set 3 new Alloys lines
- When building and powering an Ore Refinery, set the proper number of new smelters when not isolated (4 rather than 2)