### PR TITLE
Increase visibility of information about time until black hole is corrupted

### DIFF
--- a/src/wiki/mechanics.js
+++ b/src/wiki/mechanics.js
@@ -1982,7 +1982,7 @@ function quantumLevelCalc(info){
     });
 }
 
-function massCalc(info){
+export function massCalc(info){
     let calc = $(`<div class="calc" id="massCalc"></div>`);
     info.append(calc);
     

--- a/src/wiki/resets.js
+++ b/src/wiki/resets.js
@@ -2,6 +2,7 @@ import { loc } from './../locale.js';
 import { universe_types } from './../space.js';
 import { infoBoxBuilder, sideMenu, createCalcSection } from './functions.js';
 import { prestigeCalc } from './p_res.js';
+import { massCalc } from './mechanics.js';
 
 export function resetsPage(content){
     let mainContent = sideMenu('create',content);
@@ -86,10 +87,12 @@ export function resetsPage(content){
             10: ['warning','plain']
         }
     });
-    section = createCalcSection(section,'bigbang','gain');
-    prestigeCalc(section,'plasmid',false,'bigbang');
-    prestigeCalc(section,'phage',false,'bigbang');
-    prestigeCalc(section,'dark',false,'bigbang');
+    let subSection = createCalcSection(section,'bigbang','gain');
+    prestigeCalc(subSection,'plasmid',false,'bigbang');
+    prestigeCalc(subSection,'phage',false,'bigbang');
+    prestigeCalc(subSection,'dark',false,'bigbang');
+    subSection = createCalcSection(section,'eject','mass');
+    massCalc(subSection);
     sideMenu('add',`resets-prestige`,'blackhole',loc('wiki_resets_blackhole'));
 
     // Vacuum Collapse


### PR DESCRIPTION
I have observed that many players are confused about how long it will take them to reach the reset condition for the Black Hole reset (0.025 solar masses of exotic matter), even when they are aware of what the reset condition may be.

Even players who use the in-game wiki tend not to notice that there is a mass ejector calculator in Gameplay > Mechanics, or that there is a detailed description in the FAQ.

In order to alleviate this confusion:
1. Add another instance of the mass ejection calculator to Resets > Black Hole on the wiki.
2. For players who have ever performed a black hole reset (`global.stats.blackhole != 0`), display the time to 0.025 solar masses of exotic matter directly in the Mass Ejector description. The time is not displayed while in the Magic universe. Existing text from the wiki is used to avoid creating new strings. The remaining time is always shown on the wiki view, even for first-timers.