### PR TITLE
Fixed unlock Secret to Immortality

### DIFF
--- a/src/resets.js
+++ b/src/resets.js
@@ -639,6 +639,9 @@ export function descension(){
         if (affix !== 'm' && affix !== 'l'){
             global.stats['endless_hunger'].b5.l = true;
         }
+        if (global.stats.starved == 0){
+            unlockFeat('immortal');
+        }
     }
     if (races[global.race.species].type === 'angelic'){
         unlockFeat('twisted');


### PR DESCRIPTION
The code to check and unlock the feat Secret to Immortality was missing in the descension reset.