### PR TITLE
Fix a LS knowledge exploit

### DIFF
--- a/src/truepath.js
+++ b/src/truepath.js
@@ -5338,8 +5338,8 @@ export function loneSurvivor(){
         global.resource.Containers.amount = 1000;
         global.resource.Money.max = 1000000000;
         global.resource.Money.amount = 1000000000;
-        global.resource.Knowledge.max = 8000000;
-        global.resource.Knowledge.amount = 8000000;
+        global.resource.Knowledge.max = 4321200;
+        global.resource.Knowledge.amount = 4321200;
         global.resource.Food.max = 10000;
         global.resource.Food.amount = 10000;
         global.resource.Oil.max = 500000;


### PR DESCRIPTION
LS currently starts you with 8 million knowledge in the bank. The cap gets recalculated and excess lost the next time `midLoop()` runs, but if you're very fast or use a script, you can manage to research a tech before that happens, making it essentially free.

This PR sets the knowledge at the start to be the maximum you'd normally have (1000 base + 100000 LS + 3500000 outpost and +20% outpost). Ideally we'd recalculate as soon as the game starts, but that turned out to be pretty involved because `midLoop()` also handles other things, so I opted for a simpler solution.

As far as I can see the only thing that affects the cap is Logical, which in LS gives you whopping 525 knowledge cap, so the cap is effectively the same in every LS game.