### PR TITLE
Fix scientific notation; use locale number formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -206,6 +206,8 @@ export function mainVue(){
                         return loc(`metric`);
                     case 'sci':
                         return loc(`scientific`);
+                    case 'eng':
+                        return loc(`engineering`);
                     case 'sln':
                         return loc(`sln`);
                 }
@@ -1277,6 +1279,7 @@ export function index(){
                 </button>
                 <b-dropdown-item v-on:click="numNotation('si')">{{ 'metric' | label }}</b-dropdown-item>
                 <b-dropdown-item v-on:click="numNotation('sci')">{{ 'scientific' | label }}</b-dropdown-item>
+                <b-dropdown-item v-on:click="numNotation('eng')">{{ 'engineering' | label }}</b-dropdown-item>
                 <b-dropdown-item v-on:click="numNotation('sln')">{{ 'sln' | label }}</b-dropdown-item>
                 ${hideTreat}
             </b-dropdown>

--- a/src/portal.js
+++ b/src/portal.js
@@ -4749,13 +4749,6 @@ function drawHellAnalysis(){
         }
     });
     
-    let expandedLocaleNum = function(num,sigFigs){
-        num = num.toFixed(sigFigs);
-        let whole = Math.floor(num);
-        let decimals = (+(num - whole).toFixed(sigFigs)).toString().substring(1);
-        return whole.toLocaleString() + decimals;
-    };
-    
     let calcAverage = function(num,gameDays,units){
         if (num){
             if (units !== 'game_days' && global.portal.observe.settings.hyperSlow){
@@ -4783,7 +4776,7 @@ function drawHellAnalysis(){
                 default:
                     break;
             }
-            num = global.portal.observe.settings.expanded ? expandedLocaleNum(num,5) : sizeApproximation(num,5,true);
+            num = sizeApproximation(num, 5, global.portal.observe.settings.expanded);
         }
         return loc('hell_analysis_time_average',[num,loc(`hell_analysis_time_${units}_abbr`)])
     };
@@ -4856,13 +4849,15 @@ function drawHellAnalysis(){
             filters: {
                 generic(num, name, average){
                     if (!average){
-                        return loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),global.portal.observe.settings.expanded ? (+(num).toFixed(5)).toLocaleString() : sizeApproximation(num,5,true)]);
+                        let val = sizeApproximation(num, 5, global.portal.observe.settings.expanded);
+                        return loc('hell_analysis_number_display', [loc(`hell_analysis_${name}`), val]);
                     }
                     return loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),calcAverage(num,global.portal.observe.stats[type].days,global.portal.observe.settings.display)]);
                 },
                 genericSub(num, name, average){
                     if (!average){
-                        return 'ᄂ' + loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),global.portal.observe.settings.expanded ? (+(num).toFixed(5)).toLocaleString() : sizeApproximation(num,5,true)]);
+                        let val = sizeApproximation(num, 5, global.portal.observe.settings.expanded);
+                        return 'ᄂ' + loc('hell_analysis_number_display', [loc(`hell_analysis_${name}`), val]);
                     }
                     return 'ᄂ' + loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),calcAverage(num,global.portal.observe.stats[type].days,global.portal.observe.settings.display)]);
                 },
@@ -4872,7 +4867,8 @@ function drawHellAnalysis(){
                         num += group[type];
                     });
                     if (!average){
-                        return loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),global.portal.observe.settings.expanded ? (+(num).toFixed(5)).toLocaleString() : sizeApproximation(num,5,true)]);
+                        let val = sizeApproximation(num, 5, global.portal.observe.settings.expanded);
+                        return loc('hell_analysis_number_display', [loc(`hell_analysis_${name}`), val]);
                     }
                     return loc('hell_analysis_number_display',[loc(`hell_analysis_${name}`),calcAverage(num,global.portal.observe.stats[type].days,global.portal.observe.settings.display)]);
                 },
@@ -4901,7 +4897,8 @@ function drawHellAnalysis(){
                         default:
                             break;
                     }
-                    return loc('hell_analysis_time',[loc(`hell_analysis_time_${units}`),global.portal.observe.settings.expanded ? expandedLocaleNum(days,8) : sizeApproximation(days,5,true)]);
+                    let formattedTime = sizeApproximation(days, global.portal.observe.settings.expanded ? 8 : 5, global.portal.observe.settings.expanded);
+                    return loc('hell_analysis_time', [loc(`hell_analysis_time_${units}`), formattedTime]);
                 },
                 resetLabel(){
                     return loc('hell_analysis_period_reset');

--- a/src/resources.js
+++ b/src/resources.js
@@ -1174,12 +1174,12 @@ function loadSpecialResource(name,color) {
 
     var res_container = $(`<div id="res${name}" class="resource" v-show="count"><span class="res has-text-${color}">${loc(`resource_${name}_name`)}</span><span class="count">{{ count | round }}</span></div>`);
     $('#resources').append(res_container);
-    
+
     vBind({
         el: `#res${name}`,
         data: global.prestige[name],
         filters: {
-            round(n){ return +(n).toFixed(3); }
+            round(n){ return n ? sizeApproximation(n, 3, false, true) : n; }
         }
     });
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -2058,9 +2058,9 @@ export function sizeApproximation(value, precision = 1, precise = false, exact =
     else if (oom < 4 || precise){
         // The objective here is to provide high precision for both large and small numbers,
         // while preventing excess precision for large numbers that also have many fractional digits.
-        let maxSigFigs = Math.max(oom + 1,      // Full precision for the integer component of large numbers (at least 1e4)
-                                  precision,    // Requested precision for fractions less than 1
-                                  5);           // Always allow 5 sigfigs, not only 4, for numbers where 1e3 <= x < 1e4
+        let maxSigFigs = Math.max(oom + 1,          // Full precision for the integer component of large numbers (at least 1e4)
+                                  precision + 1,    // Requested precision for values with only 1 leading digit
+                                  5);               // Always allow 5 sigfigs, not only 4, for numbers where 1e3 <= x < 1e4
         return value.toLocaleString(undefined, {maximumSignificantDigits: maxSigFigs, maximumFractionDigits: precision, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
     }
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -2067,13 +2067,14 @@ export function sizeApproximation(value, precision = 1, precise = false, exact =
     else {
         const oomMod3 = oom % 3;
         const dispShort = oom === 4; // Reduce significant figures from 4 to 3 for numbers below 100,000
+        const forceSI = global.settings.affix !== 'eng' && oom >= 27;
         // Reduce displayed order of magnitude to the nearest multiple of 3, except for SI mode
-        if (global.settings.affix !== 'sci'){
+        if (global.settings.affix !== 'sci' && !forceSI){
             oom -= oomMod3;
         }
 
         let affix;
-        if (global.settings.affix === 'sci' || global.settings.affix === 'eng' || oom >= 27){
+        if (global.settings.affix === 'sci' || global.settings.affix === 'eng' || forceSI){
             // Manually build SI suffix to guarantee that the 'e' is lowercase for aesthetic preference
             affix = 'e' + oom;
         } else {

--- a/src/vars.js
+++ b/src/vars.js
@@ -2024,7 +2024,7 @@ var affix_list = {
     sln: ['K','M','B','t','q','Q','s','S']
 };
 // Number formatting options, in the user's default locale
-var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, minimumSignificantDigits: 3, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
+var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, minimumSignificantDigits: 3, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 
 /**

--- a/src/vars.js
+++ b/src/vars.js
@@ -2060,7 +2060,7 @@ export function sizeApproximation(value, precision = 1, precise = false, exact =
         // while preventing excess precision for large numbers that also have many fractional digits.
         let maxSigFigs = Math.max(oom + 1,          // Full precision for the integer component of large numbers (at least 1e4)
                                   precision + 1,    // Requested precision for values with only 1 leading digit
-                                  5);               // Always allow 5 sigfigs, not only 4, for numbers where 1e3 <= x < 1e4
+                                  5);               // Always allow 5 sigfigs, not only 4, for numbers where 1e2 <= x < 1e4
         return value.toLocaleString(undefined, {maximumSignificantDigits: maxSigFigs, maximumFractionDigits: precision, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
     }
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -2025,7 +2025,7 @@ var affix_list = {
 };
 // Number formatting options, in the user's default locale
 var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
-var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, minimumSignificantDigits: 3, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
+var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 
 /**
  * Return a locale-dependent string that represents the significance of the input value.

--- a/src/vars.js
+++ b/src/vars.js
@@ -2021,59 +2021,74 @@ export function resizeGame(){
 
 var affix_list = {
     si: ['K','M','G','T','P','E','Z','Y'],
-    sci: ['e3','e6','e9','e12','e15','e18','e21','e24'],
     sln: ['K','M','B','t','q','Q','s','S']
 };
+// Number formatting options, in the user's default locale
+var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, minimumSignificantDigits: 3, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
+var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, minimumSignificantDigits: 3, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 
-export function sizeApproximation(value,precision,fixed){
-    let result = 0;
-    let affix = '';
-    let neg = value < 0 ? true : false;
-    if (neg){
-        value *= -1;
+/**
+ * Return a locale-dependent string that represents the significance of the input value.
+ * Numbers are typically represented with 3 or 4 significant figures.
+ * Abbreviations are not applied to numbers less than 10,000.
+ *
+ * All input values are truncated toward 0 when precision reduction is required.
+ * Trailing fractional zeroes are never printed, regardless of the apparent significant figure requirement.
+ *
+ * @arg {Number} value - The value to format
+ * @arg {Number} precision - The maximum number of fractional digits to display
+ * @arg {Boolean} precise - Do not apply abbreviation and display all integer significant figures in the value.
+ * @arg {Boolean} exact - Do not apply abbreviation and display all significant figures in the value.
+ * @return {String}
+ */
+export function sizeApproximation(value, precision = 1, precise = false, exact = false){
+    const absValue = Math.abs(value);
+    let oom = Math.floor(Math.log10(absValue));
+
+    // Exact mode:
+    //  The number of significant figures is not limited in any way.
+    //  The number of fractional digits is limited by the precision argument.
+    if (exact){
+        return value.toLocaleString(undefined, {maximumFractionDigits: precision, roundingMode: 'trunc'});
     }
-    if (value <= 9999){
-        result = +value.toFixed(precision);
+
+    // Fixed mode:
+    //  The number of significant figures is at least 5, but may increase for large values.
+    //  The number of fractional digits is limited by the precision argument, but may be reduced for large values.
+    else if (oom < 4 || precise){
+        // The objective here is to provide high precision for both large and small numbers,
+        // while preventing excess precision for large numbers that also have many fractional digits.
+        let maxSigFigs = Math.max(oom + 1,      // Full precision for the integer component of large numbers (at least 1e4)
+                                  precision,    // Requested precision for fractions less than 1
+                                  5);           // Always allow 5 sigfigs, not only 4, for numbers where 1e3 <= x < 1e4
+        return value.toLocaleString(undefined, {maximumSignificantDigits: maxSigFigs, maximumFractionDigits: precision, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
     }
-    else if (value < 1000000){
-        affix = affix_list[global.settings.affix][0];
-        result = fixed ? +(value / 1000).toFixed(1) : (Math.floor(value / 100) / 10);
-    }
-    else if (value < 1000000000){
-        affix = affix_list[global.settings.affix][1];
-        result = fixed ? +(value / 1000000).toFixed(1) : (Math.floor(value / 10000) / 100);
-    }
-    else if (value < 1000000000000){
-        affix = affix_list[global.settings.affix][2];
-        result = fixed ? +(value / 1000000000).toFixed(1) : (Math.floor(value / 10000000) / 100);
-    }
-    else if (value < 1000000000000000){
-        affix = affix_list[global.settings.affix][3];
-        result = fixed ? +(value / 1000000000000).toFixed(1) : (Math.floor(value / 10000000000) / 100);
-    }
-    else if (value < 1000000000000000000){
-        affix = affix_list[global.settings.affix][4];
-        result = fixed ? +(value / 1000000000000000).toFixed(1) : (Math.floor(value / 10000000000000) / 100);
-    }
-    else if (value < 1000000000000000000000){
-        affix = affix_list[global.settings.affix][5];
-        result = fixed ? +(value / 1000000000000000000).toFixed(1) : (Math.floor(value / 10000000000000000) / 100);
-    }
-    else if (value < 1000000000000000000000000){
-        affix = affix_list[global.settings.affix][6];
-        result = fixed ? +(value / 1000000000000000000000).toFixed(1) : (Math.floor(value / 10000000000000000000) / 100);
-    }
+
     else {
-        affix = affix_list[global.settings.affix][7];
-        result = fixed ? +(value / 1000000000000000000000000).toFixed(1) : (Math.floor(value / 10000000000000000000000) / 100);
+        const oomMod3 = oom % 3;
+        const dispShort = oom === 4; // Reduce significant figures from 4 to 3 for numbers below 100,000
+        // Reduce displayed order of magnitude to the nearest multiple of 3, except for SI mode
+        if (global.settings.affix !== 'sci'){
+            oom -= oomMod3;
+        }
+
+        let affix;
+        if (global.settings.affix === 'sci' || global.settings.affix === 'eng' || oom >= 27){
+            // Manually build SI suffix to guarantee that the 'e' is lowercase for aesthetic preference
+            affix = 'e' + oom;
+        } else {
+            // Get the string suffix from the configured lookup table
+            affix = affix_list[global.settings.affix][(oom / 3) - 1];
+        }
+
+        value /= (10**oom);
+
+        if (dispShort){
+            return numFormatShort.format(value) + affix;
+        } else {
+            return numFormatLong.format(value) + affix;
+        }
     }
-    if (result >= 100){
-        result = +result.toFixed(1);
-    }
-    if (neg){
-        result *= -1;
-    }
-    return result + affix;
 }
 
 $(window).resize(function(){

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -85,6 +85,7 @@
   "units": "Number Notation",
   "metric": "Metric",
   "scientific": "Scientific",
+  "engineering": "Engineering",
   "sln": "Single Letter",
   "font": "Font Size",
   "standard": "Standard",


### PR DESCRIPTION
Evolve's default number display mode, SI, is actually engineering notation, because it uses only exponents that are multiples of 3. In addition, it can't handle exponents larger than 27.

Fix these deficiencies:
- Change scientific notation to use any integer exponent.
- Create a new engineering notation selection for users who like the current behavior.
- **See Comparison 1**

For quite large numbers (1e27 and larger), metric suffixes become inadequate.
- Numbers 1e27 or larger use SI instead of a suffix.
- **See Comparison 3**

The display precision of numbers with whole components currently follows a somewhat curious trend, likely for aesthetic purposes. Minor modifications are made, especially for values in the `e2` order of magnitude.
- Numbers `x < 10` permit 2+ fractional digits (3+ significant figures) when `precision` is 2 or more
- Numbers `10 <= x < 100` permit 2+ fractional digits (4+ significant figures) when `precision` is 2 or more
- Numbers `100 <= x < 1000` permit just 1 fractional digit (4 significant figures), even if `precision` is 2 or more. **This commit removes the limitation at this order of magnitude. See Comparison 1.**
- Numbers `1000 <= x < 10000` usually permit 1 fractional digit (5 significant figures), but could provide more when `precision` is 2 or more.
- Numbers `10000 <= x < 100000` are abbreviated with 1 fractional digit (3 significant figures). **(Now removed) When `precision` is greater than 0, a trailing zero may now be displayed. For example, `45,000` may be formatted as `45.0K`**.
- Numbers `100000 <= x < 1e6` are abbreviated with 1 fractional digit (4 significant figures)
- Numbers `1e6 <= x < 1e7` are abbreviated with 2 fractional digits (3 significant figures)
- Numbers `1e7 <= x < 1e8` are abbreviated with 2 fractional digits (3 significant figures)
- The preceding 3 lines repeat for all subsequent orders of magnitude up to `e26`
- Trailing zeroes are quite rare at higher orders of magnitude, but could appear in cases where displayed precision was lower than 3 digits.

Locale-aware number formatting is available in Hell observation statistics, but absent in the rest of the game. This is a good opportunity to provide locale-aware number formatting to more places.
- Use locale-aware formatting in sizeApproximation()
- Change "fixed" (always 1 fractional digit mode) to "precise", which enforces a minimum precision and displays at least all integer digits. This mode is used only for Hell observations.
- Add new "exact" parameter that forces all fractional digits to display, even if the number gets really big. This is now used for prestige resource counts.
- **See Comparison 2**

## Comparison 1
Before (scientific):
![image](https://github.com/user-attachments/assets/f1a39c3e-d10d-49bf-8dd0-36575f16cd08)
After (scientific):
![image](https://github.com/user-attachments/assets/899b0906-ca76-4713-ba1e-a4bf499324df)
After (engineering):
![image](https://github.com/user-attachments/assets/7501b264-0b0a-435e-bbd9-c23a58b23827)

## Comparison 2
Before:
![image](https://github.com/user-attachments/assets/0f139179-65f4-4d76-877f-d72cd77ea2c1)
After:
![image](https://github.com/user-attachments/assets/723eb696-fac6-4d93-9678-0100f8bc1986)

## Comparison 3
Before:
![image](https://github.com/user-attachments/assets/5def583a-bd47-45ab-b41b-c5317adacfc5)
After:
![image](https://github.com/user-attachments/assets/11e03d49-3e61-4606-87df-d88a6c7f9ce6)