### PR TITLE
Fix floating point rounding issues

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -2042,8 +2042,13 @@ var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, 
  * @return {String}
  */
 export function sizeApproximation(value, precision = 1, precise = false, exact = false){
-    const absValue = Math.abs(value);
+    let absValue = Math.abs(value);
     let oom = Math.floor(Math.log10(absValue));
+
+    // Add a few ULP of magnitude to all numbers to avoid rounding issues
+    absValue += 10**(oom-15);
+    // Explicitly avoid adding anything to either -0 or +0 to avoid altering the sign
+    value = value<0 ? -absValue : value>0 ? absValue : value;
 
     // Exact mode:
     //  The number of significant figures is not limited in any way.

--- a/src/vars.js
+++ b/src/vars.js
@@ -2027,7 +2027,7 @@ var affix_list = {
 var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 // Constant value that is used frequently
-const ADD_4_ULP = 1 + (4 * Number.EPSILON);
+const ADD_16_ULP = 1 + (16 * Number.EPSILON);
 
 /**
  * Return a locale-dependent string that represents the significance of the input value.
@@ -2047,8 +2047,8 @@ export function sizeApproximation(value, precision = 1, precise = false, exact =
     let absValue = Math.abs(value);
     let oom = Math.floor(Math.log10(absValue));
 
-    // Increase magnitude of all numbers by 4 to 8 ULP to avoid rounding issues
-    absValue *= ADD_4_ULP;
+    // Increase magnitude of all numbers by 16 to 32 ULP to avoid rounding issues
+    absValue *= ADD_16_ULP;
     // Explicitly avoid adding anything to either -0 or +0 to avoid altering the sign
     value = value<0 ? -absValue : value>0 ? absValue : value;
 

--- a/src/vars.js
+++ b/src/vars.js
@@ -2026,6 +2026,8 @@ var affix_list = {
 // Number formatting options, in the user's default locale
 var numFormatShort = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 3, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
 var numFormatLong = new Intl.NumberFormat(undefined, {maximumFractionDigits: 2, maximumSignificantDigits: 4, roundingMode: 'trunc', roundingPriority: 'lessPrecision'});
+// Constant value that is used frequently
+const ADD_4_ULP = 1 + (4 * Number.EPSILON);
 
 /**
  * Return a locale-dependent string that represents the significance of the input value.
@@ -2045,8 +2047,8 @@ export function sizeApproximation(value, precision = 1, precise = false, exact =
     let absValue = Math.abs(value);
     let oom = Math.floor(Math.log10(absValue));
 
-    // Add a few ULP of magnitude to all numbers to avoid rounding issues
-    absValue += 10**(oom-15);
+    // Increase magnitude of all numbers by 4 to 8 ULP to avoid rounding issues
+    absValue *= ADD_4_ULP;
     // Explicitly avoid adding anything to either -0 or +0 to avoid altering the sign
     value = value<0 ? -absValue : value>0 ? absValue : value;
 


### PR DESCRIPTION
Change #1208 sometimes erroneously rounds down seemingly exact quantities due to floating point precision errors.

This change adds a few ULP ("units in the last place") of additional magnitude to the mantissa of numbers that are being formatted. The exact increase in ULP terms isn't controlled, because it's fewer lines of code this way.