### PR TITLE
Create Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *~
 *#
-.*
 update.*.json
 strings/last-strings.json
 node_modules/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=$BUILDPLATFORM node:20-alpine as builder
+
+WORKDIR /app
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+FROM nginx:1.27.1-alpine3.20-slim
+
+COPY --from=builder /app/lib/ /usr/share/nginx/html/lib/
+COPY --from=builder /app/font/ /usr/share/nginx/html/font/
+COPY --from=builder /app/evolved.ico /app/evolved-light.ico /usr/share/nginx/html/
+COPY --from=builder /app/index.html /app/save.html /app/wiki.html /usr/share/nginx/html/
+COPY --from=builder /app/strings/ /usr/share/nginx/html/strings/
+COPY --from=builder /app/evolve/ /usr/share/nginx/html/evolve/
+


### PR DESCRIPTION
This PR creates a Dockerfile that will build an image that will run evolve as a static page.

Docker file is platform-agnostic, as all of the base images are dockerhub library images and promised to be available for all supported platforms. It built well on my machine for both amd64 arch and armhf. Versions of the images are not precisely locked, as builder step is only restricted to node version 20. Runner image is more restricted though.

The Dockerfile is somewhat optimized, as it uses separate build step, and the resulting image only contains files needed to render the page and run scripts. The copy directives are also sorted from the least changing to the most changing, so layers should be preserved as much as possible. The resulting image is 24MB total, in which about 15MB is the game, and 9MB is nginx.

This PR also fixes the `.gitignore` as it excluded `.*` for some reason, so both `.gitignore` and `.dockerignore` are not processed by git. This is most unusual, and if there are some dot-files that should be ignored by git they should definitely be put explicitly by name in the `.gitignore`. As this is additional change only tangentially related to this PR, if it doesn't meet your need, I will revert it.

Lastly, the page starts without errors and plays well - I did a hell lord run without any issues on my own instance. But I did not analyze the whole code and there might be some resources that I overlooked, so I would appreciate more engaged maintainer to recheck if everything is included.