### PR TITLE
Prevent cancel routes exploit of entrepreneur governor

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -1435,8 +1435,7 @@ export function marketItem(mount,market_item,name,color,full){
                     }
                 }
             },
-            autoBuy(res){
-                let keyMult = keyMultiplier();
+            autoBuy(res, keyMult = keyMultiplier()){
                 for (let i=0; i<keyMult; i++){
                     if (govActive('dealmaker',0)){
                         let exporting = 0;
@@ -1469,8 +1468,7 @@ export function marketItem(mount,market_item,name,color,full){
                 }
                 tradeRouteColor(res);
             },
-            autoSell(res){
-                let keyMult = keyMultiplier();
+            autoSell(res, keyMult = keyMultiplier()){
                 for (let i=0; i<keyMult; i++){
                     if (global.resource[res].trade <= 0){
                         if (exportRouteEnabled(res) && global.city.market.trade < global.city.market.mtrade){
@@ -1489,9 +1487,12 @@ export function marketItem(mount,market_item,name,color,full){
                 tradeRouteColor(res);
             },
             zero(res){
-                global.city.market.trade -= Math.abs(global.resource[res].trade);
-                global.resource[res].trade = 0;
-                tradeRouteColor(res);
+                if (global.resource[res].trade > 0){
+                    this.autoSell(res, global.resource[res].trade);
+                }
+                else if (global.resource[res].trade < 0){
+                    this.autoBuy(res, -global.resource[res].trade);
+                }
             }
         },
         filters: {


### PR DESCRIPTION
The entrepreneur governor requires at least as many exporting trade routes to be active as there are importing routes.

This currently can be bypassed by using the Cancel Routes button on a specific exporting route. This patch addresses that exploit by limiting the removed export routes to the number of "excess" exports.

The Cancel All Routes button still works normally, and the + and - buttons also still work normally.

I tested in a local save and it worked as expected.