### PR TITLE
Differentiate horseshoes strings on wiki "Races" page

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -2804,7 +2804,7 @@ const valAdjust = {
     living_tool: false,
 };
 
-function getTraitVals(trait,rank){
+function getTraitVals(trait, rank, species){
     let vals = traits[trait].hasOwnProperty('vars') ? traits[trait].vars(rank) : [];
     if (valAdjust.hasOwnProperty(trait)){
         if (trait === 'fibroblast'){
@@ -2829,7 +2829,7 @@ function getTraitVals(trait,rank){
             vals = [14 - vals[0], vals[0]];
         }
         else if (trait === 'hooved'){
-            vals.unshift(hoovedRename());
+            vals.unshift(hoovedRename(false, species));
         }
         else if (trait === 'anthropophagite'){
             vals = [vals[0] * 10000];
@@ -2841,53 +2841,53 @@ function getTraitVals(trait,rank){
     return vals;
 }
 
-export function hoovedRename(style){
-    if (global.race['sludge']){
+export function hoovedRename(style, species=global.race.species){
+    if (species === 'sludge'){
         return style ? 'craft' : loc('resource_Beaker_name');
     }
-    else if (global.race.species === 'cath'){
+    else if (species === 'cath'){
         return style ? 'craft' : loc('resource_Box_name');
     }
-    else if (global.race.species === 'wolven'){
+    else if (species === 'wolven'){
         return style ? 'craft' : loc('resource_ChewToy_name');
     }
-    else if (global.race.species === 'dracnid'){
+    else if (species === 'dracnid'){
         return style ? 'craft' : loc('resource_Hoard_name');
     }
-    else if (global.race.species === 'seraph'){
+    else if (species === 'seraph'){
         return style ? 'forge' : loc('resource_Halo_name');
     }
-    else if (global.race.species === 'cyclops'){
+    else if (species === 'cyclops'){
         return style ? 'craft' : loc('resource_Monocle_name');
     }
-    else if (global.race.species === 'kobold'){
+    else if (species === 'kobold'){
         return style ? 'craft' : loc('resource_Candle_name');
     }
-    else if (global.race.species === 'tuskin'){
+    else if (species === 'tuskin'){
         return style ? 'craft' : loc('resource_Goggles_name');
     }
-    else if (global.race.species === 'sharkin'){
+    else if (species === 'sharkin'){
         return style ? 'craft' : loc('resource_ToothSharpener_name');
     }
-    else if (races[global.race.species].type === 'humanoid'){
+    else if (races[species].type === 'humanoid'){
         return style ? 'craft' : loc('resource_Sandals_name');
     }
-    else if (races[global.race.species].type === 'avian'){
+    else if (races[species].type === 'avian'){
         return style ? 'craft' : loc('resource_Perch_name');
     }
-    else if (races[global.race.species].type === 'plant'){
+    else if (races[species].type === 'plant'){
         return style ? 'craft' : loc('resource_Planter_name');
     }
-    else if (races[global.race.species].type === 'fungi'){
+    else if (races[species].type === 'fungi'){
         return style ? 'craft' : loc('resource_DampCloth_name');
     }
-    else if (races[global.race.species].type === 'reptilian'){
+    else if (races[species].type === 'reptilian'){
         return style ? 'craft' : loc('resource_HeatRock_name');
     }
-    else if (races[global.race.species].type === 'fey'){
+    else if (races[species].type === 'fey'){
         return style ? 'craft' : loc('resource_PixieDust_name');
     }
-    else if (races[global.race.species].type === 'synthetic'){
+    else if (races[species].type === 'synthetic'){
         return style ? 'craft' : loc('resource_Battery_name');
     }
     else {
@@ -2914,7 +2914,7 @@ const traitExtra = {
         loc(`wiki_trait_effect_sniper_ex1`),
     ],
     hooved: [
-        loc(`wiki_trait_effect_hooved_ex1`,[hoovedRename(false)]),
+        function(opts){return loc(`wiki_trait_effect_hooved_ex1`,[hoovedRename(false, opts.species)])},
         loc(`wiki_trait_effect_hooved_ex2`,[
             `<span class="has-text-warning">${global.resource.hasOwnProperty('Lumber') ? global.resource.Lumber.name : loc('resource_Lumber_name')}</span>`,
             `<span class="has-text-warning">${global.resource.hasOwnProperty('Copper') ? global.resource.Copper.name : loc('resource_Copper_name')}</span>`,
@@ -2925,7 +2925,7 @@ const traitExtra = {
             12,75,150,500,5000
         ]),
         loc(`wiki_trait_effect_hooved_ex3`),
-        loc(`wiki_trait_effect_hooved_ex4`,[`<span class="has-text-warning">${5}</span>`,hoovedRename(false)]),
+        function(opts){return loc(`wiki_trait_effect_hooved_ex4`,[`<span class="has-text-warning">${5}</span>`,hoovedRename(false, opts.species)])},
         loc(`wiki_trait_effect_hooved_ex5`,[
             `<span class="has-text-warning">${global.resource.hasOwnProperty('Lumber') ? global.resource.Lumber.name : loc('resource_Lumber_name')}</span>`,
             `<span class="has-text-warning">${global.resource.hasOwnProperty('Copper') ? global.resource.Copper.name : loc('resource_Copper_name')}</span>`
@@ -2957,15 +2957,16 @@ function rName(r){
     return `<span class="has-text-warning">${res}</span>`;
 }
 
-export function getTraitDesc(info,trait,opts){
+export function getTraitDesc(info, trait, opts){
     let fanatic = opts['fanatic'] || false;
     let tpage = opts['tpage'] || false;
     let trank = opts['trank'] || false;
     let wiki = opts['wiki'] || false;
+    let species = opts['species']; // Intentionally keep undefined, not false, when undefined
     let rank = '';
 
-    let traitName = traitSkin('name',trait);
-    let traitDesc = traitSkin('desc',trait);
+    let traitName = traitSkin('name', trait, species);
+    let traitDesc = traitSkin('desc', trait, species);
 
     if (tpage && ['genus','major'].includes(traits[trait].type)){
         rank = `<span><span role="button" @click="down()">&laquo;</span><span class="has-text-warning">${loc(`wiki_trait_rank`)} {{ rank }}</span><span role="button" @click="up()">&raquo;</span></span>`;
@@ -2997,11 +2998,14 @@ export function getTraitDesc(info,trait,opts){
     }
     else {
         if (wiki || (global.stats.feat['journeyman'] && global.stats.achieve['seeder'] && global.stats.achieve.seeder.l > 0)){
-            info.append(`<div class="has-text-${color} effect">${loc(`wiki_trait_effect_${trait}`,getTraitVals(trait,trank))}</div>`);
+            info.append(`<div class="has-text-${color} effect">${loc(`wiki_trait_effect_${trait}`, getTraitVals(trait, trank, species))}</div>`);
         }
     }
     if (traitExtra[trait] && wiki){
         traitExtra[trait].forEach(function(te){
+            if (typeof te !== 'string'){
+                te = te(opts);
+            }
             info.append(`<div class="effect">${te}</div>`);
         });
     }
@@ -3013,7 +3017,7 @@ export function getTraitDesc(info,trait,opts){
             data: data,
             methods: {
                 getTraitDesc(rk){
-                    return loc(`wiki_trait_effect_${trait}`,getTraitVals(trait,rk));
+                    return loc(`wiki_trait_effect_${trait}`, getTraitVals(trait, rk, species));
                 },
                 up(){
                     switch (data.rank){

--- a/src/races.js
+++ b/src/races.js
@@ -5659,40 +5659,41 @@ export function fathomCheck(race){
     return 0;
 }
 
-export function traitSkin(type,trait){
+export function traitSkin(type, trait, species){
+    let artificial = species ? genus_traits[races[species].type].artifical : global.race['artifical'];
     switch (type){
         case 'name':
         {
             let name = {
-                hooved: hoovedReskin(false),
-                promiscuous: global.race['artifical'] ? loc('trait_promiscuous_synth_name') : traits['promiscuous'].name,
+                hooved: hoovedReskin(false, species),
+                promiscuous: artificial ? loc('trait_promiscuous_synth_name') : traits['promiscuous'].name,
             };
             return trait ? (name[trait] ? name[trait] : traits[trait].name) : name;
         } 
         case 'desc':
         {
             let desc = {
-                hooved: hoovedReskin(true),
-                promiscuous: global.race['artifical'] ? loc('trait_promiscuous_synth') : traits['promiscuous'].desc,
+                hooved: hoovedReskin(true, species),
+                promiscuous: artificial ? loc('trait_promiscuous_synth') : traits['promiscuous'].desc,
             };
             return trait ? (desc[trait] ? desc[trait] : traits[trait].desc) : desc;
         }
     }
 }
 
-export function hoovedReskin(desc){
-    if (global.race['sludge']){
+export function hoovedReskin(desc, species=global.race.species){
+    if (species === 'sludge'){
         return desc ? loc('trait_hooved_slime') : loc('trait_hooved_slime_name');
     }
     else if ([
         'cath','wolven','dracnid','seraph','cyclops','kobold','tuskin','sharkin'
-        ].includes(global.race.species)){
-        return desc ? loc(`trait_hooved_${global.race.species}`) : loc(`trait_hooved_${global.race.species}_name`);
+        ].includes(species)){
+        return desc ? loc(`trait_hooved_${species}`) : loc(`trait_hooved_${species}_name`);
     }
     else if ([
         'humanoid','avian','plant','fungi','reptilian','fey','synthetic'
-        ].includes(races[global.race.species].type)){
-        return desc ? loc(`trait_hooved_${races[global.race.species].type}`) : loc(`trait_hooved_${races[global.race.species].type}_name`);
+        ].includes(races[species].type)){
+        return desc ? loc(`trait_hooved_${races[species].type}`) : loc(`trait_hooved_${races[species].type}_name`);
     }
     else {
         return desc ? traits['hooved'].desc : traits['hooved'].name;

--- a/src/wiki/species.js
+++ b/src/wiki/species.js
@@ -96,19 +96,19 @@ export function racesPage(content){
         Object.keys(genus_traits[races[race].type]).sort().forEach(function (trait){
             let id = `raceTrait${race}${trait}`;
             let color = races[race].fanaticism === trait ? 'danger' : 'caution';
-            genes.append(`<span class="has-text-${color}" id="${id}">${traits[trait].name}<span>`);
+            genes.append(`<span class="has-text-${color}" id="${id}">${traitSkin('name', trait, race)}<span>`);
             traitList.push({ t: trait, r: 1});
         });
         Object.keys(races[race].traits).sort().forEach(function (trait){
             let id = `raceTrait${race}${trait}`;
             let color = races[race].fanaticism === trait ? 'danger' : 'info';
-            genes.append(`<span class="has-text-${color}" id="${id}">${traits[trait].name}<span>`);
+            genes.append(`<span class="has-text-${color}" id="${id}">${traitSkin('name', trait, race)}<span>`);
             traitList.push({ t: trait, r: races[race].traits[trait] });
         });
         for (let i=0; i<extraTraits.length; i++){
             let id = `raceTrait${race}${extraTraits[i].t}`;
             let color = races[race].fanaticism === extraTraits[i] ? 'danger' : 'info';
-            genes.append(`<span class="has-text-${color}" id="${id}">${traits[extraTraits[i].t].name}<span>`);
+            genes.append(`<span class="has-text-${color}" id="${id}">${traitSkin('name', extraTraits[i].t, race)}<span>`);
             traitList.push(extraTraits[i]);
         }
         info.append(genes);
@@ -123,7 +123,8 @@ export function racesPage(content){
             getTraitDesc(desc, traitList[i].t, {
                 fanatic: traitList[i].t === races[race].fanaticism ? races[race].name : false, 
                 trank: traitList[i].r,
-                wiki: true
+                wiki: true,
+                species: race
             });
 
             popover(id,desc,{ wide: true, classes: 'w25' });

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7630,7 +7630,7 @@
   "wiki_trait_effect_sniper": "Weapon upgrades are %0% stronger.",
   "wiki_trait_effect_sniper_ex1": "This upgrade effect is cumulative.",
   "wiki_trait_effect_hooved": "Expanding population requires %0. %0 costs scaled to %1%.",
-  "wiki_trait_effect_hooved_ex1": "%0 materials change at various breakpoints for total acquired shoes.",
+  "wiki_trait_effect_hooved_ex1": "%0 materials change at various breakpoints for total acquired quantity.",
   "wiki_trait_effect_hooved_ex2": "%0 --%6-> %1 --%7-> %2 --%8-> %3 --%9-> %4 --%10-> %5",
   "wiki_trait_effect_hooved_ex3": "If the next resource is not unlocked by the time you reach the breakpoint, it will keep charging the current resource but at a greatly inflated price.",
   "wiki_trait_effect_hooved_ex4": "Note that you start with %0 %1, which count against the total.",


### PR DESCRIPTION
Test by loading the wiki page for the list of races. Centaur will show horseshoes, Valdi will show sandals, Sludge will show beakers, and any custom race with Hooved will show whatever is applicable to its genus. Other locations that display trait info (ARPA genetics, wiki traits page, custom lab) should be unaffected.

I also applied the per-species logic for the minor trait Promiscuous in traitSkin(), but this should never actually change the displayed text at the present time. It's just for consistency.

functions.js
- getTraitVals - private. 2 of 2 call sites updated.
- hoovedRename - public. 3 of 3 local call sites and 0 of 12 remote call sites updated.
- getTraitDesc - public. Updated only in wiki racesPage(). Not changed in ARPA genetics, custom species lab, or wiki traitsPage().

races.js
- traitSkin - public. Updated in getTraitDesc() and wiki racesPage(). Not touched in ARPA genetics or wiki traitsPage().
- hoovedReskin - public. Updated in local traitSkin() but not updated in wiki page for governor task.

strings.json
- For extended horseshoes description, change "shoes" to "quantity" so that the text flows equally naturally in all cases.