### PR TITLE
Snap build queue to best height in one go

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10393,7 +10393,7 @@ function midLoop(){
                 buildQueueElement.scrollHeight > buildQueueElement.clientHeight
             ) {
                 // The build queue has a scroll-bar.
-                buildHeight++;
+                buildHeight += buildQueueElement.scrollHeight - buildQueueElement.clientHeight;
             } else if (['auto', 'shrink'].includes(global.settings.q_resize)) {
                 let minHeight = rem;
                 buildQueueElement.childNodes.forEach(function (e) {


### PR DESCRIPTION
Previously we would incrementally grow the queue height one pixel at a time. This was visually unpleasant and somewhat distracting. Now we snap straight to the "best" height directly.

This is a follow-up to https://github.com/pmotschmann/Evolve/pull/944
Fixes #1099