### PR TITLE
Fix unnecessary multi-line overflow in resources view

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -2633,16 +2633,13 @@ a {
             display: flex;
             cursor: default;
 
-            :first-child {
-                width: 34%;
+            div {
+                width: 70%;
+                display: flex;
+                justify-content: space-between;
             }
 
-            :nth-child(2) {
-                text-align: right;
-                width: 36%;
-            }
-
-            :nth-child(3) {
+            > :nth-child(2) {
                 text-align: center;
                 width: 4%;
             }
@@ -2651,7 +2648,7 @@ a {
                 cursor: pointer;
             }
 
-            :nth-child(4) {
+            > :nth-child(3) {
                 text-align: right;
                 width: 26%;
             }

--- a/src/resources.js
+++ b/src/resources.js
@@ -811,10 +811,10 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
 
     var res_container;
     if (global.resource[name].max === -1 || global.resource[name].max === -2){
-        res_container = $(`<div id="res${name}" class="resource crafted" v-show="display"><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | diffSize }}</span></div>`);
+        res_container = $(`<div id="res${name}" class="resource crafted" v-show="display"><div><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | diffSize }}</span></div></div>`);
     }
     else {
-        res_container = $(`<div id="res${name}" class="resource" v-show="display"><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | size }} / {{ max | size }}</span></div>`);
+        res_container = $(`<div id="res${name}" class="resource" v-show="display"><div><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | size }} / {{ max | size }}</span></div></div>`);
     }
 
     if (stackable){
@@ -1206,7 +1206,7 @@ function loadSpecialResource(name,color) {
     }
     color = color || 'special';
 
-    var res_container = $(`<div id="res${name}" class="resource" v-show="count"><span class="res has-text-${color}">${loc(`resource_${name}_name`)}</span><span class="count">{{ count | round }}</span></div>`);
+    var res_container = $(`<div id="res${name}" class="resource" v-show="count"><div><span class="res has-text-${color}">${loc(`resource_${name}_name`)}</span><span class="count">{{ count | round }}</span></div></div>`);
     $('#resources').append(res_container);
 
     vBind({


### PR DESCRIPTION
Fixes #1236

Before version 1.4.0, the first two columns in the resources list were 30% and 40% respectively. Since version 1.4.0, these are 34% and 36%, which makes #1236 easier to trigger. This change combines these two columns and lets the browser split the two now-child elements therein as needed to have these left/right of the now-combined 70% "column."