### PR TITLE
Imitate and Mimic fixes

### DIFF
--- a/src/arpa.js
+++ b/src/arpa.js
@@ -1760,7 +1760,7 @@ function dragGeneticsList(){
     }
 }
 
-function genetics(){
+export function genetics(){
     let parent = $('#arpaGenetics');
     clearGeneticsDrag();
     clearElement(parent);


### PR DESCRIPTION
Add genus traits for hybrid imitate.
Fixed mimic being unset on imitate, now only does when imitating mimiced genus.
Fixed mimic not visually updating after imitating and mimic not visually updating traits when set.
Fixed removing imitate not updating possible mimic targets.
(note: I am **not** familiar with how you should redraw in this game, please suggest improvements if any improved methods of mine are overly complicated.)