### PR TITLE
Fix piracy

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -6373,12 +6373,10 @@ export function piracy(region,rating,raw,wiki){
 
         if (global.race['chicken']){
             pirate *= 1 + (traits.chicken.vars()[1] / 100);
-            pirate = pirate;
         }
 
         if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.f){
             pirate *= 1 - (traits.ocular_power.vars()[1] / 500);
-            pirate = pirate;
         }
 
         let num_def_plat_on = wiki ? global.galaxy.defense_platform.on : p_on['defense_platform'];

--- a/src/space.js
+++ b/src/space.js
@@ -6373,12 +6373,12 @@ export function piracy(region,rating,raw,wiki){
 
         if (global.race['chicken']){
             pirate *= 1 + (traits.chicken.vars()[1] / 100);
-            pirate = Math.round(pirate);
+            pirate = pirate;
         }
 
         if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.f){
             pirate *= 1 - (traits.ocular_power.vars()[1] / 500);
-            pirate = Math.round(pirate);
+            pirate = pirate;
         }
 
         let num_def_plat_on = wiki ? global.galaxy.defense_platform.on : p_on['defense_platform'];

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -5213,11 +5213,11 @@ export function syndicate(region,extra){
         let piracy = global.space.syndicate[region];
         if (global.race['chicken']){
             piracy *= 1 + (traits.chicken.vars()[1] / 100);
-            piracy = Math.round(pirate);
+            piracy = Math.round(piracy);
         }
         if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.f){
             piracy *= 1 - (traits.ocular_power.vars()[1] / 500);
-            piracy = Math.round(pirate);
+            piracy = Math.round(piracy);
         }
         let patrol = 0;
         let sensor = 0;


### PR DESCRIPTION
Chicken/ocular rounding can cause piracy to drop to 0, causing division by 0

TP syndicate was accidentally put down as "pirate" instead of "piracy", causing an error.