### PR TITLE
Fix wiki page loading when no save file is present

### DIFF
--- a/src/edenic.js
+++ b/src/edenic.js
@@ -1388,7 +1388,7 @@ const edenicModules = {
                 let food = 250000;
                 let morale = 0;
                 morale += global.eden.hasOwnProperty('pillbox') && p_on['pillbox'] ? 0.35 * p_on['pillbox'] : 0;
-                morale += global.civic.elysium_miner.workers * 0.15;
+                morale += (global.civic?.elysium_miner?.workers ?? 0) * 0.15;
                 morale += global.eden.hasOwnProperty('archive') && p_on['archive'] ? 0.4 * p_on['archive'] : 0;
 
                 let desc =  `<div>${loc('space_red_vr_center_effect1',[morale.toFixed(1)])}</div>`

--- a/src/tech.js
+++ b/src/tech.js
@@ -4417,7 +4417,7 @@ const techs = {
             Knowledge(){ return 80000000; },
             Omniscience(){ return 12500; },
         },
-        effect(){ return loc('tech_spirit_researcher_effect',[global.civic.scientist.name]); },
+        effect(){ return loc('tech_spirit_researcher_effect',[global.civic.scientist ? global.civic.scientist.name : loc('job_scientist')]); },
         action(){
             if (payCosts($(this)[0])){
                 return true;


### PR DESCRIPTION
Presently, exceptions are thrown on the new Edenic Realm structures page and the Existential tech page if the user visits the wiki without ever having loaded the game.