### PR TITLE
Geothermal smelter related fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5,7 +5,7 @@ import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from 
 import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck, traitCostMod, renderSupernatural, blubberFill } from './races.js';
 import { defineResources, unlockCrates, unlockContainers, galacticTrade, spatialReasoning, resource_values, initResourceTabs, marketItem, containerItem, tradeSummery, faithBonus, templePlasmidBonus } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
-import { loadIndustry, defineIndustry, nf_resources, gridDefs } from './industry.js';
+import { loadIndustry, defineIndustry, nf_resources, gridDefs, addSmelter } from './industry.js';
 import { defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating, garrisonSize } from './civics.js';
 import { spaceTech, interstellarTech, galaxyTech, incrementStruct, universe_affixes, renderSpace, piracy, fuel_adjust, isStargateOn } from './space.js';
 import { renderFortress, fortressTech } from './portal.js';
@@ -2958,24 +2958,20 @@ export const actions = {
                 }
             },
             special: true,
+            smelting(){
+                return 1;
+            },
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('smelter','city');
-                    if (global.race['kindling_kindred'] || global.race['smoldering'] || global.race['artifical']){
-                        if (global.race['artifical']){
-                            global.city['smelter'].Oil++;
-                        }
-                        else if (global.race['evil']) {
-                            global.city['smelter'].Wood++;
-                        }
-                        else {
-                            global.city['smelter'].Coal++;
-                        }
+                    let fuel = 'Wood';
+                    if (global.race['artifical']){
+                        fuel = 'Oil';
                     }
-                    else {
-                        global.city['smelter'].Wood++;
+                    else if ((global.race['kindling_kindred'] || global.race['smoldering']) && !global.race['evil']) {
+                        fuel = 'Coal';
                     }
-                    global.city['smelter'].Iron++;
+                    addSmelter($(this)[0].smelting(), 'Iron', fuel);
                     global.settings.showIndustry = true;
                     defineIndustry();
                     return true;
@@ -8899,7 +8895,7 @@ function aiStart(){
 
         initStruct(actions.city.factory);
         initStruct(actions.city.foundry);
-        initStruct(actions.city.smelter); global.city.smelter.count = 1; global.city.smelter.Oil = 1; global.city.smelter.Iron = 1;
+        initStruct(actions.city.smelter); addSmelter(1, 'Iron');
         initStruct(actions.city.oil_power); global.city.oil_power.count = 1; global.city.oil_power.on = 1; 
         initStruct(actions.city.coal_power);
         initStruct(actions.city.transmitter); global.city.transmitter.count = 1; global.city.transmitter.on = 1;
@@ -9153,7 +9149,7 @@ function cataclysm(){
         }
         initStruct(actions.city.factory);
         initStruct(actions.city.foundry);
-        initStruct(actions.city.smelter); global.city.smelter.cap = 2; global.city.smelter.Oil = 2; global.city.smelter.Iron = 1; global.city.smelter.Steel = 1;
+        initStruct(actions.city.smelter); addSmelter(1, 'Iron'); addSmelter(1, 'Steel');
         initStruct(actions.city.fission_power);
         initStruct(actions.city.oil_power);
         initStruct(actions.city.coal_power);

--- a/src/edenic.js
+++ b/src/edenic.js
@@ -10,6 +10,7 @@ import { loc } from './locale.js';
 import { armyRating, armorCalc, garrisonSize, mercCost, soldierDeath } from './civics.js';
 import { govActive } from './governor.js';
 import { races, traits, traitCostMod, racialTrait } from './races.js';
+import { addSmelter } from './industry.js'
 
 const edenicModules = {
     eden_asphodel: {
@@ -1267,21 +1268,22 @@ const edenicModules = {
                 Scarletite(offset){ return spaceCostMultiplier('sacred_smelter', offset, 1250000, 1.25, 'eden'); },
             },
             effect(){
-                let desc = `<div>${loc('interstellar_stellar_forge_effect3',[5])}</div>`;
+                let desc = `<div>${loc('interstellar_stellar_forge_effect3',[$(this)[0].smelting()])}</div>`;
                 if (global.tech['elysium'] && global.tech.elysium >= 19){
                     desc += `<div>${loc('city_foundry_effect1',[jobScale(3)])}</div>`;
                 }
                 return `${desc}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
             powered(){ return powerCostMod(33); },
+            smelting(){
+                return 5;
+            },
             special: true,
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('sacred_smelter','eden');
                     if (powerOnNewStruct($(this)[0])){
-                        global.city.smelter.cap += 5;
-                        global.city.smelter.Steel += 5;
-                        global.city.smelter.Oil += 5;
+                        addSmelter($(this)[0].smelting(), 'Steel');
                     }
                     return true;
                 }

--- a/src/industry.js
+++ b/src/industry.js
@@ -57,7 +57,7 @@ export function defineIndustry(){
     }
     clearElement($('#industry'));
 
-    if (global.city['smelter'] && (global.city.smelter.count > 0 || global.race['cataclysm'] || global.race['orbit_decayed'] || global.tech['isolation'])){
+    if (smelterUnlocked()){
         var smelter = $(`<div id="iSmelter" class="industry"><h2 class="header has-text-advanced">${loc('city_smelter')}</h2></div>`);
         $(`#industry`).append(smelter);
         loadIndustry('smelter',smelter,'#iSmelter');
@@ -521,6 +521,19 @@ function loadSmelter(parent,bind){
                 attach: '#main',
             });
         });
+    }
+}
+
+export function smelterUnlocked(){
+    return global.city['smelter'] && (global.city.smelter.count > 0 || global.race['cataclysm'] || global.race['orbit_decayed'] || global.tech['isolation']);
+}
+
+export function addSmelter(num=1, product="Iron", fuel="Oil"){
+    global.city.smelter.cap += num;
+    global.city.smelter[product] += num; // ["Iron", "Steel", "Iridium"]
+    global.city.smelter[fuel] += num; // ["Wood", "Coal", "Oil", "Star", "Inferno"]
+    if (fuel === 'star') {
+        global.city.smelter.StarCap += num;
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaT
 import { races, traits, racialTrait, orbitLength, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck, blubberFill } from './races.js';
 import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
-import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice } from './industry.js';
+import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
 import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct } from './actions.js';
 import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes } from './space.js';
@@ -4828,35 +4828,30 @@ function fastLoop(){
         let iron_smelter = 0;
         let star_forge = 0;
         let iridium_smelter = 0;
-        if (global.city['smelter'] && (global.city.smelter.count > 0 || global.race['cataclysm'] || global.race['orbit_decayed'] || global.tech['isolation'])){
+        if (smelterUnlocked()){
             let capacity = global.city.smelter.count;
-            if (p_on['stellar_forge'] && global.tech['star_forge'] && global.tech.star_forge >= 2){
-                capacity += p_on['stellar_forge'] * 2;
+            if (p_on['stellar_forge']){
+                star_forge = p_on['stellar_forge'] * actions.interstellar.int_neutron.stellar_forge.smelting();
+                global.city.smelter.Star = Math.max(global.city.smelter.Star, star_forge);
+                capacity += star_forge;
             }
             if (p_on['hell_forge']){
-                capacity += p_on['hell_forge'] * 3;
+                capacity += p_on['hell_forge'] * actions.portal.prtl_ruins.hell_forge.smelting();
             }
             if (p_on['sacred_smelter']){
-                capacity += p_on['sacred_smelter'] * 5;
+                capacity += p_on['sacred_smelter'] * actions.eden.eden_elysium.sacred_smelter.smelting();
             }
             if (p_on['ore_refinery']){
-                capacity += p_on['ore_refinery'] * (global.tech['isolation'] ? 12 : 4);
+                capacity += p_on['ore_refinery'] * actions.tauceti.tau_gas.ore_refinery.smelting();
             }
-            if (global.tech['m_smelting'] && global.space['hell_smelter']){
-                capacity += global.space.hell_smelter.count * 2;
+            if (global.space['hell_smelter']){
+                capacity += global.space.hell_smelter.count * actions.space.spc_hell.hell_smelter.smelting();
             }
-            if ((global.race['cataclysm'] || global.race['orbit_decayed']) && global.space['geothermal']){
-                capacity += global.space.geothermal.on;
+            if (p_on['geothermal']){
+                capacity += p_on['geothermal'] * actions.space.spc_hell.geothermal.smelting();
             }
             global.city.smelter.cap = capacity;
-
-            if (global.tech['star_forge'] >= 2){
-                global.city.smelter.StarCap = p_on['stellar_forge'] * 2;
-                global.city.smelter.Star = global.city.smelter.StarCap;
-            }
-            else {
-                global.city.smelter.StarCap = 0;
-            }
+            global.city.smelter.StarCap = star_forge;
 
             if (global.race['forge']){
                 global.city.smelter.Wood = 0;
@@ -4914,7 +4909,6 @@ function fastLoop(){
             let steel_smelter = global.city.smelter.Steel;
             iridium_smelter = global.city.smelter.Iridium;
             let oil_bonus = global.race['forge'] ? global.city.smelter.Wood + global.city.smelter.Coal + global.city.smelter.Oil : global.city.smelter.Oil;
-            star_forge = global.city.smelter.Star;
             let inferno_bonus = global.city.smelter.Inferno;
 
             if (global.race['steelen']) {
@@ -11828,19 +11822,7 @@ function longLoop(){
             if (moldFathom >= 0.02 && global.resource.Knowledge.max >= (actions.tech.smelting.cost.Knowledge() * know_adjust) && checkTechRequirements('smelting',false) && !global.tech['smelting']){
                 messageQueue(loc(tech_source,[loc('tech_smelting')]),'info',false,['progress']);
                 global.tech['smelting'] = 1;
-                global.city['smelter'] = {
-                    count: 0,
-                    cap: 0,
-                    Wood: 0,
-                    Coal: 0,
-                    Oil: 0,
-                    Star: 0,
-                    StarCap: 0,
-                    Inferno: 0,
-                    Iron: 0,
-                    Steel: 0,
-                    Iridium: 0
-                };
+                initStruct(actions.city.smelter);
                 if (global.race['steelen']){
                     global.tech['smelting'] = 2;
                 }

--- a/src/portal.js
+++ b/src/portal.js
@@ -14,6 +14,7 @@ import { descension } from './resets.js';
 import { renderEdenic } from './edenic.js';
 import { loadTab } from './index.js';
 import { loc } from './locale.js';
+import { addSmelter } from './industry.js';
 
 const fortressModules = {
     prtl_fortress: {
@@ -832,20 +833,21 @@ const fortressModules = {
                 Soul_Gem(offset){ return spaceCostMultiplier('hell_forge', offset, 5, 1.22, 'portal'); },
             },
             powered(){ return powerCostMod(12); },
+            smelting(){
+                return 3;
+            },
             special: true,
             effect(wiki){
                 let sup = hellSupression('ruins', 0, wiki);
                 let craft = +(75 * sup.supress).toFixed(1);
                 let reactor = global.tech['inferno_power'] ? `<div>${loc('portal_hell_forge_effect2',[10,loc(`portal_inferno_power_title`)])}</div>` : ``;
-                return `<div>${loc('portal_hell_forge_effect',[jobScale(1)])}</div>${reactor}<div>${loc('interstellar_stellar_forge_effect3',[3])}</div><div>${loc('interstellar_stellar_forge_effect',[craft])}</div><div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
+                return `<div>${loc('portal_hell_forge_effect',[jobScale(1)])}</div>${reactor}<div>${loc('interstellar_stellar_forge_effect3',[$(this)[0].smelting()])}</div><div>${loc('interstellar_stellar_forge_effect',[craft])}</div><div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('hell_forge','portal');
                     if (powerOnNewStruct($(this)[0])){
-                        global.city.smelter.cap += 3;
-                        global.city.smelter.Oil += 3;
-                        global.city.smelter.Iron += 3;
+                        addSmelter($(this)[0].smelting());
                     }
                     return true;
                 }

--- a/src/tech.js
+++ b/src/tech.js
@@ -11,7 +11,7 @@ import { renderSpace, planetName, int_fuel_adjust } from './space.js';
 import { drawHellObservations } from './portal.js';
 import { setOrbits, jumpGateShutdown } from './truepath.js';
 import { arpa } from './arpa.js';
-import { setPowerGrid, defineIndustry } from './industry.js';
+import { setPowerGrid, defineIndustry, addSmelter } from './industry.js';
 import { defineGovernor, removeTask } from './governor.js';
 import { big_bang, cataclysm_end, descension, aiApocalypse } from './resets.js';
 
@@ -1506,17 +1506,14 @@ const techs = {
         effect: loc('tech_stellar_smelting_effect'),
         action(){
             if (payCosts($(this)[0])){
-                let num_forge_on = p_on['stellar_forge'];
-                let num_new_smelters = num_forge_on * 2;
-                global.city.smelter.cap += num_new_smelters;
-                global.city.smelter.Star += num_new_smelters;
-                global.city.smelter.StarCap += num_new_smelters;
-                global.city.smelter.Iron += num_new_smelters;
                 return true;
             }
             return false;
         },
         post(){
+            let num_forge_on = p_on['stellar_forge'];
+            let num_new_smelters = num_forge_on * actions.interstellar.int_neutron.stellar_forge.smelting();
+            addSmelter(num_new_smelters, 'Iron', 'Star');
             defineIndustry();
         }
     },

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -8,7 +8,7 @@ import { production, highPopAdjust } from './prod.js';
 import { actions, payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, buildTemplate, casinoEffect, housingLabel, structName, initStruct } from './actions.js';
 import { fuel_adjust, int_fuel_adjust, spaceTech, renderSpace, checkRequirements, incrementStruct, planetName } from './space.js';
 import { removeTask, govActive } from './governor.js';
-import { defineIndustry, nf_resources } from './industry.js';
+import { defineIndustry, nf_resources, addSmelter } from './industry.js';
 import { arpa } from './arpa.js';
 import { matrix, retirement, gardenOfEden } from './resets.js';
 import { loc } from './locale.js';
@@ -3335,14 +3335,7 @@ const tauCetiModules = {
                     incrementStruct('ore_refinery','tauceti');
                     if (powerOnNewStruct($(this)[0])){
                         let num_smelters = $(this)[0].smelting();
-                        global.city.smelter.cap += num_smelters;
-                        global.city.smelter.Steel += num_smelters;
-                        if (global.race['evil']) {
-                            global.city['smelter'].Wood += num_smelters;
-                        }
-                        else {
-                            global.city.smelter.Oil += num_smelters;
-                        }
+                        addSmelter(num_smelters, 'Steel', global.race['evil'] ? 'Wood' : 'Oil');
                     }
                     return true;
                 }
@@ -5955,7 +5948,7 @@ export function loneSurvivor(){
 
         initStruct(actions.city.factory);
         initStruct(actions.city.foundry);
-        initStruct(actions.city.smelter); global.city.smelter.cap = 2; global.city.smelter.Oil = 2; global.city.smelter.Iron = 1; global.city.smelter.Steel = 1;
+        initStruct(actions.city.smelter); addSmelter(1, 'Iron'); addSmelter(1, 'Steel');
 
         initStruct(actions.city.amphitheatre);
         initStruct(actions.city.apartment);


### PR DESCRIPTION
Automatically smelt iron in geothermal plants when no homeworld is available. Prevent geothermal plants from smelting when they are not receiving enough He-3 fuel.

Add a smelting() method to all structures that provide smelting. Use it for all references to number of supported smelters.

Create common functions to enable a new smelter and to check whether smelting is possible.