### PR TITLE
Update fractional soldier healing and recruitment

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7777,8 +7777,8 @@ function fastLoop(){
             global.civic.garrison.rate += traits.brute.vars(1)[1] / 40 * fathom * time_multiplier;
         }
         global.civic.garrison.progress += global.civic.garrison.rate;
-        if (global.civic.garrison.progress >= 100){
-            global.civic.garrison.progress = 0;
+        while (global.civic.garrison.progress >= 100){
+            global.civic.garrison.progress -= 100;
             global.civic.garrison.workers++;
 
             if (global.portal['fortress'] && global.portal.fortress['assigned'] && global.portal.fortress.garrison < global.portal.fortress.assigned){
@@ -11122,7 +11122,7 @@ function longLoop(){
                     healed++;
                     hc -= max_bound;
                 }
-                if (Math.rand(0,hc) > Math.rand(0,max_bound)){
+                if (Math.rand(0,max_bound) < hc){
                     healed++;
                 }
             }


### PR DESCRIPTION
Fractional soldier healing now works correctly. Previously, it was less effective than intended.

Recruitment speed for insects and in the Edenic Realms is likely to reach speeds where individual bonuses to recruitment speed have no real effect. To resolve this issue, allow the recruitment bar to roll over, and allow more than one soldier to be recruited per day.