### PR TITLE
Fixed elysium cement for fliers/hell towers when pillaring

### DIFF
--- a/src/edenic.js
+++ b/src/edenic.js
@@ -1632,7 +1632,7 @@ const edenicModules = {
             desc(){
                 return `<div>${loc('city_cement_plant_desc')}</div><div class="has-text-special">${loc('requires_power')}</div>`;
             },
-            reqs: { elysium: 18 },
+            reqs: { cement:8 },
             cost: {
                 Money(offset){ return spaceCostMultiplier('eden_cement', offset, 5000000000, 1.24, 'eden'); },
                 Stone(offset){ return spaceCostMultiplier('eden_cement', offset, 1000000000, 1.24, 'eden'); },

--- a/src/main.js
+++ b/src/main.js
@@ -9246,7 +9246,7 @@ function midLoop(){
         if (p_on['stellar_forge']){
             lCaps['craftsman'] += jobScale(p_on['stellar_forge'] * 2);
         }
-        if (global.tech['elysium'] && global.tech.elysium >= 19 && p_on['sacred_smelter']){
+        if (global.tech['elysium'] && global.tech.elysium >= 18 && p_on['sacred_smelter']){
             lCaps['craftsman'] += jobScale(p_on['sacred_smelter'] * 3);
         }
         if (global.portal['carport']){

--- a/src/portal.js
+++ b/src/portal.js
@@ -956,6 +956,8 @@ const fortressModules = {
                         spatialReasoning(0,false,true);
                         calcPillar(true);
                         towerSize(true);
+                        fortressModules.prtl_gate.west_tower.post(); //unlock towers if both are complete now
+                        fortressModules.prtl_gate.east_tower.post();
                         unlockAchieve('resonance');
                         vBind({el: `#portal-ancient_pillars`},'update');
                         return true;

--- a/src/races.js
+++ b/src/races.js
@@ -6499,6 +6499,7 @@ export function cleanAddTrait(trait){
             global.civic.cement_worker.assigned = 0;
             setPurgatory('tech','cement');
             setPurgatory('city','cement_plant');
+            setPurgatory('eden','eden_cement');
             break;
         case 'sappy':
             if (global.civic.d_job === 'quarry_worker'){
@@ -6766,6 +6767,7 @@ export function cleanRemoveTrait(trait,rank){
             checkPurgatory('tech','cement');
             if (global.tech['cement']){
                 checkPurgatory('city','cement_plant');
+                checkPurgatory('eden','eden_cement');
                 global.resource.Cement.display = true;
                 global.civic.cement_worker.display = true;
             }

--- a/src/tech.js
+++ b/src/tech.js
@@ -5294,7 +5294,7 @@ const techs = {
             return global.resource.Demonic_Essence.amount >= 1 ? true : false;
         },
         grant: ['edenic',2],
-        not_trait: ['witch_hunter'],
+        not_trait: ['witch_hunter', 'fasting'],
         cost: {
             Knowledge(){ return 60000000; },
             Artifact(){ return 1; },
@@ -14920,7 +14920,8 @@ const techs = {
         category: 'housing',
         era: 'existential',
         reqs: { elysium: 17, cement: 7 },
-        grant: ['elysium',18],
+        grant: ['cement', 8],
+        not_trait: ['flier'],
         cost: {
             Knowledge(){ return 135000000; },
             Omniscience(){ return 42500; },
@@ -14940,8 +14941,8 @@ const techs = {
         desc(){ return loc('tech_ancient_crafters'); },
         category: 'housing',
         era: 'existential',
-        reqs: { elysium: 18 },
-        grant: ['elysium',19],
+        reqs: { elysium: 17 },
+        grant: ['elysium',18],
         cost: {
             Knowledge(){ return 140000000; },
             Omniscience(){ return 44000; },

--- a/src/vars.js
+++ b/src/vars.js
@@ -1216,6 +1216,9 @@ if (convertVersion(global['version']) <= 104000){
     if (global.city.hasOwnProperty('shrine') && !global.city.shrine.hasOwnProperty('cycle')){
         global.city.shrine['cycle'] = 0;
     }
+}
+
+if (convertVersion(global['version']) <= 104001){
     if(global.tech['elysium'] && global.tech.elysium >= 18){
         global.tech.elysium--;
         if(global.tech.cement && !global.race['flier']){

--- a/src/vars.js
+++ b/src/vars.js
@@ -1218,7 +1218,7 @@ if (convertVersion(global['version']) <= 104000){
     }
 }
 
-if (convertVersion(global['version']) <= 104001){
+if (convertVersion(global['version']) < 104001){
     if(global.tech['elysium'] && global.tech.elysium >= 18){
         global.tech.elysium--;
         if(global.tech.cement && !global.race['flier']){

--- a/src/vars.js
+++ b/src/vars.js
@@ -1216,6 +1216,12 @@ if (convertVersion(global['version']) <= 104000){
     if (global.city.hasOwnProperty('shrine') && !global.city.shrine.hasOwnProperty('cycle')){
         global.city.shrine['cycle'] = 0;
     }
+    if(global.tech['elysium'] && global.tech.elysium >= 18){
+        global.tech.elysium--;
+        if(global.tech.cement && !global.race['flier']){
+            global.tech.cement = 8;
+        }
+    }
 }
 
 global['version'] = '1.4.1';


### PR DESCRIPTION
Hide elysium cement tech and building for avians.
This causes the next tech, (ancient crafters) to show up earlier since it now doesn't require the cement tech anymore.

Fix for hell towers getting stuck if pillaring reduces towers cost below built segments.

Note: Mimicing avian currently does not correctly hide cement techs and buildings with preload enabled, this PR does *not* fix this.