### PR TITLE
Fix hunting banquet hall bonus/Lone survivor reclaimers

### DIFF
--- a/src/civics.js
+++ b/src/civics.js
@@ -2222,9 +2222,6 @@ export function armyRating(val,type,wound){
         if (global.race['unfathomable']){
             army *= 0.66;
         }
-        if(global.city.banquet && global.city.banquet.on && global.city.banquet.count >= 3){
-            army *= 1 + (global.city.banquet.strength ** 0.65) / 100;
-        }
         if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.w){
             let hunt = 60 * (traits.ocular_power.vars()[1] / 100);
             army *= 1 + (hunt / 100);

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -5733,6 +5733,9 @@ export function loneSurvivor(){
                 total: 0,
             };
         }
+        if(global.race.universe === 'evil'){
+            global.tech['reclaimer'] = 1;
+        }
 
         global.settings.showSpace = false;
         global.settings.showTau = true;


### PR DESCRIPTION
Fixed Hunting soldiers getting the banquet hall hunting bonus twice.
Fixed reclaimers in lone survivor doing nothing and showing NaN in the tooltip before researching their associated tech (tech now granted upon starting Lone Survivor)