### PR TITLE
Fix trait value used by Elemental frost effect

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -2960,7 +2960,7 @@ function getTraitVals(trait, rank, species){
                 vals = [loc(`element_fire`), traits.elemental.vars(rank)[3], traits.elemental.vars(rank)[5]];
                 break;
             case 'frost':
-                vals = [loc(`element_frost`), traits.elemental.vars(rank)[3], traits.elemental.vars(rank)[5], loc('city_biolab')];
+                vals = [loc(`element_frost`), traits.elemental.vars(rank)[4], traits.elemental.vars(rank)[5], loc('city_biolab')];
                 break;
         }
     }


### PR DESCRIPTION
Both Fire and Frost were using trait value 3, even though [races.js has value 4 for frost](https://github.com/pmotschmann/Evolve/blob/c1ace9b20f487a0334aa1c4ed817bfe9d53ae5b9/src/races.js#L3987).

(I think this is a wiki/visual change only, main.js uses the correct one in its calculations.)