### PR TITLE
Fix broken ore processors (#1283)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2766,106 +2766,107 @@ function fastLoop(){
             let used_support = 0;
             for (let i=0; i<galaxy_ship_types[j].ships.length; i++){
                 const ship = galaxy_ship_types[j].ships[i];
-                let operating = 0;
+                if (global[area][ship]){
+                    let operating = 0;
+                    if (global[area][ship].hasOwnProperty('on') && req && (p_on['s_gate'] || area !== 'galaxy')){
+                        const id = actions[area][region][ship].id;
+                        const num_on = global[area][ship].on;
+                        operating = num_on;
 
-                if (global[area][ship] && global[area][ship].hasOwnProperty('on') && req && (p_on['s_gate'] || area !== 'galaxy')){
-                    const id = actions[area][region][ship].id;
-                    const num_on = global[area][ship].on;
-                    operating = num_on;
+                        // Support cost
+                        const operating_cost = actions[area][region][ship].hasOwnProperty('support') ? -(actions[area][region][ship].support()) : 0;
+                        if (operating_cost > 0){
+                            const max_operating = Math.floor((global[area][support_home].s_max - used_support) / operating_cost);
+                            operating = Math.min(operating, max_operating);
+                        }
 
-                    // Support cost
-                    const operating_cost = actions[area][region][ship].hasOwnProperty('support') ? -(actions[area][region][ship].support()) : 0;
-                    if (operating_cost > 0){
-                        const max_operating = Math.floor((global[area][support_home].s_max - used_support) / operating_cost);
-                        operating = Math.min(operating, max_operating);
-                    }
-
-                    if (actions[area][region][ship].hasOwnProperty('ship')){
-                        if (actions[area][region][ship].ship.civ && global[area][ship].hasOwnProperty('crew')){
-                            // Civilian ships can only be crewed at a rate of 1 ship (per type) per fast tick
-                            let civPerShip = actions[area][region][ship].ship.civ();
-                            if (civPerShip > 0){
-                                if (global[area][ship].crew < 0){
-                                    global[area][ship].crew = 0;
-                                }
-                                if (global[area][ship].crew < operating * civPerShip){
-                                    if (total < global.resource[global.race.species].amount){
-                                        if (global.civic[global.civic.d_job].workers >= civPerShip){
-                                            global.civic[global.civic.d_job].workers -= civPerShip;
-                                            global.civic.crew.workers += civPerShip;
-                                            global[area][ship].crew += civPerShip;
+                        if (actions[area][region][ship].hasOwnProperty('ship')){
+                            if (actions[area][region][ship].ship.civ && global[area][ship].hasOwnProperty('crew')){
+                                // Civilian ships can only be crewed at a rate of 1 ship (per type) per fast tick
+                                let civPerShip = actions[area][region][ship].ship.civ();
+                                if (civPerShip > 0){
+                                    if (global[area][ship].crew < 0){
+                                        global[area][ship].crew = 0;
+                                    }
+                                    if (global[area][ship].crew < operating * civPerShip){
+                                        if (total < global.resource[global.race.species].amount){
+                                            if (global.civic[global.civic.d_job].workers >= civPerShip){
+                                                global.civic[global.civic.d_job].workers -= civPerShip;
+                                                global.civic.crew.workers += civPerShip;
+                                                global[area][ship].crew += civPerShip;
+                                            }
                                         }
                                     }
+                                    else if (global[area][ship].crew > operating * civPerShip){
+                                        global.civic[global.civic.d_job].workers += civPerShip;
+                                        global.civic.crew.workers -= civPerShip;
+                                        global[area][ship].crew -= civPerShip;
+                                    }
+                                    global.civic.crew.assigned = global.civic.crew.workers;
+                                    crew_civ += global[area][ship].crew;
+                                    total += global[area][ship].crew;
+                                    operating = Math.min(operating, Math.floor(global[area][ship].crew / civPerShip));
                                 }
-                                else if (global[area][ship].crew > operating * civPerShip){
-                                    global.civic[global.civic.d_job].workers += civPerShip;
-                                    global.civic.crew.workers -= civPerShip;
-                                    global[area][ship].crew -= civPerShip;
+                            }
+
+                            if (actions[area][region][ship].ship.mil && global[area][ship].hasOwnProperty('mil')){
+                                // All military ships can be crewed instantly
+                                let milPerShip = actions[area][region][ship].ship.mil();
+                                if (milPerShip > 0){
+                                    if (global[area][ship].mil !== operating * milPerShip){
+                                        global[area][ship].mil = operating * milPerShip;
+                                    }
+                                    if (global.civic.garrison.workers - global.portal.fortress.garrison < 0){
+                                        let underflow = global.civic.garrison.workers - global.portal.fortress.garrison;
+                                        global[area][ship].mil -= underflow;
+                                    }
+                                    if (crew_mil + global[area][ship].mil > global.civic.garrison.workers - global.portal.fortress.garrison){
+                                        global[area][ship].mil = global.civic.garrison.workers - global.portal.fortress.garrison - crew_mil;
+                                    }
+                                    if (global[area][ship].mil < 0){
+                                        global[area][ship].mil = 0;
+                                    }
+                                    crew_mil += global[area][ship].mil;
+                                    operating = Math.min(operating, Math.floor(global[area][ship].mil / milPerShip));
                                 }
-                                global.civic.crew.assigned = global.civic.crew.workers;
-                                crew_civ += global[area][ship].crew;
-                                total += global[area][ship].crew;
-                                operating = Math.min(operating, Math.floor(global[area][ship].crew / civPerShip));
+                            }
+
+                            if (actions[area][region][ship].ship.hasOwnProperty('helium')){
+                                let increment = +int_fuel_adjust(actions[area][region][ship].ship.helium).toFixed(2);
+                                let consume = operating * increment;
+                                while (consume * time_multiplier > global.resource.Helium_3.amount + (global.resource.Helium_3.diff > 0 ? global.resource.Helium_3.diff * time_multiplier : 0) && operating > 0){
+                                    consume -= increment;
+                                    operating--;
+                                }
+                                modRes('Helium_3', -(consume * time_multiplier));
+                                andromeda_helium += consume;
+                            }
+
+                            if (actions[area][region][ship].ship.hasOwnProperty('deuterium')){
+                                let increment = +int_fuel_adjust(actions[area][region][ship].ship.deuterium).toFixed(2);
+                                let consume = operating * increment;
+                                while (consume * time_multiplier > global.resource.Deuterium.amount + (global.resource.Deuterium.diff > 0 ? global.resource.Deuterium.diff * time_multiplier : 0) && operating > 0){
+                                    consume -= increment;
+                                    operating--;
+                                }
+                                modRes('Deuterium', -(consume * time_multiplier));
+                                andromeda_deuterium += consume;
                             }
                         }
 
-                        if (actions[area][region][ship].ship.mil && global[area][ship].hasOwnProperty('mil')){
-                            // All military ships can be crewed instantly
-                            let milPerShip = actions[area][region][ship].ship.mil();
-                            if (milPerShip > 0){
-                                if (global[area][ship].mil !== operating * milPerShip){
-                                    global[area][ship].mil = operating * milPerShip;
-                                }
-                                if (global.civic.garrison.workers - global.portal.fortress.garrison < 0){
-                                    let underflow = global.civic.garrison.workers - global.portal.fortress.garrison;
-                                    global[area][ship].mil -= underflow;
-                                }
-                                if (crew_mil + global[area][ship].mil > global.civic.garrison.workers - global.portal.fortress.garrison){
-                                    global[area][ship].mil = global.civic.garrison.workers - global.portal.fortress.garrison - crew_mil;
-                                }
-                                if (global[area][ship].mil < 0){
-                                    global[area][ship].mil = 0;
-                                }
-                                crew_mil += global[area][ship].mil;
-                                operating = Math.min(operating, Math.floor(global[area][ship].mil / milPerShip));
-                            }
+                        if (operating < num_on){
+                            $(`#${id} .on`).addClass('warn');
+                            $(`#${id} .on`).prop('title',`ON ${operating}/${num_on}`);
+                        }
+                        else {
+                            $(`#${id} .on`).removeClass('warn');
+                            $(`#${id} .on`).prop('title',`ON`);
                         }
 
-                        if (actions[area][region][ship].ship.hasOwnProperty('helium')){
-                            let increment = +int_fuel_adjust(actions[area][region][ship].ship.helium).toFixed(2);
-                            let consume = operating * increment;
-                            while (consume * time_multiplier > global.resource.Helium_3.amount + (global.resource.Helium_3.diff > 0 ? global.resource.Helium_3.diff * time_multiplier : 0) && operating > 0){
-                                consume -= increment;
-                                operating--;
-                            }
-                            modRes('Helium_3', -(consume * time_multiplier));
-                            andromeda_helium += consume;
-                        }
-
-                        if (actions[area][region][ship].ship.hasOwnProperty('deuterium')){
-                            let increment = +int_fuel_adjust(actions[area][region][ship].ship.deuterium).toFixed(2);
-                            let consume = operating * increment;
-                            while (consume * time_multiplier > global.resource.Deuterium.amount + (global.resource.Deuterium.diff > 0 ? global.resource.Deuterium.diff * time_multiplier : 0) && operating > 0){
-                                consume -= increment;
-                                operating--;
-                            }
-                            modRes('Deuterium', -(consume * time_multiplier));
-                            andromeda_deuterium += consume;
-                        }
+                        used_support += operating * operating_cost;
                     }
-
-                    if (operating < num_on){
-                        $(`#${id} .on`).addClass('warn');
-                        $(`#${id} .on`).prop('title',`ON ${operating}/${num_on}`);
-                    }
-                    else {
-                        $(`#${id} .on`).removeClass('warn');
-                        $(`#${id} .on`).prop('title',`ON`);
-                    }
-
-                    used_support += operating * operating_cost;
+                    gal_on[ship] = operating;
                 }
-                gal_on[ship] = operating;
             }
             if (support_home && global?.[area]?.[support_home]?.hasOwnProperty('support')){
                 global[area][support_home].support = used_support;


### PR DESCRIPTION
Two different loops were using the galaxy_ship_types structure. The first one correctly powered ore processors (replacing the earlier foothold station loop that was deleted in #1265). However, the second loop checked for crew, and ore processors have no civilian or military crew requirements, so it always set `gal_on['ore_processor'] = 0`.