### PR TITLE
Forager mimic/imitation fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -2,7 +2,7 @@ import { global, save, seededRandom, webWorker, keyMultiplier, keyMap, srSpeak, 
 import { loc } from './locale.js';
 import { timeCheck, timeFormat, vBind, popover, clearPopper, flib, tagEvent, clearElement, costMultiplier, darkEffect, genCivName, powerModifier, powerCostMod, calcPrestige, adjustCosts, modRes, messageQueue, buildQueue, format_emblem, shrineBonusActive, calc_mastery, calcPillar, calcGenomeScore, getShrineBonus, eventActive, easterEgg, getHalloween, trickOrTreat, deepClone, hoovedRename, get_qlevel } from './functions.js';
 import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from './achieve.js';
-import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck, traitCostMod, renderSupernatural, blubberFill } from './races.js';
+import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, combineTraits, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck, traitCostMod, renderSupernatural, blubberFill } from './races.js';
 import { defineResources, unlockCrates, unlockContainers, galacticTrade, spatialReasoning, resource_values, initResourceTabs, marketItem, containerItem, tradeSummery, faithBonus, templePlasmidBonus } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
 import { loadIndustry, defineIndustry, nf_resources, gridDefs, addSmelter } from './industry.js';
@@ -8173,11 +8173,6 @@ function sentience(){
             }
         });
     });
-    if (typeList.includes('carnivore') && typeList.includes('herbivore')){
-        setTraitRank('forager',{ set: genus_traits.omnivore.forager });
-        delete global.race['carnivore'];
-        delete global.race['herbivore'];
-    }
 
     Object.keys(races[global.race.species].traits).forEach(function (trait) {
         setTraitRank(trait,{ set: races[global.race.species].traits[trait] });
@@ -8190,6 +8185,7 @@ function sentience(){
     if (global.race['imitation'] && global.race['srace']){
         setImitation(false);
     }
+    combineTraits();
 
     Object.keys(global.tech).forEach(function (tech){
         if (tech.substring(0,4) === 'evo_'){

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -1963,14 +1963,21 @@ function genetics(){
         }
         Object.keys(trait_listing).forEach(function (trait){
             if (traits[trait] && traits[trait].type !== 'minor' && traits[trait].type !== 'special' && trait !== 'evil' && trait !== 'soul_eater' && trait !== 'artifical'){
+                let mimicTraits = [
+                    ...(global.race['ss_traits'] ? global.race['ss_traits'] : []),
+                    ...(global.race['iTraits'] ? Object.keys(global.race['iTraits']) : [])
+                ];
                 let readOnly = false;
-                if ((global.race['ss_traits'] && global.race.ss_traits.includes(trait)) || (global.race['iTraits'] && global.race.iTraits.hasOwnProperty(trait))){
+                if (mimicTraits.includes(trait)){
                     readOnly = true;
                 }
                 else if (['sludge','ultra_sludge'].includes(global.race.species) && (trait === 'ooze' || global.race['modified'])){
                     readOnly = true;
                 }
                 else if (!global.race.hasOwnProperty(trait)){
+                    readOnly = true;
+                }
+                else if(trait === 'forager' && mimicTraits.some(item => ['herbivore', 'carnivore'].includes(item))){
                     readOnly = true;
                 }
                 if (!readOnly && ((traits[trait].type === 'major' && global.genes['mutation']) || (traits[trait].type === 'genus' && global.genes['mutation'] && global.genes['mutation'] >= 2))){

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2194,6 +2194,10 @@ function genetics(){
                         else {
                             global.race['modified']++;
                         }
+                        if(t === 'forager'){
+                            delete global.race.inactive['herbivore'];
+                            delete global.race.inactive['carnivore'];
+                        }
                         cleanRemoveTrait(t,rank);
                         genetics();
                         drawTech();

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -1,7 +1,7 @@
 import { global, keyMultiplier, sizeApproximation, srSpeak, p_on, support_on } from './vars.js';
 import { clearElement, popover, clearPopper, flib, fibonacci, eventActive, timeFormat, vBind, messageQueue, adjustCosts, calcQueueMax, calcRQueueMax, buildQueue, calcPrestige, calc_mastery, darkEffect, easterEgg, trickOrTreat, getTraitDesc, removeFromQueue, arpaTimeCheck, deepClone } from './functions.js';
 import { actions, updateQueueNames, drawTech, drawCity, addAction, removeAction, wardenLabel, checkCosts, structName } from './actions.js';
-import { races, traits, cleanAddTrait, cleanRemoveTrait, traitSkin, fathomCheck, planetTraits, setTraitRank, traitRank } from './races.js';
+import { races, traits, cleanAddTrait, cleanRemoveTrait, combineTraits, traitSkin, fathomCheck, planetTraits, setTraitRank, traitRank } from './races.js';
 import { renderSpace } from './space.js';
 import { drawMechLab } from './portal.js';
 import { govActive, defineGovernor } from './governor.js';
@@ -2234,6 +2234,7 @@ function genetics(){
                         genetics();
                         drawTech();
                         drawCity();
+                        combineTraits();
                     }
                 },
                 geneCost(t){

--- a/src/races.js
+++ b/src/races.js
@@ -7104,12 +7104,6 @@ export function combineTraits(){
         global.race.inactive['carnivore'] = global.race['carnivore'];
         delete global.race['herbivore'];
         delete global.race['carnivore'];
-        if(global.race.ss_traits && (global.race.ss_traits.includes('herbivore') || global.race.ss_traits.includes('carnivore')) && !global.race.ss_traits.includes('forager')){
-            global.race.ss_traits.push('forager');
-        }
-        if(global.race.iTraits && (global.race.iTraits.hasOwnProperty('herbivore') || global.race.iTraits.hasOwnProperty('carnivore'))){
-            global.race.iTraits['forager'] = 0;
-        }
         if(global.race['forager'] !== rank){
             setTraitRank('forager',{ set: rank, force:true});
             cleanRemoveTrait('carnivore');
@@ -7119,12 +7113,6 @@ export function combineTraits(){
     }
     else if(global.race['forager']){
         delete global.race['forager'];
-        if(global.race.ss_traits?.includes('forager')){
-            global.race.ss_traits = global.race.ss_traits.filter(trait => trait !== 'forager');
-        }
-        if(global.race.iTraits?.hasOwnProperty('forager')){
-            delete global.race.iTraits['forager'];
-        }
         cleanRemoveTrait('forager');
     }
 }

--- a/src/vars.js
+++ b/src/vars.js
@@ -1227,6 +1227,15 @@ if (convertVersion(global['version']) < 104001){
     }
 }
 
+if (convertVersion(global['version']) < 104002){
+    if(!global.race.inactive){
+        global.race.inactive = {};
+    }
+    if(global.race['forager']){
+        global.race.inactive = {herbivore:global.race['forager'], carnivore:global.race['forager']};
+    }
+}
+
 global['version'] = '1.4.1';
 delete global['revision'];
 delete global['beta'];


### PR DESCRIPTION
When you obtain both carnivore and herbivore, both are moved to "inactive traits" and forager is obtained.
Changes are somewhat complicated but I tested the following successfully.
Starting a run as racconar
Starting a run as synth imitating racconar
Mutating in imitate racconar
Playing as herbivore or carnivore and setting mimic to the other genus
Mimicing herbivore and mutating in imitate carnivore
Imitating herbivore and setting mimic to carnivore

This should make it easier to add more type of combined traits in the future as well.

NOTE: Mutating out forager doesn't correctly remove the forager job or techs, this PR does not fix this.
