### PR TITLE
Temple/ziggurat fixes + misc fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,7 +3,7 @@ import { loc } from './locale.js';
 import { timeCheck, timeFormat, vBind, popover, clearPopper, flib, tagEvent, clearElement, costMultiplier, darkEffect, genCivName, powerModifier, powerCostMod, calcPrestige, adjustCosts, modRes, messageQueue, buildQueue, format_emblem, shrineBonusActive, calc_mastery, calcPillar, calcGenomeScore, getShrineBonus, eventActive, easterEgg, getHalloween, trickOrTreat, deepClone, hoovedRename, get_qlevel } from './functions.js';
 import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from './achieve.js';
 import { races, traits, genus_traits, neg_roll_traits, randomMinorTrait, cleanAddTrait, biomes, planetTraits, setJType, altRace, setTraitRank, setImitation, shapeShift, basicRace, fathomCheck, traitCostMod, renderSupernatural, blubberFill } from './races.js';
-import { defineResources, unlockCrates, unlockContainers, galacticTrade, spatialReasoning, resource_values, initResourceTabs, marketItem, containerItem, tradeSummery, faithBonus, templePlasmidBonus } from './resources.js';
+import { defineResources, unlockCrates, unlockContainers, galacticTrade, spatialReasoning, resource_values, initResourceTabs, marketItem, containerItem, tradeSummery, faithBonus, templePlasmidBonus, faithTempleCount } from './resources.js';
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
 import { loadIndustry, defineIndustry, nf_resources, gridDefs, addSmelter } from './industry.js';
 import { defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating, garrisonSize } from './civics.js';
@@ -3971,7 +3971,7 @@ export const actions = {
                     gain *= 1.4;
                 }
                 if (global.tech['anthropology'] && global.tech['anthropology'] >= 2){
-                    gain *= 1 + (global.city.temple.count * 0.05);
+                    gain *= 1 + (faithTempleCount() * 0.05);
                 }
                 if (global.tech['science'] && global.tech['science'] >= 5){
                     let sci_val = workerScale(global.civic.scientist.workers,'scientist');
@@ -4013,7 +4013,7 @@ export const actions = {
                         gain *= 1.4;
                     }
                     if (global.tech['anthropology'] && global.tech.anthropology >= 2){
-                        gain *= 1 + (global.city.temple.count * 0.05);
+                        gain *= 1 + (faithTempleCount() * 0.05);
                     }
                     if (global.tech['science'] && global.tech.science >= 5){
                         gain *= 1 + (workerScale(global.civic.scientist.workers,'scientist') * 0.12);
@@ -8521,7 +8521,7 @@ function sentience(){
         global.resource.Steel.display = true;
         global.resource.Steel.amount = 25;
         if (global.stats.achieve.technophobe.l >= 3){
-            if (!global.race['truepath']){
+            if (!global.race['truepath'] && !global.race['lone_survivor']){
                 global.resource.Soul_Gem.display = true;
             }
             let gems = 1;

--- a/src/civics.js
+++ b/src/civics.js
@@ -6,7 +6,7 @@ import { races, racialTrait, traits, planetTraits, biomes, fathomCheck, blubberF
 import { defineGovernor, govActive } from './governor.js';
 import { drawTech } from  './actions.js';
 import { jobScale } from './jobs.js';
-import { templeCount } from './resources.js';
+import { templeCount } from './actions.js';
 import { astrologySign, astroVal } from './seasons.js';
 import { warhead } from './resets.js';
 

--- a/src/civics.js
+++ b/src/civics.js
@@ -6,6 +6,7 @@ import { races, racialTrait, traits, planetTraits, biomes, fathomCheck, blubberF
 import { defineGovernor, govActive } from './governor.js';
 import { drawTech } from  './actions.js';
 import { jobScale } from './jobs.js';
+import { templeCount } from './resources.js';
 import { astrologySign, astroVal } from './seasons.js';
 import { warhead } from './resets.js';
 
@@ -2169,7 +2170,7 @@ export function armyRating(val,type,wound){
             army *= 1 + (traits.tactical.vars()[0] * global.race['tactical'] / 100);
         }
         if (global.tech['fanaticism'] && global.tech['fanaticism'] >= 4){
-            army *= 1 + (global.city.temple.count * 0.01);
+            army *= 1 + (templeCount() * 0.01);
         }
         if (global.race['holy'] && type === 'hellArmy'){
             army *= 1 + (traits.holy.vars()[0] / 100);

--- a/src/edenic.js
+++ b/src/edenic.js
@@ -1269,7 +1269,7 @@ const edenicModules = {
             },
             effect(){
                 let desc = `<div>${loc('interstellar_stellar_forge_effect3',[$(this)[0].smelting()])}</div>`;
-                if (global.tech['elysium'] && global.tech.elysium >= 19){
+                if (global.tech['elysium'] && global.tech.elysium >= 18){
                     desc += `<div>${loc('city_foundry_effect1',[jobScale(3)])}</div>`;
                 }
                 return `${desc}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;

--- a/src/edenic.js
+++ b/src/edenic.js
@@ -1547,6 +1547,7 @@ const edenicModules = {
                     incrementStruct('north_pier','eden');
                     if (global.eden.south_pier.count === 10 && global.eden.north_pier.count === 10 && global.tech.isle === 2){
                         global.tech.isle = 3;
+                        drawTech();
                     }
                     return true;
                 }
@@ -1726,6 +1727,7 @@ const edenicModules = {
                     incrementStruct('south_pier','eden');
                     if (global.eden.south_pier.count === 10 && global.eden.north_pier.count === 10 && global.tech.isle === 2){
                         global.tech.isle = 3;
+                        drawTech();
                     }
                     return true;
                 }

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -3,7 +3,7 @@ import { vBind, clearElement, popover, darkEffect, eventActive, easterEgg, getHa
 import { loc } from './locale.js';
 import { racialTrait, servantTrait, races, traits, biomes, planetTraits, fathomCheck } from './races.js';
 import { armyRating } from './civics.js';
-import { craftingRatio, craftCost, craftingPopover } from './resources.js';
+import { craftingRatio, craftCost, craftingPopover, templeCount } from './resources.js';
 import { planetName } from './space.js';
 import { asphodelResist } from './edenic.js';
 import { actions } from './actions.js';
@@ -281,7 +281,7 @@ export const job_desc = {
         professor *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
         professor *= racialTrait(global.civic.professor.workers,'science');
         if (global.tech['anthropology'] && global.tech['anthropology'] >= 3){
-            professor *= 1 + (global.city.temple.count * 0.05);
+            professor *= 1 + (templeCount() * 0.05);
         }
         if (global.civic.govern.type === 'theocracy'){
             professor *= 0.75;

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -3,10 +3,10 @@ import { vBind, clearElement, popover, darkEffect, eventActive, easterEgg, getHa
 import { loc } from './locale.js';
 import { racialTrait, servantTrait, races, traits, biomes, planetTraits, fathomCheck } from './races.js';
 import { armyRating } from './civics.js';
-import { craftingRatio, craftCost, craftingPopover, templeCount } from './resources.js';
+import { craftingRatio, craftCost, craftingPopover } from './resources.js';
 import { planetName } from './space.js';
 import { asphodelResist } from './edenic.js';
-import { actions } from './actions.js';
+import { actions, templeCount } from './actions.js';
 
 export const job_desc = {
     unemployed: function(servant){

--- a/src/main.js
+++ b/src/main.js
@@ -10241,6 +10241,7 @@ function midLoop(){
             if (global.portal.hasOwnProperty('spire') && global.portal.spire.count >= 50 && !global.tech['edenic'] && Object.keys(global.pillars).length >= 10){
                 messageQueue(loc('eden_purify_well_msg',[50]),'info',false,['progress']);
                 global.tech['edenic'] = 1;
+                drawTech();
             }
 
             let progress = 0;

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import { loc } from './locale.js';
 import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat, checkAdept } from './achieve.js';
 import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, addATime, exceededATimeThreshold, loopTimers, calcQuantumLevel } from './functions.js';
 import { races, traits, racialTrait, orbitLength, servantTrait, randomMinorTrait, biomes, planetTraits, shapeShift, fathomCheck, blubberFill } from './races.js';
-import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
+import { defineResources, resource_values, spatialReasoning, craftCost, plasmidBonus, faithBonus, faithTempleCount, tradeRatio, craftingRatio, crateValue, containerValue, tradeSellPrice, tradeBuyPrice, atomic_mass, supplyValue, galaxyOffers } from './resources.js';
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
@@ -831,7 +831,7 @@ function fastLoop(){
         global_multiplier *= (1 + bonus);
     }
     if (global.race['no_plasmid'] || global.race.universe === 'antimatter'){
-        if (((global.race['cataclysm'] || global.race['orbit_decayed']) && global.space['ziggurat'] && templeCount(true)) || (global.city['temple'] && global.city['temple'].count)){
+        if (faithTempleCount()){
             let faith = faithBonus();
             breakdown.p['Global'][loc('faith')] = (faith * 100) + '%';
             global_multiplier *= (1 + faith);
@@ -4066,7 +4066,7 @@ function fastLoop(){
             professors_base *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
             professors_base *= racialTrait(workerScale(global.civic.professor.workers,'professor'),'science');
             if (global.tech['anthropology'] && global.tech['anthropology'] >= 3){
-                professors_base *= 1 + (global.race['cataclysm'] || global.race['orbit_decayed'] ? (global.space['ziggurat'] ? templeCount(true) : 0) : templeCount()) * 0.05;
+                professors_base *= 1 + fathTempleCount() * 0.05;
             }
             if (global.civic.govern.type === 'theocracy'){
                 professors_base *= 1 - (govEffect.theocracy()[1] / 100);
@@ -7261,7 +7261,7 @@ function fastLoop(){
 
             let temple_mult = 1;
             if (global.tech['anthropology'] && global.tech['anthropology'] >= 4 && !global.race['truepath']){
-                temple_mult += (global.race['cataclysm'] || global.race['orbit_decayed'] ? (global.space['ziggurat'] ? templeCount(true) : 0) : templeCount()) * 0.025;
+                temple_mult += faithTempleCount() * 0.025;
             }
 
             let upkeep = 0;
@@ -8705,7 +8705,7 @@ function midLoop(){
                 shelving *= 1 + (sci_val * 0.12);
             }
             if (global.tech['anthropology'] && global.tech['anthropology'] >= 2){
-                shelving *= 1 + (global.race['cataclysm'] || global.race['orbit_decayed'] ? (global.space['ziggurat'] ? templeCount(true) : 0) : templeCount()) * 0.05;
+                shelving *= 1 + faithTempleCount() * 0.05;
             }
             let teachVal = govActive('teacher',0);
             if (teachVal){
@@ -9231,7 +9231,7 @@ function midLoop(){
             global.city.market.mtrade += routes * global.city.trade.count;
             breakdown.t_route[loc('city_trade')] = routes * global.city.trade.count;
             if (global.tech['fanaticism'] && global.tech['fanaticism'] >= 3){
-                let r_count = global.race['cataclysm'] || global.race['orbit_decayed'] ? (global.space['ziggurat'] ? templeCount(true) : 0) : templeCount();
+                let r_count = faithTempleCount();
                 global.city.market.mtrade += r_count;
                 breakdown.t_route[global.race['cataclysm'] ? loc('space_red_ziggurat_title') : structName('temple')] = r_count;
             }

--- a/src/main.js
+++ b/src/main.js
@@ -4066,7 +4066,7 @@ function fastLoop(){
             professors_base *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
             professors_base *= racialTrait(workerScale(global.civic.professor.workers,'professor'),'science');
             if (global.tech['anthropology'] && global.tech['anthropology'] >= 3){
-                professors_base *= 1 + fathTempleCount() * 0.05;
+                professors_base *= 1 + faithTempleCount() * 0.05;
             }
             if (global.civic.govern.type === 'theocracy'){
                 professors_base *= 1 - (govEffect.theocracy()[1] / 100);

--- a/src/resources.js
+++ b/src/resources.js
@@ -3068,7 +3068,7 @@ export const spatialReasoning = (function(){
     }
 })();
 
-function faithTempleCount(){
+export function faithTempleCount(){
     let noEarth = global.race['cataclysm'] || global.race['orbit_decayed'] ? true : false;
     return templeCount(noEarth);
 }

--- a/src/resources.js
+++ b/src/resources.js
@@ -2997,8 +2997,8 @@ export const spatialReasoning = (function(){
             global.race['nerfed'] || '0',
             global.genes['store'] || '0',
             global.genes['bleed'] || '0',
-            global.city['temple'] ? global.city.temple.count : '0',
-            global.space['ziggurat'] ? global.space.ziggurat.count : '0',
+            templeCount(false) || '0',
+            templeCount(true) || '0',
             global.race['cataclysm'] ? global.race.cataclysm : '0',
             global.race['orbit_decayed'] ? global.race.orbit_decayed : '0',
             global.genes['ancients'] || '0',
@@ -3010,7 +3010,6 @@ export const spatialReasoning = (function(){
         }
         if (!spatial[tkey][key] || recalc){            
             let modifier = 1;
-            let noEarth = global.race['cataclysm'] || global.race['orbit_decayed'] ? true : false;
             if (global.genes['store']){
                 let plasmids = 0;
                 if (!type || (type && ((type === 'plasmid' && global.race.universe !== 'antimatter') || (type === 'anti' && global.race.universe === 'antimatter')))){
@@ -3045,7 +3044,7 @@ export const spatialReasoning = (function(){
             if (global.race.universe === 'standard'){
                 modifier *= darkEffect('standard');
             }
-            if (global.race.universe === 'antimatter' && ((!noEarth && global.city['temple'] && global.city['temple'].count) || (noEarth && global.space['ziggurat'] && global.space['ziggurat'].count))){
+            if (global.race.universe === 'antimatter' && faithTempleCount()){
                 let temple = 0.06;
                 if (global.genes['ancients'] && global.genes['ancients'] >= 2 && global.civic.priest.display){
                     let priest = global.genes['ancients'] >= 5 ? 0.0012 : (global.genes['ancients'] >= 3 ? 0.001 : 0.0008);
@@ -3054,7 +3053,7 @@ export const spatialReasoning = (function(){
                     }
                     temple += priest * global.civic.priest.workers;
                 }
-                modifier *= 1 + ((noEarth ? global.space.ziggurat.count : global.city.temple.count) * temple);
+                modifier *= 1 + (faithTempleCount() * temple);
             }
             if (!type){
                 if (global['pillars']){
@@ -3070,15 +3069,8 @@ export const spatialReasoning = (function(){
 })();
 
 function faithTempleCount(){
-    let num_temples = 0;
     let noEarth = global.race['cataclysm'] || global.race['orbit_decayed'] ? true : false;
-    if (noEarth && global.space['ziggurat']){
-        num_temples = templeCount(true);
-    }
-    else if (global.city['temple']){
-        num_temples = templeCount(false);
-    }
-    return num_temples;
+    return templeCount(noEarth);
 }
 
 export function faithBonus(num_temples = -1){
@@ -3186,8 +3178,8 @@ export const plasmidBonus = (function (){
             global.race['nerfed'] || '0',
             global.race['no_plasmid'] || '0',
             global.genes['ancients'] || '0',
-            global.city['temple'] ? global.city.temple.count : '0',
-            global.space['ziggurat'] ? global.space.ziggurat.count : '0',
+            templeCount(false) || '0',
+            templeCount(true) || '0',
             global.civic['priest'] ? global.civic.priest.workers : '0',
             global.race['orbit_decayed'] ? global.race.orbit_decayed : '0',
             global.race['spiritual'] || '0',

--- a/src/space.js
+++ b/src/space.js
@@ -6,7 +6,7 @@ import { spatialReasoning, unlockContainers, drawResourceTab, atomic_mass } from
 import { loadFoundry, jobScale } from './jobs.js';
 import { defineIndustry, addSmelter } from './industry.js';
 import { garrisonSize, describeSoldier, checkControlling, govTitle } from './civics.js';
-import { actions, payCosts, powerOnNewStruct, initStruct, setAction, setPlanet, storageMultipler, drawTech, bank_vault, updateDesc, actionDesc, templeEffect, casinoEffect, wardenLabel, buildTemplate, structName } from './actions.js';
+import { actions, payCosts, powerOnNewStruct, initStruct, setAction, setPlanet, storageMultipler, drawTech, bank_vault, updateDesc, actionDesc, templeEffect, templeCount, casinoEffect, wardenLabel, buildTemplate, structName } from './actions.js';
 import { outerTruthTech, syndicate } from './truepath.js';
 import { production, highPopAdjust } from './prod.js';
 import { defineGovernor, govActive } from './governor.js';

--- a/src/space.js
+++ b/src/space.js
@@ -1238,7 +1238,7 @@ const spaceProjects = {
                     sci += num_lab_on * 25;
                 }
                 if (global.tech['ancient_study'] && global.tech['ancient_study'] >= 2){
-                    sci += global.space.ziggurat.count * 15;
+                    sci += templeCount(true) * 15;
                 }
                 let num_mass_driver_on = wiki ? (global.city?.mass_driver?.on ?? 0) : p_on['mass_driver'];
                 if (global.tech.mass >= 2 && num_mass_driver_on > 0){
@@ -7206,7 +7206,7 @@ export function int_fuel_adjust(fuel){
 
 export function zigguratBonus(){
     let bonus = 1;
-    if (global.space['ziggurat'] && global.space['ziggurat'].count > 0){
+    if (global.space['ziggurat']){
         let zig = global.tech['ancient_study'] ? 0.006 : 0.004;
         if (global.tech['ancient_deify'] && global.tech['ancient_deify'] >= 2 && support_on['exotic_lab']){
             zig += 0.0001 * support_on['exotic_lab'];
@@ -7224,7 +7224,7 @@ export function zigguratBonus(){
         if (global.race['high_pop']){
             zig = highPopAdjust(zig);
         }
-        bonus += (global.space.ziggurat.count * global.civic.colonist.workers * zig);
+        bonus += (templeCount(true) * global.civic.colonist.workers * zig);
     }
     return bonus;
 }

--- a/src/wiki/species.js
+++ b/src/wiki/species.js
@@ -122,7 +122,7 @@ export function racesPage(content){
         });
         
         Object.keys(races[race].traits).sort().forEach(function (trait){
-            if (hallowed.active && (race === 'tortoisan' && trait === 'slow') || (race === 'unicorn' && trait === 'rainbow')){
+            if (hallowed.active && ((race === 'tortoisan' && trait === 'slow') || (race === 'unicorn' && trait === 'rainbow'))){
                 return;
             }
             let id = `raceTrait${race}${trait}`;


### PR DESCRIPTION
Fixed unicorn not having rainbow on species list in wiki.
Added redraw after spire floor 50 so purify essence tech shows up.
Added redraw after piers in edenic so spirit vacuum tech shows up.
Fixed sacred smelter tooltip not having +3 crafters
Removed soul gem display in lone survivor
Lots of temple fixes mostly related to descriptions and missing upgrade interaction.
Fix professor description to include free temples and scale with ziggurats in cata/OD like their production does
Fix exolab description to include free ziggurats
Fix library description to include free temple
Temple faith effect no longer requires a temple to be built now.
Free temple affects zealotry now
Free ziggurat affects space production now
Free temple and ziggurat affect storage in antimatter now
