### PR TITLE
Deplete default job first when paying population

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -4678,6 +4678,7 @@ export function buildTemplate(key, region){
                     }
                     else if (global['resource'][global.race.species].max > global['resource'][global.race.species].amount && payCosts($(this)[0])){
                         global['resource'][global.race.species].amount++;
+                        global.civic[global.civic.d_job].workers++;
                         return true;
                     }
                     return false;

--- a/src/actions.js
+++ b/src/actions.js
@@ -7408,11 +7408,16 @@ export function payCosts(c_action, costs){
                 let cost = costs[res]();
                 global.portal.purifier.supply -= cost;
             }
+            else if (res === 'Species'){
+                let cost = costs[res]();
+                global.resource[global.race.species].amount -= cost;
+                // If the default job does not have enough workers, then the main game loop will deplete some other job
+                global.civic[global.civic.d_job].workers = Math.max(0, global.civic[global.civic.d_job].workers - cost);
+            }
             else if (res !== 'Morale' && res !== 'Army' && res !== 'HellArmy' && res !== 'Troops' && res !== 'Structs' && res !== 'Bool' && res !== 'Custom'){
                 let cost = costs[res]();
-                let f_res = res === 'Species' ? global.race.species : res;
-                global['resource'][f_res].amount -= cost;
-                if (f_res === 'Knowledge'){
+                global.resource[res].amount -= cost;
+                if (res === 'Knowledge'){
                     global.stats.know += cost;
                 }
             }

--- a/src/civics.js
+++ b/src/civics.js
@@ -1918,9 +1918,7 @@ function war_campaign(gov){
             }
             if (infected > 0){
                 global.resource[global.race.species].amount += infected;
-                if (global.civic.d_job !== 'unemployed'){
-                    global.civic[global.civic.d_job].workers += infected;
-                }
+                global.civic[global.civic.d_job].workers += infected;
                 if (infected === 1){
                     messageQueue(loc('civics_garrison_soldier_infected'),'special',false,['combat']);
                 }

--- a/src/edenic.js
+++ b/src/edenic.js
@@ -1620,6 +1620,7 @@ const edenicModules = {
                 }
                 else if (global.eden.reincarnation.count === 1 && global['resource'][global.race.species].max > global['resource'][global.race.species].amount && payCosts($(this)[0])){
                     global['resource'][global.race.species].amount++;
+                    global.civic[global.civic.d_job].workers++;
                     if (global.race['warlord']){
                         global.stats.warlord.r = true;
                         checkWarlordAchieve();

--- a/src/main.js
+++ b/src/main.js
@@ -3857,6 +3857,7 @@ function fastLoop(){
             let missing = Math.min(global.civic.homeless, global.resource[global.race.species].max - global.resource[global.race.species].amount);
             global.civic.homeless -= missing;
             global.resource[global.race.species].amount += missing;
+            global.civic[global.civic.d_job].workers++;
         }
         else if (((fed && global['resource']['Food'].amount > 0) || global.race['fasting']) && global['resource'][global.race.species].max > global['resource'][global.race.species].amount){
             if (global.race['artifical'] || (global.race['spongy'] && global.city.calendar.weather === 0)){
@@ -3924,6 +3925,7 @@ function fastLoop(){
                 upperBound *= (3 - (2 ** time_multiplier));
                 if(Math.rand(0, upperBound) <= lowerBound){
                     global['resource'][global.race.species].amount++;
+                    global.civic[global.civic.d_job].workers++;
                 }
             }
         }


### PR DESCRIPTION
Not tested, but the change seems simple enough. Without this change, population costs for actions will be stolen from the bottom jobs first, so probably ship crew, archaeologists, etc.

Motivated by Discord bug report: https://discord.com/channels/586926974585274373/1330324166406307972