### PR TITLE
Merge casino storage and earning logic

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -5380,47 +5380,49 @@ export function templeEffect(){
     return desc;
 }
 
-export function casinoEffect(){
-    let money = global.tech['gambling'] >= 3 ? 60000 : 40000;
+export function casino_vault(){
+    let vault = global.tech['gambling'] >= 3 ? 60000 : 40000;
     if (global.tech['gambling'] >= 5){
-        money += global.tech['gambling'] >= 6 ? 240000 : 60000;
+        vault += global.tech['gambling'] >= 6 ? 240000 : 60000;
     }
-    money = spatialReasoning(money);
+    vault = spatialReasoning(vault);
     if (global.race['gambler']){
-        money *= 1 + (global.race['gambler'] * 0.04);
+        vault *= 1 + (traits.gambler.vars()[0] * global.race['gambler'] / 100);
     }
     if (global.tech['world_control']){
-        money = money * 1.25;
+        vault *= 1.25;
     }
     if (global.race['truepath']){
-        money = money * 1.5;
+        vault *= 1.5;
     }
     if (global.tech['stock_exchange'] && global.tech['gambling'] >= 4){
-        money *= 1 + (global.tech['stock_exchange'] * 0.05);
+        vault *= 1 + (global.tech['stock_exchange'] * 0.05);
     }
     if (global.race['inflation']){
-        money *= 1 + (global.race.inflation / 100);
+        vault *= 1 + (global.race.inflation / 100);
     }
     if (global.tech['isolation']){
-        money *= 5.5;
+        vault *= 5.5;
     }
-    money = Math.round(money);
+    return vault;
+}
 
-    let joy = global.race['joyless'] ? '' : `<div>${loc('plus_max_resource',[jobScale(1),loc(`job_entertainer`)])}</div>`;
-    let banker = global.race['orbit_decayed'] || global.tech['isolation'] ? `<div>${loc('plus_max_resource',[jobScale(1),loc('banker_name')])}</div>` : '';
-    let desc = `<div>${loc('plus_max_resource',[`\$${money.toLocaleString()}`,loc('resource_Money_name')])}</div>${joy}${banker}<div>${loc('city_max_morale',[1])}</div>`;
-    let cash = Math.log2(1 + global.resource[global.race.species].amount) * (global.race['gambler'] ? 2.5 + (global.race['gambler'] / 10) : 2.5);
+export function casinoEarn(){
+    let cash = Math.log2(1 + global.resource[global.race.species].amount) * 2.5;
+    if (global.race['gambler']){
+        cash *= 1 + (traits.gambler.vars()[0] * global.race['gambler'] / 100);
+    }
     if (global.tech['gambling'] && global.tech['gambling'] >= 2){
         cash *= global.tech.gambling >= 5 ? 2 : 1.5;
-    }
-    if (global.tech['stock_exchange'] && global.tech['gambling'] >= 4){
-        cash *= 1 + (global.tech['stock_exchange'] * 0.01);
+        if (global.tech['stock_exchange'] && global.tech['gambling'] >= 4){
+            cash *= 1 + (global.tech['stock_exchange'] * 0.01);
+        }
     }
     if (global.civic.govern.type === 'corpocracy'){
-        cash *= 3;
+        cash *= 1 + (govEffect.corpocracy()[0] / 100);
     }
     if (global.civic.govern.type === 'socialist'){
-        cash *= 0.8;
+        cash *= 1 - (govEffect.socialist()[3] / 100);
     }
     if (global.race['inflation']){
         cash *= 1 + (global.race.inflation / 1250);
@@ -5431,10 +5433,24 @@ export function casinoEffect(){
             cash *= 1 + (workerScale(global.civic.banker.workers,'banker') * 0.05)
         }
     }
+    cash *= production('psychic_cash');
+    let racVal = govActive('racketeer', 1);
+    if (racVal){
+        cash *= 1 + (racVal / 100);
+    }
     if (global.race['wish'] && global.race['wishStats'] && global.race.wishStats.casino){
         cash *= 1.35;
     }
-    cash = +(cash).toFixed(2);
+    return cash;
+}
+
+export function casinoEffect(){
+    let money = Math.round(casino_vault());
+
+    let joy = global.race['joyless'] ? '' : `<div>${loc('plus_max_resource',[jobScale(1),loc(`job_entertainer`)])}</div>`;
+    let banker = global.race['orbit_decayed'] || global.tech['isolation'] ? `<div>${loc('plus_max_resource',[jobScale(1),loc('banker_name')])}</div>` : '';
+    let desc = `<div>${loc('plus_max_resource',[`\$${money.toLocaleString()}`,loc('resource_Money_name')])}</div>${joy}${banker}<div>${loc('city_max_morale',[1])}</div>`;
+    let cash = +(casinoEarn()).toFixed(2);
     desc = desc + `<div>${loc('tech_casino_effect2',[cash])}</div>`;
     return desc;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { defineResources, resource_values, spatialReasoning, craftCost, plasmidB
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
-import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct } from './actions.js';
+import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn } from './actions.js';
 import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
@@ -7298,42 +7298,7 @@ function fastLoop(){
             if (p_on['spc_casino']){ casinos += p_on['spc_casino']; }
             if (p_on['tauceti_casino']){ casinos += p_on['tauceti_casino']; }
 
-            let cash = Math.log2(1 + global.resource[global.race.species].amount);
-            let revenue = 2.5;
-            if (global.race['gambler']){
-                revenue *= 1 + (traits.gambler.vars()[0] * global.race['gambler'] / 100);
-            }
-            cash *= revenue;
-            if (global.tech.gambling >= 2){
-                cash *= global.tech.gambling >= 5 ? 2 : 1.5;
-            }
-            if (global.tech['stock_exchange'] && global.tech['gambling'] >= 4){
-                cash *= 1 + (global.tech['stock_exchange'] * 0.01);
-            }
-            if (global.civic.govern.type === 'corpocracy'){
-                cash *= 1 + (govEffect.corpocracy()[0] / 100);
-            }
-            if (global.civic.govern.type === 'socialist'){
-                cash *= 1 - (govEffect.socialist()[3] / 100);
-            }
-            if (global.race['inflation']){
-                cash *= 1 + (global.race.inflation / 1250);
-            }
-            if (global.tech['isolation']){
-                cash *= 1.25;
-                if (global.tech['iso_gambling']){
-                    cash *= 1 + (workerScale(global.civic.banker.workers,'banker') * 0.05)
-                }
-            }
-            cash *= production('psychic_cash');
-            let racVal = govActive('racketeer',1);
-            if (racVal){
-                cash *= 1 + (racVal / 100);
-            }
-            if (global.race['wish'] && global.race['wishStats'] && global.race.wishStats.casino){
-                cash *= 1.35;
-            }
-            cash *= casinos;
+            let cash = casinos * casinoEarn();
             breakdown.p['Money'][loc('city_casino')] = cash + 'v';
             modRes('Money', +(cash * time_multiplier * global_multiplier * hunger).toFixed(2));
             rawCash += cash * global_multiplier * hunger;
@@ -8985,26 +8950,8 @@ function midLoop(){
             if (global.tauceti['tauceti_casino'] && global.tauceti.tauceti_casino.count > 0){
                 casinos += global.tauceti.tauceti_casino.count;
             }
-            let casino_capacity = global.tech['gambling'] >= 3 ? 60000 : 40000;
-            if (global.tech['gambling'] >= 5){
-                casino_capacity += global.tech['gambling'] >= 6 ? 240000 : 60000;
-            }
-            let vault = casinos * spatialReasoning(casino_capacity);
-            if (global.race['gambler']){
-                vault *= 1 + (traits.gambler.vars()[0] * global.race['gambler'] / 100);
-            }
-            if (global.tech['world_control']){
-                vault = Math.round(vault * 1.25);
-            }
-            if (global.tech['stock_exchange'] && global.tech['gambling'] >= 4){
-                vault *= 1 + (global.tech['stock_exchange'] * 0.05);
-            }
-            if (global.race['inflation']){
-                vault *= 1 + (global.race.inflation / 100);
-            }
-            if (global.tech['isolation']){
-                vault *= 5.5;
-            }
+
+            let vault = casinos * casino_vault();
             caps['Money'] += vault;
             breakdown.c.Money[loc('city_casino')] = vault+'v';
         }


### PR DESCRIPTION
Motivated by a bug report that casinos were not storing 1.5x as much money in True Path. The wiki and the description indicate the extra storage, but the game loop did not apply the bonus storage.

Not tested at this time.