### PR TITLE
Misc fixes. (elemental smelters, high pop in eden)

### DIFF
--- a/src/governor.js
+++ b/src/governor.js
@@ -1499,6 +1499,10 @@ export const gov_tasks = {
             }
 
             let rBal = false;
+            let blacklist = ['Asphodel_Powder', 'Elysanite'];
+            if(global.race['fasting']){
+                blacklist.push('Food');
+            }
             for (let idx = 0; global.race.governor.config.replicate.res.que && idx < global.queue.queue.length; idx++){
                 let struct = decodeStructId(global.queue.queue[idx].id);
                 let tc = false;
@@ -1512,7 +1516,7 @@ export const gov_tasks = {
                 }
                 let resSorted = Object.keys(tc.s).sort(function(a,b){return tc.s[b]-tc.s[a]});
                 for (let i=0; i<resSorted.length; i++){
-                    if (global.resource[resSorted[i]] && global.resource[resSorted[i]].display && atomic_mass[resSorted[i]] && !(resSorted[i] === 'Food' && global.race['fasting'])){
+                    if (global.resource[resSorted[i]] && global.resource[resSorted[i]].display && atomic_mass[resSorted[i]] && !blacklist.includes(resSorted[i])){
                         global.race.replicator.res = resSorted[i];
                         rBal = true;
                         break;

--- a/src/industry.js
+++ b/src/industry.js
@@ -1472,8 +1472,12 @@ function loadReplicator(parent,bind){
         }
         else {
             let scrollMenu = ``;
+            let blacklist = ['Asphodel_Powder', 'Elysanite'];
+            if(global.race['fasting']){
+                blacklist.push('Food');
+            }
             Object.keys(atomic_mass).forEach(function(res){
-                if (global.resource[res].display && res !== 'Asphodel_Powder' && res !== 'Elysanite'){
+                if (global.resource[res].display && !blacklist.includes(res)){
                     scrollMenu += `<b-radio-button v-model="res" native-value="${res}">${global.resource[res].name}</b-radio-button>`;
                 }
             });

--- a/src/main.js
+++ b/src/main.js
@@ -4226,7 +4226,6 @@ function fastLoop(){
                 let ghost_base = workerScale(global.civic.ghost_trapper.workers,'ghost_trapper');
                 ghost_base *= racialTrait(ghost_base,'science');
                 ghost_base *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
-                ghost_base = highPopAdjust(ghost_base);
 
                 let ghost_gain = support_on['research_station'] * ghost_base * 0.0000325;
                 breakdown.p['Omniscience'][loc('eden_research_station_title')] = ghost_gain + 'v';
@@ -4240,8 +4239,6 @@ function fastLoop(){
             if (global.tech['science'] && global.tech.science >= 23){
                 let scientist = workerScale(global.civic.scientist.workers,'scientist');
                 scientist *= racialTrait(scientist,'science');
-                scientist *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
-                scientist = highPopAdjust(scientist);
 
                 let sci_gain = scientist * 0.000707;
                 breakdown.p['Omniscience'][global.civic.scientist.name] = sci_gain + 'v';
@@ -4995,6 +4992,9 @@ function fastLoop(){
                 }
                 if (dirtVal){
                     steel_smelter *= 1 + (dirtVal / 100);
+                }
+                if (global.race['elemental'] && traits.elemental.vars()[0] === 'fire'){
+                    steel_smelter *= 1 + highPopAdjust(traits.elemental.vars()[3] * global.resource[global.race.species].amount / 100);
                 }
                 if (salFathom > 0){
                     steel_smelter *= 1 + (0.2 * salFathom);
@@ -6908,7 +6908,6 @@ function fastLoop(){
             if (global.civic.elysium_miner.display){
                 let miner_base = workerScale(global.civic.elysium_miner.workers,'elysium_miner');
                 miner_base *= racialTrait(miner_base,'miner') * 0.36;
-                miner_base = highPopAdjust(miner_base);
 
                 if (!global.race['living_tool'] && !global.race['tusk']){
                     miner_base *= (global.tech['pickaxe'] && global.tech.pickaxe > 0 ? global.tech.pickaxe * 0.15 : 0) + 1;
@@ -7700,6 +7699,8 @@ function fastLoop(){
                 global.portal.carport.repair = 0;
                 global.portal.carport.damaged--;
             }
+            //limit carport damage to account for removing high population
+            global.portal.carport.damaged = Math.min(global.portal.carport.damaged, jobScale(global.portal.carport.count));
         }
         else {
             if ($('#portal-carport .count').hasClass('has-text-alert')){
@@ -9088,9 +9089,6 @@ function midLoop(){
             let sci = 200 + attact;
             if (global.tech['science'] && global.tech.science >= 22 && p_on['embassy'] && p_on['symposium']){
                 sci *= 1 + (p_on['symposium'] * piracy('gxy_gorddon'));
-            }
-            if (global.race['high_pop']){
-                sci = highPopAdjust(sci);
             }
             let gain = support_on['research_station'] * highPopAdjust(global.civic.ghost_trapper.workers) * sci;
             caps['Knowledge'] += gain;

--- a/src/main.js
+++ b/src/main.js
@@ -4239,6 +4239,7 @@ function fastLoop(){
             if (global.tech['science'] && global.tech.science >= 23){
                 let scientist = workerScale(global.civic.scientist.workers,'scientist');
                 scientist *= racialTrait(scientist,'science');
+                scientist *= global.race['pompous'] ? (1 - traits.pompous.vars()[0] / 100) : 1;
 
                 let sci_gain = scientist * 0.000707;
                 breakdown.p['Omniscience'][global.civic.scientist.name] = sci_gain + 'v';

--- a/src/main.js
+++ b/src/main.js
@@ -6916,6 +6916,13 @@ function fastLoop(){
                 if (global.tech['explosives'] && global.tech.explosives >= 2){
                     miner_base *= 0.95 + (global.tech.explosives * 0.15);
                 }
+                if (global.race['tough']){
+                    miner_base *= 1 + (traits.tough.vars()[0] / 100);
+                }
+                let ogreFathom = fathomCheck('ogre');
+                if (ogreFathom > 0){
+                    miner_base *= 1 + (traits.tough.vars(1)[0] / 100 * ogreFathom);
+                }
 
                 breakdown.p['Elysanite'][loc('job_elysium_miner')] = miner_base + 'v';
 

--- a/src/space.js
+++ b/src/space.js
@@ -5573,10 +5573,14 @@ const galaxyProjects = {
             effect(wiki){
                 let pirate = piracy('gxy_gorddon',false,false,wiki);
                 let leave = '';
+                let spirit_box = '';
                 if (global.tech.xeno >= 7){
                     leave = `<div>${loc('galaxy_symposium_effect3',[+highPopAdjust(300 * pirate).toFixed(2)])}</div>`;
                 }
-                return `<div class="has-text-caution">${loc(`requires_res`,[loc('galaxy_embassy')])}</div><div>${loc('galaxy_symposium_effect',[(1750 * pirate).toFixed(0)])}</div><div>${loc('galaxy_symposium_effect2',[(650 * pirate).toFixed(0)])}</div>${leave}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
+                if(global.tech.science >= 22){
+                    spirit_box = `<div>${loc('galaxy_symposium_effect4',[+(100 * pirate).toFixed(2), loc('eden_research_station_title')])}</div>`;
+                }
+                return `<div class="has-text-caution">${loc(`requires_res`,[loc('galaxy_embassy')])}</div><div>${loc('galaxy_symposium_effect',[(1750 * pirate).toFixed(0)])}</div><div>${loc('galaxy_symposium_effect2',[(650 * pirate).toFixed(0)])}</div>${leave}${spirit_box}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
             powered(){ return powerCostMod(4); },
             action(){

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -6876,6 +6876,7 @@
   "galaxy_symposium_effect": "+%0 Max Knowledge per Dormitory",
   "galaxy_symposium_effect2": "+%0 Max Knowledge per active Galactic Trade Route",
   "galaxy_symposium_effect3": "+%0 Max Knowledge per crew stationed in system",
+  "galaxy_symposium_effect4": "+%0% %1 Max Knowledge",
   "galaxy_freighter": "Freighter",
   "galaxy_freighter_effect": "+%0 %1 Trade Routes",
   "galaxy_freighter_assign": "Assign a freighter to import %0 and export %1.",


### PR DESCRIPTION
Added blacklist to replicator and governor task to disallow either setting asphodel powder, Elysanite or food during fasting.
Added tooltip to symposiums to show that they boost magisteriums.
Added fix to prevent surveyor job slots from going negative when high population is removed.

Fixed high population penalty applying twice to omniscience production, Elysanite miners and magisterium knowledge cap.
Fixed Elysanite miners not being affected by tough
Fixed elemental fire not applying its smelting bonus to steel production.