### PR TITLE
Make soul gem count also clickable in hell reports

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -5601,7 +5601,7 @@ function drawHellReports(){
                     gemString = `<span class="has-text-advanced" aria-label="${loc(`hell_report_log_soul_gem_aria`)}">${gemCount >= 5 ? `&#9830x${gemCount}` : "&#9830".repeat(gemCount)}</span>`;
                 }
                 list = `
-                    <div class="text-button"><span @click="reportLoad('${startYear}','${startDay}')">${loc('year') + " " + startYear + " | " + loc('day') + " " + startDay}</span>${gemString}</div>
+                    <div class="text-button"><span @click="reportLoad('${startYear}','${startDay}')">${loc('year') + " " + startYear + " | " + loc('day') + " " + startDay}${gemString}</span></div>
                 ` + list;
             }
             startDay = 1;
@@ -5613,7 +5613,7 @@ function drawHellReports(){
                 gemString = `<span class="has-text-advanced" aria-label="${loc(`hell_report_log_soul_gem_aria`)}">${gemCount >= 5 ? `&#9830x${gemCount}` : "&#9830".repeat(gemCount)}</span>`;
             }
             list = `
-                <div class="text-button"><span @click="reportLoad('${startYear}','${startDay}')">${loc('year') + " " + startYear + " | " + loc('day') + " " + startDay}</span>${gemString}</div>
+                <div class="text-button"><span @click="reportLoad('${startYear}','${startDay}')">${loc('year') + " " + startYear + " | " + loc('day') + " " + startDay}${gemString}</span></div>
             ` + list;
         }
         recentDay.year = startYear;


### PR DESCRIPTION
This part:
![image](https://github.com/user-attachments/assets/1a379ced-d57f-4797-b37e-42b65e97fdff)
It looks like you can click it, but that doesn't open the report. You need to click the white text.