### PR TITLE
Refactor alchemy addSpell/subSpell loops into linear for better performance

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -2944,26 +2944,18 @@ export function loadAlchemy(name,color,basic){
             methods: {
                 addSpell(spell){
                     let keyMult = keyMultiplier();
-                    for (let i=0; i<keyMult; i++){
-                        if (global.resource.Mana.diff >= 1){
-                            global.race.alchemy[spell]++;
-                            global.resource.Mana.diff--;
-                        }
-                        else {
-                            break;
-                        }
+                    let change = Math.min(Math.floor(global.resource.Mana.diff), keyMult);
+                    if (change > 0) {
+                        global.race.alchemy[spell] += change;
+                        global.resource.Mana.diff -= change;
                     }
                 },
                 subSpell(spell){
                     let keyMult = keyMultiplier();
-                    for (let i=0; i<keyMult; i++){
-                        if (global.race.alchemy[spell] > 0){
-                            global.race.alchemy[spell]--;
-                            global.resource.Mana.diff++;
-                        }
-                        else {
-                            break;
-                        }
+                    let change = Math.min(global.race.alchemy[spell], keyMult);
+                    if (change > 0) {
+                        global.race.alchemy[spell] -= change;
+                        global.resource.Mana.diff += change;
                     }
                 },
             }


### PR DESCRIPTION
Alchemy addSpell/subSpell code loops over the whole keyMultiplier one at a time, writing to Vue reactive properties that are expensive to write to much more often than necessary.

Since mana generation can get really high at very high levels of prestige, this ends up being very slow when assigning/reassigning endgame levels of mana at once (potentially many millions). This reduces the usage by the maximum amount that can be assigned per click (so a ~25000x performance improvement if ctrl-alt-shift-clicking).