### PR TITLE
Fix trait description in ARPA when empowered

### DIFF
--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2308,14 +2308,14 @@ function genetics(){
 
             let id = `raceTrait${t}`;
             let desc = $(`<div></div>`);
-            getTraitDesc(desc, t, { trank: global.race[t] });
+            getTraitDesc(desc, t, { trank: traitRank(t) });
             popover(id,desc,{ wide: true, classes: 'w30' });
         });
 
         null_list.forEach(function (t){
             let id = `raceTrait${t}`;
             let desc = $(`<div></div>`);
-            getTraitDesc(desc, t, { trank: global.race[t] });
+            getTraitDesc(desc, t, { trank: traitRank(t) });
             popover(id, desc, { elm: `#geneticBreakdown .trait${t}`, wide: true, classes: 'w30' });
         });
 


### PR DESCRIPTION
Currently if you have empowered, trait descriptions are shown as if you don't have it. This fixes that.