### PR TITLE
Fixed some immoral inconsistencies

### DIFF
--- a/src/vars.js
+++ b/src/vars.js
@@ -1724,16 +1724,6 @@ if (typeof global.civic.foreign.gov2['name'] !== "undefined" && global.civic.for
     global.civic.foreign.gov2.name.s1 = 'Divine';
 }
 
-if (!global.race['evil'] && global.race['immoral'] && global.race !== undefined && global.race.species !== 'wendigo'){
-    delete global.race['immoral'];
-}
-else if (global.race !== undefined && global.race.species === 'wendigo'){
-    const date = new Date();
-    if (global.settings.hasOwnProperty('boring') && !global.settings.boring && date.getMonth() === 11 && date.getDate() >= 17){
-        global.race['immoral'] = 3;
-    }
-}
-
 {
     if (global.hasOwnProperty('special') && global.special.hasOwnProperty('gift')){
         const sdate = new Date(global.stats.start);


### PR DESCRIPTION
Immoral was previously removed on game load if your species didn't have the evil trait. This was presumably an ancient leftover from a patch that accidentally added immoral onto every race. It should not be necessary anymore.
This code caused issues as it also removed immoral from non-evil demons and celestial Nephilim upon game load. Both races that are possible to play with standard gameplay.

Immoral no longer added to wendigo on game load during Christmas period.
During Christmas, Wendigos are reskinned as Krampus and get three additional traits, however for some reason, after a game load, the immoral trait is added if you don't have it yet, even if you mutated it out or didn't even start the run as Krampus. This was the only event trait that works like that.