### PR TITLE
Added extra flair to chicken hunter event

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -3,6 +3,7 @@ import { loc } from './locale.js';
 import { races, traits, fathomCheck, blubberFill } from './races.js';
 import { govTitle, garrisonSize, armyRating } from './civics.js';
 import { housingLabel, drawTech, actions } from './actions.js';
+import { flib } from './functions.js';
 import { tradeRatio } from './resources.js';
 import { checkControlling, soldierDeath } from './civics.js';
 import { govActive } from './governor.js';
@@ -594,10 +595,14 @@ export const events = {
         type: 'major',
         effect(){
             let dead = Math.floor(seededRandom(2,jobScale(10)));
+            let type = Math.floor(seededRandom(0,10));
             if (dead > global.resource[global.race.species].amount){ dead = global.resource[global.race.species].amount; }
             global.resource[global.race.species].amount -= dead;
             blubberFill(dead);
-            return loc('event_chicken',[loc(`event_chicken_eaten${Math.floor(seededRandom(0,10))}`),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
+            if(type === 7){
+                return loc('event_chicken',[loc(`event_chicken_eaten${type}`, [flib('name')]),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
+            }
+            return loc('event_chicken',[loc(`event_chicken_eaten${type}`),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
         }
     },
     brawl:{ 

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -663,7 +663,7 @@
   "event_chicken_eaten4": "velociraptor",
   "event_chicken_eaten5": "gluttony demon",
   "event_chicken_eaten6": "bloodthirsty feral chicken",
-  "event_chicken_eaten7": "group of hunters",
+  "event_chicken_eaten7": "group of %0 hunters",
   "event_chicken_eaten8": "swarm of ants",
   "event_chicken_eaten9": "cute bunny that's surprisingly fast, deadly, and hungry for meat",
   "event_chicken_seasoning0": "Lemon pepper seasoning",


### PR DESCRIPTION
The "X citizens were devoured by a group of hunters" event is supposed to be a monster hunter reference, but in it's current state, it's very bland.

I've updated it so it contains your species name, so it would turn into a "group of Tortoisan hunters" for example.