### PR TITLE
Fix Double Application of Plasmid Storage Nerf in TruePath

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -3020,10 +3020,7 @@ export const spatialReasoning = (function(){
                         let active = global.race.p_mutation + (global.race['wish'] && global.race['wishStats'] ? global.race.wishStats.plas : 0);
                         raw = Math.min(active, plasmids);
                     }
-                    else if (global.race['nerfed']){
-                        raw = Math.floor(plasmids / (global.race.universe === 'antimatter' ? 2 : 5));
-                    }
-                    plasmids = Math.round(raw * (global.race['nerfed'] ? 0.5 : 1));
+                    plasmids = Math.round(raw * (global.race['nerfed'] ? .5 : 1));
                 }
                 if (!type || (type && type === 'phage')){
                     if (global.genes['store'] >= 4){


### PR DESCRIPTION
Fixes #1031 
The current behavior of the nerfed gene causes an application of the production malus to effective plasmid count, followed by the application of the storage malus stated on the wiki.  The fact that this occurs in two steps and is incongruent with the wiki leads me to believe it is a bug.