### PR TITLE
Fix purgatory values

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="https://unpkg.com/sortablejs@1.10.2/Sortable.min.js" integrity="sha384-6qM1TfKo1alBw3Uw9AWXnaY5h0G3ScEjxtUm4TwRJm7HRmDX8UfiDleTAEEg5vIe" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/chart.js@3.8.2/dist/chart.min.js" integrity="sha384-z7c1KnSCkMpfoib43Lq1v2pokQC8cdqBWmH2qiyH2KkmNv60hACtZUjoCEkp1Y08" crossorigin="anonymous"></script>
     <script src="lib/lz-string.min.js"></script>
-    <script src="evolve/main.js" type="module"></script>
+    <script src="src/main.js" type="module"></script>
 </head>
 <body>
     <style>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="https://unpkg.com/sortablejs@1.10.2/Sortable.min.js" integrity="sha384-6qM1TfKo1alBw3Uw9AWXnaY5h0G3ScEjxtUm4TwRJm7HRmDX8UfiDleTAEEg5vIe" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/chart.js@3.8.2/dist/chart.min.js" integrity="sha384-z7c1KnSCkMpfoib43Lq1v2pokQC8cdqBWmH2qiyH2KkmNv60hACtZUjoCEkp1Y08" crossorigin="anonymous"></script>
     <script src="lib/lz-string.min.js"></script>
-    <script src="src/main.js" type="module"></script>
+    <script src="evolve/main.js" type="module"></script>
 </head>
 <body>
     <style>

--- a/src/vars.js
+++ b/src/vars.js
@@ -1933,14 +1933,13 @@ if (!global.civic['new']){
 }
 
 if (!global.race['purgatory']){
-    global.race['purgatory'] = {
-        city: {},
-        space: {},
-        portal: {},
-        eden: {},
-        tech: {},
-    };
+    global.race['purgatory'] = {};
 }
+['city', 'space', 'portal', 'eden', 'tech'].forEach((item) => {
+    if(!global.race['purgatory'][item]){
+        global.race['purgatory'][item] = {};
+    }
+})
 
 if (!global.civic['d_job']){
     if (global.race['carnivore'] || global.race['soul_eater']){


### PR DESCRIPTION
In rare cases, purgatory did not contain the eden object, which would throw errors when edenic buildings are checked in the purgatory.
Notably this happens when attempting to remove the flier trait.