### PR TITLE
Fix seemingly bugged eldrich hunter capture chance

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -7968,7 +7968,7 @@ function midLoop(){
             }
 
             let catchVar = Math.round(40 / traits.unfathomable.vars()[1]);
-            if (usedCap < global.city.captive_housing.raceCap && Math.rand(0,(catchVar * usedCap) - hunt) <= 0){
+            if (usedCap < global.city.captive_housing.raceCap && Math.rand(0,(catchVar * usedCap)) - hunt <= 0){
                 let k = Math.rand(0,global.city.surfaceDwellers.length);
                 global.city.captive_housing[`jailrace${k}`]++;
             }


### PR DESCRIPTION
Related to issue #1199 
Gives a catch rate that is forgiving enough to allow actually filling the amount of captive housing that can be built.

To summarize the change: 
currently the chance of capturing an additional captive (Not taking into account additional traits such as sniper)
`1 / ((50 * number of captives)  - (number of raiders * military research rank))`
 
With the current highest military weapon strength being 10 (without additional traits), this imposes an end-game soft cap on captives/thralls of 1/5th the number of assigned raiders. Where below this soft cap capture is certain, and beyond the soft cap the chance of capture drops off so quickly that you are unlikely to get more than 10 or 20 additional captives no matter how long you were to wait. (the chance of getting your 20th captive past the soft cap is 0.1% per in game day) 

The new system instead has a chance of:
`(number of raiders * military research rank) / (50 * number of captives)`
to obtain a new captive each day. 
Which also, given the `<= 0` comparison in the code, seems likely to have been the original intention for this mechanic.

Thank you for your time. 