### PR TITLE
Fix ARIA Labels Referencing Resources

### DIFF
--- a/src/jobs.js
+++ b/src/jobs.js
@@ -834,8 +834,8 @@ export function loadFoundry(servants){
                 resource.append(controls);
                 element.append(resource);
 
-                let sub = $(`<span role="button" aria-label="remove ${res} craftsman" class="sub has-text-danger" @click="sub('${res}')"><span>&laquo;</span></span>`);
-                let add = $(`<span role="button" aria-label="add ${res} craftsman" class="add has-text-success" @click="add('${res}')"><span>&raquo;</span></span>`);
+                let sub = $(`<span role="button" aria-label="remove ${global.resource[res].name} craftsman" class="sub has-text-danger" @click="sub('${res}')"><span>&laquo;</span></span>`);
+                let add = $(`<span role="button" aria-label="add ${global.resource[res].name} craftsman" class="add has-text-success" @click="add('${res}')"><span>&raquo;</span></span>`);
 
                 controls.append(sub);
                 controls.append(add);

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -834,8 +834,8 @@ export function loadFoundry(servants){
                 resource.append(controls);
                 element.append(resource);
 
-                let sub = $(`<span role="button" aria-label="remove ${global.resource[res].name} craftsman" class="sub has-text-danger" @click="sub('${res}')"><span>&laquo;</span></span>`);
-                let add = $(`<span role="button" aria-label="add ${global.resource[res].name} craftsman" class="add has-text-success" @click="add('${res}')"><span>&raquo;</span></span>`);
+                let sub = $(`<span role="button" aria-label="remove ${global.resource[res].name} crafter" class="sub has-text-danger" @click="sub('${res}')"><span>&laquo;</span></span>`);
+                let add = $(`<span role="button" aria-label="add ${global.resource[res].name} crafter" class="add has-text-success" @click="add('${res}')"><span>&raquo;</span></span>`);
 
                 controls.append(sub);
                 controls.append(add);

--- a/src/resources.js
+++ b/src/resources.js
@@ -2792,9 +2792,9 @@ export function loadEjector(name,color){
         let res = $(`<span class="trade"></span>`);
         ejector.append(res);
 
-        res.append($(`<span role="button" aria-label="eject less ${loc('resource_'+name+'_name')}" class="sub has-text-danger" @click="ejectLess('${name}')"><span>&laquo;</span></span>`));
+        res.append($(`<span role="button" aria-label="eject less ${global.resource[name].name}" class="sub has-text-danger" @click="ejectLess('${name}')"><span>&laquo;</span></span>`));
         res.append($(`<span class="current">{{ e.${name} }}</span>`));
-        res.append($(`<span role="button" aria-label="eject more ${loc('resource_'+name+'_name')}" class="add has-text-success" @click="ejectMore('${name}')"><span>&raquo;</span></span>`));
+        res.append($(`<span role="button" aria-label="eject more ${global.resource[name].name}" class="add has-text-success" @click="ejectMore('${name}')"><span>&raquo;</span></span>`));
 
         res.append($(`<span class="mass">${loc('interstellar_mass_ejector_per')}: <span class="has-text-warning">${atomic_mass[name]}</span> kt</span>`));
 
@@ -2927,9 +2927,9 @@ export function loadAlchemy(name,color,basic){
         let res = $(`<span class="trade"></span>`);
         alchemy.append(res);
 
-        res.append($(`<span role="button" aria-label="transmute less ${loc('resource_'+name+'_name')}" class="sub has-text-danger" @click="subSpell('${name}')"><span>&laquo;</span></span>`));
+        res.append($(`<span role="button" aria-label="transmute less ${global.resource[name].name}" class="sub has-text-danger" @click="subSpell('${name}')"><span>&laquo;</span></span>`));
         res.append($(`<span class="current">{{ a.${name} }}</span>`));
-        res.append($(`<span role="button" aria-label="transmute more ${loc('resource_'+name+'_name')}" class="add has-text-success" @click="addSpell('${name}')"><span>&raquo;</span></span>`));
+        res.append($(`<span role="button" aria-label="transmute more ${global.resource[name].name}" class="add has-text-success" @click="addSpell('${name}')"><span>&raquo;</span></span>`));
 
         if (!global.race.alchemy.hasOwnProperty(name)){
             global.race.alchemy[name] = 0;

--- a/src/resources.js
+++ b/src/resources.js
@@ -872,7 +872,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
         methods: {
             resRate(n){
                 let diff = sizeApproximation(global.resource[n].diff,2);
-                return `${n} ${diff} per second`;
+                return `${global.resource[name].name} ${diff} per second`;
             },
             trigModal(){
                 this.$buefy.modal.open({

--- a/src/resources.js
+++ b/src/resources.js
@@ -818,7 +818,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
     }
 
     if (stackable){
-        res_container.append($(`<span><span id="con${name}" v-if="showTrigger()" class="interact has-text-success" @click="trigModal" role="button" aria-label="Open crate management for ${name}">+</span></span>`));
+        res_container.append($(`<span><span id="con${name}" v-if="showTrigger()" class="interact has-text-success" @click="trigModal" role="button" aria-label="Open crate management for ${global.resource[name].name}">+</span></span>`));
     }
     else if (max !== -1 || (max === -1 && rate === 0 && global.race['no_craft']) || name === 'Scarletite' || name === 'Quantium'){
         res_container.append($('<span></span>'));
@@ -834,7 +834,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
 
         let inc = [1,5];
         for (let i=0; i<inc.length; i++){
-            craft.append($(`<span id="inc${name}${inc[i]}"><a @click="craft('${name}',${inc[i]})" aria-label="craft ${inc[i]} ${name}">+<span class="craft" data-val="${inc[i]}">${inc[i]}</span></a></span>`));
+            craft.append($(`<span id="inc${name}${inc[i]}"><a @click="craft('${name}',${inc[i]})" aria-label="craft ${inc[i]} ${global.resource[name].name}">+<span class="craft" data-val="${inc[i]}">${inc[i]}</span></a></span>`));
         }
         craft.append($(`<span id="inc${name}A"><a @click="craft('${name}','A')" aria-label="craft max ${name}">+<span class="craft" data-val="${'A'}">A</span></a></span>`));
         infopops = true;
@@ -1374,9 +1374,9 @@ export function marketItem(mount,market_item,name,color,full){
     if (full && ((global.race['banana'] && name === 'Food') || (global.tech['trade'] && !global.race['terrifying']))){
         let trade = $(`<span class="trade" v-show="m.active"><span class="has-text-warning">${loc('resource_market_routes')}</span></span>`);
         market_item.append(trade);
-        trade.append($(`<b-tooltip :label="aSell('${name}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="export ${name}" class="sub has-text-danger" @click="autoSell('${name}')"><span>-</span></span></b-tooltip>`));
+        trade.append($(`<b-tooltip :label="aSell('${name}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="export ${global.resource[name].name}" class="sub has-text-danger" @click="autoSell('${name}')"><span>-</span></span></b-tooltip>`));
         trade.append($(`<span class="current" v-html="$options.filters.trade(r.trade)"></span>`));
-        trade.append($(`<b-tooltip :label="aBuy('${name}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="import ${name}" class="add has-text-success" @click="autoBuy('${name}')"><span>+</span></span></b-tooltip>`));
+        trade.append($(`<b-tooltip :label="aBuy('${name}')" position="is-bottom" size="is-small" multilined animated><span role="button" aria-label="import ${global.resource[name].name}" class="add has-text-success" @click="autoBuy('${name}')"><span>+</span></span></b-tooltip>`));
         trade.append($(`<span role="button" class="zero has-text-advanced" @click="zero('${name}')">${loc('cancel_routes')}</span>`));
         tradeRouteColor(name);
     }
@@ -1861,18 +1861,18 @@ export function containerItem(mount,market_item,name,color){
         let crate = $(`<span class="trade"><span class="has-text-warning">${loc('resource_Crates_name')}</span></span>`);
         market_item.append(crate);
 
-        crate.append($(`<span role="button" aria-label="remove ${name} ${loc('resource_Crates_name')}" class="sub has-text-danger" @click="subCrate('${name}')"><span>&laquo;</span></span>`));
+        crate.append($(`<span role="button" aria-label="remove ${global.resource[name].name} ${loc('resource_Crates_name')}" class="sub has-text-danger" @click="subCrate('${name}')"><span>&laquo;</span></span>`));
         crate.append($(`<span class="current" v-html="$options.filters.cCnt(crates,'${name}')"></span>`));
-        crate.append($(`<span role="button" aria-label="add ${name} ${loc('resource_Crates_name')}" class="add has-text-success" @click="addCrate('${name}')"><span>&raquo;</span></span>`));
+        crate.append($(`<span role="button" aria-label="add ${global.resource[name].name} ${loc('resource_Crates_name')}" class="add has-text-success" @click="addCrate('${name}')"><span>&raquo;</span></span>`));
     }
 
     if (global.resource.Containers.display){
         let container = $(`<span class="trade"><span class="has-text-warning">${loc('resource_Containers_name')}</span></span>`);
         market_item.append(container);
 
-        container.append($(`<span role="button" aria-label="remove ${name} ${loc('resource_Containers_name')}" class="sub has-text-danger" @click="subCon('${name}')"><span>&laquo;</span></span>`));
+        container.append($(`<span role="button" aria-label="remove ${global.resource[name].name} ${loc('resource_Containers_name')}" class="sub has-text-danger" @click="subCon('${name}')"><span>&laquo;</span></span>`));
         container.append($(`<span class="current" v-html="$options.filters.trick(containers)"></span>`));
-        container.append($(`<span role="button" aria-label="add ${name} ${loc('resource_Containers_name')}" class="add has-text-success" @click="addCon('${name}')"><span>&raquo;</span></span>`));
+        container.append($(`<span role="button" aria-label="add ${global.resource[name].name} ${loc('resource_Containers_name')}" class="add has-text-success" @click="addCon('${name}')"><span>&raquo;</span></span>`));
     }
 
     vBind({


### PR DESCRIPTION
Currently, many ARIA labels, for various buttons, including the one for resource rates, use the wrong resource name when certain conditions change them. For example, when playing with plants that have the Sappy trait, where "Stone" is renamed to "Amber," many buttons in the interface still display text like "Export Stone" or "Add Stone Crate." Clicking through the top resource section, it would display something like "Stone 18 per second" instead of "Amber."  

Having looked at the code, this appears to be because the labels were using the internal resource names instead of retrieving their current names from the global.resource object. This also meant that the labels did not use the localized versions of names. I have replaced all instances of internal name usage in the ARIA labels of buttons and in the "resRate" method and replaced them with "global.resource[name].name" (or similar) to use the correct name.  

While editing the labels for the crafter assignment buttons in the Civics tab, I noticed that they still call them "craftsman" , even after they were officially renamed to "crafters" in V1.3.17. So I have also updated those labels to say "crafter" for consistency.  