### PR TITLE
Improve Accessibility of Message Queue Filters

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -363,8 +363,8 @@ export function initMessageQueue(filters){
     filters.forEach(function (filter){
         message_logs[filter] = [];
         if (!global.settings.msgFilters[message_logs.view].vis){
-            $(`#msgQueueFilter-${message_logs.view}`).removeClass('is-active');
-            $(`#msgQueueFilter-${filter}`).addClass('is-active');
+            $(`#msgQueueFilter-${message_logs.view}`).removeClass('is-active').attr('aria-disabled', 'false');
+            $(`#msgQueueFilter-${filter}`).addClass('is-active').attr('aria-disabled', 'true');
             message_logs.view = filter;
         }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -952,7 +952,7 @@ export function index(){
     </div>`);
     message_filters.forEach(function (filter){
         $(`#msgQueueFilters`).append(`
-            <span id="msgQueueFilter-${filter}" class="${filter === 'all' ? 'is-active' : ''}" @click="swapFilter('${filter}')" v-show="s.${filter}.vis">${loc('message_log_' + filter)}</span>
+            <span id="msgQueueFilter-${filter}" class="${filter === 'all' ? 'is-active' : ''}" @click="swapFilter('${filter}')" v-show="s.${filter}.vis" role="button">${loc('message_log_' + filter)}</span>
         `);
     });
     vBind({

--- a/src/index.js
+++ b/src/index.js
@@ -952,7 +952,7 @@ export function index(){
     </div>`);
     message_filters.forEach(function (filter){
         $(`#msgQueueFilters`).append(`
-            <span id="msgQueueFilter-${filter}" class="${filter === 'all' ? 'is-active' : ''}" @click="swapFilter('${filter}')" v-show="s.${filter}.vis" role="button">${loc('message_log_' + filter)}</span>
+            <span id="msgQueueFilter-${filter}" class="${filter === 'all' ? 'is-active' : ''}" aria-disabled="${filter === 'all' ? 'true' : 'false'}" @click="swapFilter('${filter}')" v-show="s.${filter}.vis" role="button">${loc('message_log_' + filter)}</span>
         `);
     });
     vBind({
@@ -964,8 +964,8 @@ export function index(){
         methods: {
             swapFilter(filter){
                 if (message_logs.view !== filter){
-                    $(`#msgQueueFilter-${message_logs.view}`).removeClass('is-active');
-                    $(`#msgQueueFilter-${filter}`).addClass('is-active');
+                    $(`#msgQueueFilter-${message_logs.view}`).removeClass('is-active').attr('aria-disabled', 'false');
+                    $(`#msgQueueFilter-${filter}`).addClass('is-active').attr('aria-disabled', 'true');
                     message_logs.view = filter;
                     let queue = $(`#msgQueueLog`);
                     clearElement(queue);


### PR DESCRIPTION
Previously, some screen readers would combine all the message filter selectors into one text element read as something like "All Progress Events, Major Events, Minor Events." This made it much harder (if not impossible) to click on individual filters to switch between message categories.

This PR adds `role="button"` to each filter selector to force screen readers to make them into separate clickable elements, and uses the `aria-disabled` attribute on the currently selected filter to allow screen readers to detect that its selected. As this change only affects the aria of the elements, it should not affect the visual display at all.