### PR TITLE
Fix missing word in Gladiators' effect string

### DIFF
--- a/src/tech.js
+++ b/src/tech.js
@@ -1651,7 +1651,7 @@ const techs = {
         cost: {
             Knowledge(){ return 1080; }
         },
-        effect(){ return global.race.universe === 'evil' ? loc('tech_gladiators_effect') : loc('tech_playwright_effect'); },
+        effect(){ return global.race.universe === 'evil' ? loc('tech_gladiators_effect',[loc('city_colosseum')]) : loc('tech_playwright_effect'); },
         action(){
             if (payCosts($(this)[0])){
                 return true;


### PR DESCRIPTION
The description for the effect of the new Evil tech Gladiators included a %0: "Gladiatorial combat increases the quality of entertainment in the %0, much more effective then just feeding vagrants to lions." I assumed it meant to say "the Colosseum", so I added `loc('city_colosseum')` as a parameter where the string is used.