### PR TITLE
Add more structs to alwaysPower setting

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1975,6 +1975,10 @@ export const actions = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('mill','city');
+                    // Prevent alwaysPower from enabling mills that were built before researching Wind Turbines
+                    if (checkPowerRequirements($(this)[0]){
+                        powerOnNewStruct($(this)[0]);
+                    }
                     return true;
                 }
                 return false;
@@ -2742,9 +2746,7 @@ export const actions = {
                         global.settings.showIndustry = true;
                         global['resource']['Chrysotile'].max += stone;
                     }
-                    if (global.tech['mine_conveyor']){
-                        powerOnNewStruct($(this)[0]);
-                    }
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -2795,9 +2797,7 @@ export const actions = {
                     incrementStruct('cement_plant','city');
                     global.civic.cement_worker.display = true;
                     global.civic.cement_worker.max = global.city.cement_plant.count * jobScale(2);
-                    if (global.tech['cement'] && global.tech['cement'] >= 5){
-                        powerOnNewStruct($(this)[0]);
-                    }
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -3036,9 +3036,7 @@ export const actions = {
                         global.resource.Sheet_Metal.display = true;
                         loadFoundry();
                     }
-                    if (global.tech['alumina'] >= 2){
-                        powerOnNewStruct($(this)[0]);
-                    }
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -3085,9 +3083,7 @@ export const actions = {
                     global.resource.Copper.display = true;
                     global.civic.miner.display = true;
                     global.civic.miner.max = jobScale(global.city.mine.count);
-                    if (global.tech['mine_conveyor']){
-                        powerOnNewStruct($(this)[0]);
-                    }
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -3136,9 +3132,7 @@ export const actions = {
                     global.resource.Coal.display = true;
                     global.civic.coal_miner.display = true;
                     global.civic.coal_miner.max = jobScale(global.city.coal_mine.count);
-                    if (global.tech['mine_conveyor']){
-                        powerOnNewStruct($(this)[0]);
-                    }
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -6782,7 +6776,7 @@ export function powerOnNewStruct(c_action,extra){
     let need_p = c_action.hasOwnProperty('powered') && c_action.powered() > 0;
     let can_p = !need_p;
     let gov_replicator = global.race.hasOwnProperty('governor') && global.race.governor.hasOwnProperty('tasks') && global.race.hasOwnProperty('replicator') && Object.values(global.race.governor.tasks).includes('replicate') && global.race.governor.config.replicate.pow.on && global.race.replicator.pow > 0;
-    if (need_p && global.city.hasOwnProperty('powered')){
+    if (need_p && global.city.hasOwnProperty('powered') && checkPowerRequirements(c_action)){
         let power = global.city.power;
         if (gov_replicator){
             power += global.race.replicator.pow;

--- a/src/portal.js
+++ b/src/portal.js
@@ -657,7 +657,7 @@ const fortressModules = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('guard_post','portal');
-                    global.portal.guard_post.on++;
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -1533,8 +1533,11 @@ const fortressModules = {
                     global.portal['oven'].count++;
                     if (global.portal.oven.count >= 100){
                         global.tech['dish'] = 3;
-                        global.portal['oven_complete'] = { count: 1, on: 0 };
-                        global.portal['devilish_dish'] = { count: 0, done: 0, time: 0 };
+                        initStruct(fortressModules.prtl_lake.oven_complete);
+                        if (global.settings.alwaysPower){
+                            powerOnNewStruct(fortressModules.prtl_lake.oven_complete);
+                        }
+                        initStruct(fortressModules.prtl_lake.devilish_dish);
                         renderFortress();
                         clearPopper();
                     }
@@ -1570,6 +1573,12 @@ const fortressModules = {
             p_fuel(){ return { r: 'Infernite', a: 225 }},
             action(){
                 return false;
+            },
+            struct(){
+                return {
+                    d: { count: 0, on: 0 },
+                    p: ['oven_complete','portal']
+                };
             }
         },
         devilish_dish: {
@@ -1585,6 +1594,12 @@ const fortressModules = {
             },
             action(){
                 return false;
+            },
+            struct(){
+                return {
+                    d: { count: 0, done: 0, time: 0 },
+                    p: ['devilish_dish','portal']
+                };
             }
         },
         dish_soul_steeper: {
@@ -2145,6 +2160,9 @@ const fortressModules = {
                     if (global.portal.waygate.count >= 10){
                         global.tech.waygate = 2;
                         global.portal.waygate.count = 1;
+                        if (global.settings.alwaysPower){
+                            global.portal.waygate.on = 1;
+                        }
                         renderFortress();
                         drawTech();
                     }

--- a/src/space.js
+++ b/src/space.js
@@ -2447,7 +2447,12 @@ const spaceProjects = {
                     incrementStruct('world_collider');
                     if (global.space.world_collider.count >= 1859){
                         global.tech['science'] = 11;
-                        global.space['world_controller'] = { count: 1, on: 0 };
+                        initStruct(spaceProjects.spc_dwarf.world_controller);
+                        incrementStruct('world_controller');
+                        // Require the force power-on setting to automatically power end-of-era structs, even when power is abundant
+                        if (global.settings.alwaysPower){
+                            powerOnNewStruct(spaceProjects.spc_dwarf.world_controller);
+                        }
                         drawTech();
                         renderSpace();
                         if (global.race['banana']){
@@ -2603,7 +2608,8 @@ const spaceProjects = {
                     global.space.mass_relay.count++;
                     if (global.space.mass_relay.count >= 100){
                         global.tech['outer'] = 6;
-                        global.space['m_relay'] = { count: 1, on: 1, charged: 0 };
+                        initStruct(spaceProjects.spc_dwarf.m_relay);
+                        powerOnNewStruct(spaceProjects.spc_dwarf.m_relay);
                         drawTech();
                         renderSpace();
                         clearPopper();
@@ -2642,6 +2648,12 @@ const spaceProjects = {
             },
             action(){
                 return false;
+            },
+            struct(){
+                return {
+                    d: { count: 0, on: 0, charged: 0 },
+                    p: ['m_relay','space']
+                };
             }
         },
     },
@@ -4306,8 +4318,12 @@ const interstellarProjects = {
                         incrementStruct('stargate','interstellar');
                         if (global.interstellar.stargate.count >= 200){
                             global.tech['stargate'] = 4;
-                            global.interstellar['s_gate'] = { count: 1, on: 0 };
-                            powerOnNewStruct($(interstellarProjects.int_blackhole.s_gate)[0]);
+                            initStruct(interstellarProjects.int_blackhole.s_gate);
+                            incrementStruct('s_gate','interstellar');
+                            // Require the force power-on setting to automatically power end-of-era structs, even when power is abundant
+                            if (global.settings.alwaysPower){
+                                powerOnNewStruct(interstellarProjects.int_blackhole.s_gate);
+                            }
                             deepSpace();
                             clearPopper();
                         }
@@ -4540,7 +4556,8 @@ const interstellarProjects = {
                         incrementStruct('ascension_machine','interstellar');
                         if (global.interstellar.ascension_machine.count >= 100){
                             global.tech['ascension'] = 7;
-                            global.interstellar['ascension_trigger'] = { count: 1, on: 0 };
+                            initStruct(interstellarProjects.int_sirius.ascension_trigger);
+                            powerOnNewStruct(interstellarProjects.int_sirius.ascension_trigger);
                             deepSpace();
                             clearPopper();
                         }
@@ -4630,6 +4647,12 @@ const interstellarProjects = {
             },
             action(){
                 return false;
+            },
+            struct(){
+                return {
+                    d: { count: 0, on: 0 },
+                    p: ['ascension_trigger','interstellar']
+                };
             }
         },
         ascend: {

--- a/src/space.js
+++ b/src/space.js
@@ -4557,7 +4557,9 @@ const interstellarProjects = {
                         if (global.interstellar.ascension_machine.count >= 100){
                             global.tech['ascension'] = 7;
                             initStruct(interstellarProjects.int_sirius.ascension_trigger);
-                            powerOnNewStruct(interstellarProjects.int_sirius.ascension_trigger);
+                            if (global.settings.alwaysPower){
+                                powerOnNewStruct(interstellarProjects.int_sirius.ascension_trigger);
+                            }
                             deepSpace();
                             clearPopper();
                         }

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -582,8 +582,8 @@ const outerTruth = {
                         incrementStruct('ai_core');
                         if (global.space.ai_core.count >= 100){
                             global.tech['titan_ai_core'] = 1;
-                            global.space['ai_core2'] = { count: 1, on: 0 };
-                            powerOnNewStruct($(outerTruth.spc_titan.ai_core2)[0]);
+                            initStruct(outerTruth.spc_titan.ai_core2);
+                            powerOnNewStruct(outerTruth.spc_titan.ai_core2);
                             renderSpace();
                             drawTech();
                             if (global.city.ptrait.includes('kamikaze') && !global.race['tidal_decay']){
@@ -639,6 +639,12 @@ const outerTruth = {
             },
             flair(){
                 return global.space.hasOwnProperty('ai_core2') && global.space.ai_core2.on >= 1 ? loc(`space_ai_core_flair`) : loc(`space_ai_core_flair2`);
+            },
+            struct(){
+                return {
+                    d: { count: 0, on: 0 },
+                    p: ['ai_core2','space']
+                };
             }
         },
         ai_colonist: {
@@ -2641,7 +2647,7 @@ const tauCetiModules = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('tau_cultural_center','tauceti');
-                    global.tauceti.tau_cultural_center.on++;
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;


### PR DESCRIPTION
Centralize power_reqs checks to `powerOnNewStruct()`.

Allow mills to be automatically powered on after researching Wind Turbine.

Automatically power on mines, coal mines, rock quarries, cement plants, and metal refineries when the alwaysPower flag is set. Wardenclyffes and sawmills already did this, so no change to those. In all cases, the setting takes effect when the building is constructed, not when the technology is researched.

Only when the alwaysPower flag is enabled, automatically power on the completed World Collider, Stargate, Ascension Machine, Devilish Dish, or Waygate.

Force the Guard Post and Cultural Center to respect the usual rules for powering on. If the alwaysPower switch is disabled and power is insufficient, then no longer automatically power them on at time of completion.

Add initStruct-compatible definitions to some more structs.


To review discussion from the Discord suggestions thread on this PR, follow this link:
https://discord.com/channels/586926974585274373/1222741498999738440


I haven't playtested this patch.