### PR TITLE
Fix minor rounding issues

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6069,7 +6069,8 @@ export function setAction(c_action,action,type,old,prediction){
         }
     }
     else {
-        if ((c_action['powered'] && global.tech['high_tech'] && global.tech['high_tech'] >= 2 && checkPowerRequirements(c_action)) || (c_action['switchable'] && c_action.switchable())){
+        let switchable = c_action['switchable'] ? c_action.switchable() : (c_action['powered'] && global.tech['high_tech'] && global.tech['high_tech'] >= 2 && checkPowerRequirements(c_action));
+        if (switchable){
             let powerOn = $(`<span role="button" :aria-label="on_label()" class="on" @click="power_on" title="ON" v-html="$options.filters.p_on(act.on,'${c_action.id}')"></span>`);
             let powerOff = $(`<span role="button" :aria-label="off_label()" class="off" @click="power_off" title="OFF" v-html="$options.filters.p_off(act.on,'${c_action.id}')"></span>`);
             parent.append(powerOn);

--- a/src/main.js
+++ b/src/main.js
@@ -1763,21 +1763,10 @@ function fastLoop(){
         }
 
         if (global.interstellar['stellar_engine'] && global.interstellar.stellar_engine.count >= 100){
-            let waves = global.tech['gravity'] && global.tech['gravity'] >= 2 ? 13.5 : 7.5;
-            let r_mass = global.interstellar.stellar_engine.mass;
-            if (global.tech['roid_eject']){
-                r_mass += 0.225 * global.tech['roid_eject'] * (1 + (global.tech['roid_eject'] / 12));
-            }
-            let gWell = 1 + (global.stats.achieve['escape_velocity'] && global.stats.achieve.escape_velocity['h'] ? global.stats.achieve.escape_velocity['h'] * 0.02 : 0);
-            let power = powerModifier(20 + ((r_mass - 8) * waves) + (global.interstellar.stellar_engine.exotic * waves * 10)) * gWell;
-            if (power > 10000){
-                power = 10000 + (power - 10000) ** 0.975;
-                if (power > 20000){ power = 20000 + (power - 20000) ** 0.95; }
-                if (power > 30000){ power = 30000 + (power - 30000) ** 0.925; }
-            }
-            max_power -= power;
-            power_grid += power;
-            power_generated[loc('tech_stellar_engine')] = power;
+            let output = actions.interstellar.int_blackhole.stellar_engine.powered();
+            max_power += output;
+            power_grid -= output;
+            power_generated[loc('tech_stellar_engine')] = -output;
         }
 
         [

--- a/src/resets.js
+++ b/src/resets.js
@@ -611,7 +611,7 @@ export function ascend(){
     }
 
     Object.keys(geo).forEach(function (g){
-        geo[g] += 0.02;
+        geo[g] = +(geo[g] + 0.02).toFixed(2);
     });
 
     resetCommon({
@@ -821,7 +821,7 @@ export function apotheosis(){
     }
 
     Object.keys(geo).forEach(function (g){
-        geo[g] += 0.02;
+        geo[g] = +(geo[g] + 0.02).toFixed(2);
     });
 
     resetCommon({

--- a/src/space.js
+++ b/src/space.js
@@ -4114,27 +4114,38 @@ const interstellarProjects = {
                     return `<div>${loc('interstellar_stellar_engine_effect')}</div><div class="has-text-special">${loc('space_dwarf_collider_effect2',[remain])}</div>`;
                 }
                 else {
-                    let waves = global.tech['gravity'] && global.tech['gravity'] >= 2 ? 13.5 : 7.5;
-                    let r_mass = global.interstellar['stellar_engine'] ? global.interstellar.stellar_engine.mass : 8;
-                    if (global.tech['roid_eject']){
-                        r_mass += 0.225 * global.tech['roid_eject'] * (1 + (global.tech['roid_eject'] / 12));
-                    }
-                    let gWell = 1 + (global.stats.achieve['escape_velocity'] && global.stats.achieve.escape_velocity['h'] ? global.stats.achieve.escape_velocity['h'] * 0.02 : 0);
-                    let output = powerModifier((20 + ((r_mass - 8) * waves) + ((global.interstellar['stellar_engine'] ? global.interstellar.stellar_engine.exotic : 0) * waves * 10)).toFixed(2)) * gWell;
-                    if (output > 10000){
-                        output = 10000 + (output - 10000) ** 0.975;
-                        if (output > 20000){ output = 20000 + (output - 20000) ** 0.95; }
-                        if (output > 30000){ output = 30000 + (output - 30000) ** 0.925; }
-                    }
+                    let output = -$(this)[0].powered();
                     if (global.tech['blackhole'] >= 5){
-                        let exotic = +(global.interstellar.stellar_engine.exotic).toFixed(10);
-                        let blackhole = global.interstellar.stellar_engine.exotic > 0 ? loc('interstellar_stellar_engine_effect3',[r_mass,exotic]) : loc('interstellar_stellar_engine_effect2',[r_mass]);
+                        let r_mass = global.interstellar.stellar_engine.mass;
+                        let exotic = global.interstellar.stellar_engine.exotic;
+                        if (global.tech['roid_eject']){
+                            r_mass += 0.225 * global.tech['roid_eject'] * (1 + (global.tech['roid_eject'] / 12));
+                        }
+                        let blackhole = exotic > 0 ? loc('interstellar_stellar_engine_effect3',[+r_mass.toFixed(10),+exotic.toFixed(10)]) : loc('interstellar_stellar_engine_effect2',[r_mass]);
                         return `<div>${loc('interstellar_stellar_engine_complete',[+output.toFixed(2)])}</div><div>${blackhole}</div>`;
                     }
                     else {
                         return loc('interstellar_stellar_engine_complete',[+output.toFixed(2)]);
                     }
                 }
+            },
+            switchable(){ return false; },
+            powered(){
+                let waves = global.tech['gravity'] && global.tech['gravity'] >= 2 ? 13.5 : 7.5;
+                let r_mass = global.interstellar?.stellar_engine?.mass ?? 8;
+                let exotic = global.interstellar?.stellar_engine?.exotic ?? 0;
+                if (global.tech['roid_eject']){
+                    r_mass += 0.225 * global.tech['roid_eject'] * (1 + (global.tech['roid_eject'] / 12));
+                }
+                let gWell = 1 + (global.stats.achieve['escape_velocity'] && global.stats.achieve.escape_velocity['h'] ? global.stats.achieve.escape_velocity['h'] * 0.02 : 0);
+                let output = powerModifier(20 + (r_mass - 8 + exotic * 10) * waves * gWell);
+                if (output > 10000){
+                    output = 10000 + (output - 10000) ** 0.975;
+                    if (output > 20000){ output = 20000 + (output - 20000) ** 0.95; }
+                    if (output > 30000){ output = 30000 + (output - 30000) ** 0.925; }
+                }
+                output = +output.toFixed(2);
+                return -output;
             },
             action(){
                 if (payCosts($(this)[0])){


### PR DESCRIPTION
Clamp planetary geology deposits to multiples of 1% when performing floating-point addition on them at the end of an ascension or apotheosis reset.

Reduce display precision for stellar engine total mass to 10 decimal places in the description for the completed stellar engine. This matches the display on the black hole, which already limits the total mass to 10 decimal places.

Merge stellar engine power generation code from 2 places (main game loop and stellar engine description) into 1 place (`powered()` function of stellar engine action). To avoid causing UI disruption with this change, adjust the "switchable" logic on action button generation such that an explicit switchable=false can override the existence check for powered(). The displayed value for power was already limited to 0.01 MW increments, so this part of the patch has no visible side effects.