### PR TITLE
Teach Evil universe Wendigos how to use shovels

### DIFF
--- a/src/races.js
+++ b/src/races.js
@@ -5986,7 +5986,7 @@ export function racialTrait(workers,type){
     if (global.race['rejuvenated'] && ['lumberjack','miner','factory'].includes(type)){
         modifier *= 1.1;
     }
-    if (type === 'lumberjack' && global.race['evil'] && !global.race['soul_eater']){
+    if (type === 'lumberjack' && global.race['evil'] && (global.race.universe === 'evil' || !global.race['soul_eater'])){
         if (global.race['living_tool']){
             modifier *= 1 + traits.living_tool.vars()[0] * (global.tech['science'] && global.tech.science > 0 ? global.tech.science * 0.3 : 0);
         }


### PR DESCRIPTION
Currently, Wendigo reclaimers in the Evil universe always produce 1 bones/s regardless of shovel technology. This allows them to receive the usual +40% bonus per shovel level. It seems that this patch will also allow Wendigo reclaimers to benefit from Living Tool if they inherited it from their ancestors.