### PR TITLE
Allow the Soul Forge to scale with Hivemind

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -3106,14 +3106,26 @@ function towerPrice(cost, wiki){
 
 export function soulForgeSoldiers(wiki){
     let base = global.race['warlord'] ? 400 : 650;
-    let soldiers = Math.round(base / armyRating(1,'hellArmy'));
     let num_gun_emplacement = wiki ? (global.portal?.gun_emplacement?.on ?? 0) : p_on['gun_emplacement'];
-    if (num_gun_emplacement){
-        soldiers -= num_gun_emplacement * (global.tech.hell_gun >= 2 ? jobScale(2) : jobScale(1));
-        if (soldiers < 0){
-            soldiers = 0;
+    let num_soldiers_saved = num_gun_emplacement * (global.tech.hell_gun >= 2 ? jobScale(2) : jobScale(1));
+
+    // To avoid divide-by-0 type issues, force the average soldier combat rating to be at least 1
+    let avg_rating = Math.max(armyRating(1, 'hellArmy'), highPopAdjust(1));
+    let soldiers = Math.ceil(base / avg_rating);
+    soldiers = Math.max(0, soldiers - num_soldiers_saved);
+
+    if (global.race['hivemind']){
+        // Permit actual soldiers to count as a group for combat rating adjustment
+        // Gun emplacements use the combat rating of the remaining soldiers
+        // Both soldiers=0 and soldiers=1 cases use the combat rating of 1 soldier alone
+        soldiers = 0;
+        while ((soldiers + num_soldiers_saved) * avg_rating < base){
+            soldiers++;
+            avg_rating = armyRating(soldiers, 'hellArmy') / soldiers;
+            avg_rating = Math.max(avg_rating, highPopAdjust(1));
         }
     }
+
     return soldiers;
 }
 


### PR DESCRIPTION
Currently, the Soul Forge uses the combat rating of 1 soldier as its baseline when determining how many soldiers are required for full staff, regardless of the actual number of soldiers demanded. This contrasts with the Guard Post, which does scale with Hivemind, even though those soldiers are in separate structures.

This patch permits Hivemind to scale in the Soul Forge, with the following caveats:
- Gun Emplacements do work as usual, but they don't count as real soldiers for combat rating purposes. This means that each gun emplacement may appear to be less effective than usual, especially when the number of soldiers guarding the Soul Forge approaches zero.
- The combat rating of 1 soldier is used in the situation where Gun Emplacements fully obviate the need for soldiers in the Soul Forge. This is equivalent to the behavior without this patch.
- A minimum equivalent combat rating is enforced. Before high population adjustment, 1 soldier contributes at least 1 CR to the Soul Forge. This is just to prevent infinite loops. It could be adjusted to something else. This means that the Soul Forge can be manned with a finite (if large) supply of soldiers even at 0 Authority.

The following additional change is applied regardless of the Hivemind trait.
- The required number of soldiers is taken using the ceiling function instead of round-to-nearest. In some cases, this will increase the staffing requirement by 1.