### PR TITLE
Fix sequence issues between last 2 Dyson spheres

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -3599,7 +3599,10 @@ const interstellarProjects = {
             queue_size: 10,
             queue_complete(){ return 100 - global.interstellar.orichalcum_sphere.count; },
             condition(){
-                return global.interstellar.dyson_sphere.count >= 100 && global.tech['dyson'] && global.tech.dyson === 2 ? true : false;
+                if ((global.tech['dyson'] ?? 0) < 2){
+                    return false;
+                }
+                return global.interstellar.dyson_sphere.count >= 100 && (global.tech.dyson === 2 || global.interstellar.orichalcum_sphere.count < 100);
             },
             cost: {
                 Money(offset){ return ((offset || 0) + (global.interstellar.hasOwnProperty('orichalcum_sphere') ? global.interstellar.orichalcum_sphere.count : 0)) < 100 ? 25000000 : 0; },

--- a/src/tech.js
+++ b/src/tech.js
@@ -9166,6 +9166,9 @@ const techs = {
         category: 'power_generation',
         era: 'existential',
         reqs: { high_tech: 19, dyson: 2 },
+        condition(){
+            return global.interstellar?.orichalcum_sphere?.count >= 100;
+        },
         grant: ['dyson',3],
         cost: {
             Knowledge(){ return 122500000; },


### PR DESCRIPTION
Require the orichalcum version of the Dyson Sphere to be researched before allowing the elysanite version to be researched.

For users who already researched the elysanite plated dyson sphere without building the orichalcum plated dyson sphere, we can fix it in either of two ways:
- Revert their research back to the orichalcum version
- Update the display condition for the orichalcum dyson sphere

I chose the second option. It's not necessary to recursively do this for the Dyson Net or the first Dyson Sphere, because existing condition checks enforce that they have to be built in order to research the orichalcum and elysanite plated dyson spheres.

Fixes #1349. Tested using the save file in that same issue.