### PR TITLE
Assume stargate power state on load

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -222,6 +222,9 @@ if (global.interstellar['starport']){
 if (global.interstellar['fusion']){
     int_on['fusion'] = global.interstellar.fusion.on;
 }
+if (global.interstellar['s_gate']){
+    p_on['s_gate'] = global.interstellar.s_gate.on;
+}
 if (global.portal['hell_forge']){
     p_on['hell_forge'] = global.portal.hell_forge.on;
 }


### PR DESCRIPTION
If the Stargate to enable the Andromeda system has a lower priority in the power grid than any of the structures inside of it, then the `p_on` structure will be initialized out of order during the first call to `fastLoop` after the game is loaded.

In order to guarantee that this does not cause unexpected issues in the common case where the Stargate has enough power to operate, assume that the power status in the save file (on or off) can be fulfilled by the power grid.

Fixes #1328.

Caused by enforcing the requirement that the embassy must be operational for freighters to work (#1265).