### PR TITLE
Use reverse system order to fulfill armada crew

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import { defineJobs, job_desc, loadFoundry, farmerValue, jobName, jobScale, work
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
 import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn } from './actions.js';
-import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes } from './space.js';
+import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes, galaxyRegions, gatewayArmada } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay, hellguard } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
 import { renderTauCeti, syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, tpStorageMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift, drawMap, tauEnabled, shipCosts, buildTPShipQueue } from './truepath.js';
@@ -9273,37 +9273,32 @@ function midLoop(){
         }
 
         if (p_on['embassy'] && global.galaxy['symposium']){
-            let pirate = piracy('gxy_gorddon');
-            let dorm = 1750 * p_on['dormitory'] * pirate;
-            let gtrade = 650 * global.galaxy.trade.cur * pirate;
+            let dorm = 1750 * p_on['dormitory'];
+            let gtrade = 650 * global.galaxy.trade.cur;
             let leave = 0;
             if (global.tech.xeno >= 7){
-                let crew = global.galaxy.defense.gxy_gorddon.scout_ship * (actions.galaxy.gxy_gateway.scout_ship.ship.civ() + actions.galaxy.gxy_gateway.scout_ship.ship.mil());
-                crew += global.galaxy.defense.gxy_gorddon.corvette_ship * (actions.galaxy.gxy_gateway.corvette_ship.ship.civ() + actions.galaxy.gxy_gateway.corvette_ship.ship.mil());
-                crew += global.galaxy.defense.gxy_gorddon.frigate_ship * (actions.galaxy.gxy_gateway.frigate_ship.ship.civ() + actions.galaxy.gxy_gateway.frigate_ship.ship.mil());
-                crew += global.galaxy.defense.gxy_gorddon.cruiser_ship * (actions.galaxy.gxy_gateway.cruiser_ship.ship.civ() + actions.galaxy.gxy_gateway.cruiser_ship.ship.mil());
-                crew += global.galaxy.defense.gxy_gorddon.dreadnought * (actions.galaxy.gxy_gateway.dreadnought.ship.civ() + actions.galaxy.gxy_gateway.dreadnought.ship.mil());
-
-                if (gal_on['freighter']){
-                    crew += gal_on['freighter'] * (actions.galaxy.gxy_gorddon.freighter.ship.civ() + actions.galaxy.gxy_gorddon.freighter.ship.mil());
-                }
-                leave = +highPopAdjust(crew).toFixed(2) * 300 * pirate;
-
-                ['gxy_gateway','gxy_stargate','gxy_alien1','gxy_alien2','gxy_chthonian'].forEach(function(area){
-                    let crew = global.galaxy.defense[area].scout_ship * (actions.galaxy.gxy_gateway.scout_ship.ship.civ() + actions.galaxy.gxy_gateway.scout_ship.ship.mil());
-                    crew += global.galaxy.defense[area].corvette_ship * (actions.galaxy.gxy_gateway.corvette_ship.ship.civ() + actions.galaxy.gxy_gateway.corvette_ship.ship.mil());
-                    crew += global.galaxy.defense[area].frigate_ship * (actions.galaxy.gxy_gateway.frigate_ship.ship.civ() + actions.galaxy.gxy_gateway.frigate_ship.ship.mil());
-                    crew += global.galaxy.defense[area].cruiser_ship * (actions.galaxy.gxy_gateway.cruiser_ship.ship.civ() + actions.galaxy.gxy_gateway.cruiser_ship.ship.mil());
-                    crew += global.galaxy.defense[area].dreadnought * (actions.galaxy.gxy_gateway.dreadnought.ship.civ() + actions.galaxy.gxy_gateway.dreadnought.ship.mil());
-
-                    if (gal_on['super_freighter'] && area === 'gxy_alien1'){
-                        crew += gal_on['super_freighter'] * (actions.galaxy.gxy_alien1.super_freighter.ship.civ() + actions.galaxy.gxy_alien1.super_freighter.ship.mil());
+                for (const region of galaxyRegions){
+                    let crew = 0;
+                    for (const ship of gatewayArmada){
+                        crew += global.galaxy.defense[region][ship] * (actions.galaxy.gxy_gateway[ship].ship.civ() + actions.galaxy.gxy_gateway[ship].ship.mil());
                     }
 
-                    leave += +highPopAdjust(crew).toFixed(2) * 150 * pirate * piracy(area);
-                });
+                    if (region === 'gxy_gorddon'){
+                        if (gal_on['freighter']){
+                            crew += gal_on['freighter'] * (actions.galaxy.gxy_gorddon.freighter.ship.civ() + actions.galaxy.gxy_gorddon.freighter.ship.mil());
+                        }
+                        leave += +highPopAdjust(crew).toFixed(2) * 300;
+                    }
+                    else {
+                        if (region === 'gxy_alien1' && gal_on['super_freighter']){
+                            crew += gal_on['super_freighter'] * (actions.galaxy.gxy_alien1.super_freighter.ship.civ() + actions.galaxy.gxy_alien1.super_freighter.ship.mil());
+                        }
+                        leave += +highPopAdjust(crew).toFixed(2) * 150 * piracy(region);
+                    }
+                }
             }
-            let know = (dorm + gtrade + leave) * p_on['symposium'];
+            let pirate = piracy('gxy_gorddon');
+            let know = (dorm + gtrade + leave) * pirate * p_on['symposium'];
             caps['Knowledge'] += know;
             breakdown.c.Knowledge[loc('galaxy_symposium')] = know +'v';
         }
@@ -10377,27 +10372,29 @@ function midLoop(){
         }
 
         if (global.galaxy['defense']){
-            let armada_ships = ['dreadnought','cruiser_ship','frigate_ship','corvette_ship','scout_ship']
-            for (let i=0; i<armada_ships.length; i++){
+            // Check both ships and regions in reverse order to prioritize bigger ships and later systems above smaller ships and earlier systems
+            for (let i = gatewayArmada.length - 1; i >= 0; i--){
+                let ship = gatewayArmada[i];
                 let count = 0;
-                Object.keys(global.galaxy.defense).forEach(function (region){
+                for (let j = galaxyRegions.length - 1; j >= 0; j--){
+                    let region = galaxyRegions[j];
                     if (global.galaxy.defense.hasOwnProperty(region)){
-                        count += global.galaxy.defense[region][armada_ships[i]];
-                        if (isNaN(global.galaxy.defense[region][armada_ships[i]])){
-                            global.galaxy.defense[region][armada_ships[i]] = 0;
+                        count += global.galaxy.defense[region][ship];
+                        if (isNaN(global.galaxy.defense[region][ship])){
+                            global.galaxy.defense[region][ship] = 0;
                         }
-                        if (count > gal_on[armada_ships[i]]){
-                            let overflow = count - gal_on[armada_ships[i]];
-                            global.galaxy.defense[region][armada_ships[i]] -= overflow;
+                        if (count > gal_on[ship]){
+                            let overflow = count - gal_on[ship];
+                            global.galaxy.defense[region][ship] -= overflow;
                         }
-                        if (global.galaxy.defense[region][armada_ships[i]] < 0){
-                            global.galaxy.defense[region][armada_ships[i]] = 0;
+                        if (global.galaxy.defense[region][ship] < 0){
+                            global.galaxy.defense[region][ship] = 0;
                         }
                     }
-                });
-                if (count < gal_on[armada_ships[i]]){
-                    let underflow = gal_on[armada_ships[i]] - count;
-                    global.galaxy.defense.gxy_gateway[armada_ships[i]] += underflow;
+                }
+                if (count < gal_on[ship]){
+                    let underflow = gal_on[ship] - count;
+                    global.galaxy.defense.gxy_gateway[ship] += underflow;
                 }
             }
         }

--- a/src/space.js
+++ b/src/space.js
@@ -6402,6 +6402,9 @@ const galaxyProjects = {
     },
 };
 
+export const galaxyRegions = ['gxy_gateway', 'gxy_stargate', 'gxy_gorddon', 'gxy_alien1', 'gxy_alien2', 'gxy_chthonian'];
+export const gatewayArmada = ['scout_ship', 'corvette_ship', 'frigate_ship', 'cruiser_ship', 'dreadnought'];
+
 export function convertSpaceSector(part){
     let space = 'space';
     if (part.substr(0,4) === 'int_'){
@@ -6425,13 +6428,13 @@ export function convertSpaceSector(part){
 export function piracy(region,rating,raw,wiki){
     if (global.tech['piracy'] && !global.race['truepath']){
         let armada = 0;
-        let ships = ['dreadnought','cruiser_ship','frigate_ship','corvette_ship','scout_ship'];
-        for (let i=0; i<ships.length; i++){
-            if (!global.galaxy.defense[region].hasOwnProperty(ships[i])){
-                global.galaxy.defense[region][ships[i]] = 0;
+        for (let i = gatewayArmada.length - 1; i >= 0; i--){
+            let ship = gatewayArmada[i];
+            if (!global.galaxy.defense[region].hasOwnProperty(ship)){
+                global.galaxy.defense[region][ship] = 0;
             }
-            let count = global.galaxy.defense[region][ships[i]];
-            armada += count * galaxyProjects.gxy_gateway[ships[i]].ship.rating();
+            let count = global.galaxy.defense[region][ship];
+            armada += count * galaxyProjects.gxy_gateway[ship].ship.rating();
         }
 
         let pirate = 0;
@@ -7096,29 +7099,22 @@ function armada(parent,id){
         let fleet = $(`<div id="${id}" class="fleet"></div>`);
         parent.append(fleet);
 
-        let ships = ['scout_ship','corvette_ship','frigate_ship','cruiser_ship','dreadnought'];
-
         let cols = [];
-        for (let i=0; i<6; i++){
+        // One column per ship type plus an extra column for labels
+        for (let i = 0; i < gatewayArmada.length + 1; i++){
             let col = $(`<div class="area"></div>`);
             cols.push(col);
             fleet.append(col);
         }
 
-        for (let i=0; i<ships.length; i++){
-            if (global.galaxy.hasOwnProperty(ships[i])){
-                let ship = $(`<span id="armada${ships[i]}" class="ship has-text-advanced">${galaxyProjects.gxy_gateway[ships[i]].title}</span>`);
-                cols[i+1].append(ship);
-            }
-        }
-
         cols[0].append($(`<span></span>`));
         cols[0].append($(`<span id="armadagateway" class="has-text-danger">${galaxyProjects.gxy_gateway.info.name}</span>`));
 
-        for (let i=0; i<ships.length; i++){
-            if (global.galaxy.hasOwnProperty(ships[i])){
-                let ship = $(`<span class="ship">{{ gateway.${ships[i]} }}</span>`);
-                cols[i+1].append(ship);
+        for (let i = 0; i < gatewayArmada.length; i++){
+            const ship = gatewayArmada[i];
+            if (global.galaxy.hasOwnProperty(ship)){
+                cols[i+1].append($(`<span id="armada${ship}" class="ship has-text-advanced">${galaxyProjects.gxy_gateway[ship].title}</span>`));
+                cols[i+1].append($(`<span class="ship">{{ gateway.${ship} }}</span>`));
             }
         }
 
@@ -7129,16 +7125,17 @@ function armada(parent,id){
                 let region = $(`<span id="armada${r}" class="has-text-caution">${typeof galaxyProjects[area].info.name === 'string' ? galaxyProjects[area].info.name : galaxyProjects[area].info.name()}</span>`);
                 cols[0].append(region);
 
-                for (let i=0; i<ships.length; i++){
-                    if (global.galaxy.hasOwnProperty(ships[i])){
-                        let ship = $(`<span class="ship"></span>`);
-                        let sub = $(`<span role="button" aria-label="remove ${ships[i]}" class="sub has-text-danger" @click="sub('${area}','${ships[i]}')"><span>&laquo;</span></span>`);
-                        let count = $(`<span class="current">{{ ${r}.${ships[i]} }}</span>`);
-                        let add = $(`<span role="button" aria-label="add ${ships[i]}" class="add has-text-success" @click="add('${area}','${ships[i]}')"><span>&raquo;</span></span>`);
-                        cols[i+1].append(ship);
-                        ship.append(sub);
-                        ship.append(count);
-                        ship.append(add);
+                for (let i = 0; i < gatewayArmada.length; i++){
+                    const ship = gatewayArmada[i];
+                    if (global.galaxy.hasOwnProperty(ship)){
+                        let shipSpan = $(`<span class="ship"></span>`);
+                        let sub = $(`<span role="button" aria-label="remove ${ship}" class="sub has-text-danger" @click="sub('${area}','${ship}')"><span>&laquo;</span></span>`);
+                        let count = $(`<span class="current">{{ ${r}.${ship} }}</span>`);
+                        let add = $(`<span role="button" aria-label="add ${ship}" class="add has-text-success" @click="add('${area}','${ship}')"><span>&raquo;</span></span>`);
+                        cols[i+1].append(shipSpan);
+                        shipSpan.append(sub);
+                        shipSpan.append(count);
+                        shipSpan.append(add);
                     }
                 }
 
@@ -7189,10 +7186,11 @@ function armada(parent,id){
             }
         });
 
-        for (let i=0; i<ships.length; i++){
-            if (global.galaxy.hasOwnProperty(ships[i])){
-                popover(`armada${ships[i]}`,function(obj){
-                    actionDesc(obj.popper,galaxyProjects.gxy_gateway[ships[i]],global.galaxy[ships[i]]);
+        for (let i = 0; i < gatewayArmada.length; i++){
+            const ship = gatewayArmada[i];
+            if (global.galaxy.hasOwnProperty(ship)){
+                popover(`armada${ship}`,function(obj){
+                    actionDesc(obj.popper, galaxyProjects.gxy_gateway[ship], global.galaxy[ship]);
                     return undefined;
                 });
             }

--- a/src/space.js
+++ b/src/space.js
@@ -5644,7 +5644,7 @@ const galaxyProjects = {
                 desc += `<div>${loc('galaxy_symposium_effect2',[(650 * pirate).toFixed(0)])}</div>`;
                 if (global.tech.xeno >= 7){
                     desc += `<div>${loc('galaxy_symposium_effect3',[+highPopAdjust(300 * pirate).toFixed(2)])}</div>`;
-                    desc += `<div>${loc('galaxy_symposium_effect3b',[+highPopAdjust(150 * pirate).toFixed(2)])}</div>`;
+                    desc += `<div>${loc('galaxy_symposium_effect3b',[+highPopAdjust(100 * pirate).toFixed(2)])}</div>`;
                 }
                 if(global.tech.science >= 22){
                     desc += `<div>${loc('galaxy_symposium_effect4',[+(100 * pirate).toFixed(2), loc('eden_research_station_title')])}</div>`;
@@ -6404,6 +6404,44 @@ const galaxyProjects = {
 
 export const galaxyRegions = ['gxy_gateway', 'gxy_stargate', 'gxy_gorddon', 'gxy_alien1', 'gxy_alien2', 'gxy_chthonian'];
 export const gatewayArmada = ['scout_ship', 'corvette_ship', 'frigate_ship', 'cruiser_ship', 'dreadnought'];
+
+export const galaxy_ship_types = [
+    {
+        area: 'galaxy',
+        region: 'gxy_gateway',
+        ships: global.support.gateway.map(x => x.split(':')[1])
+    },
+    {
+        area: 'galaxy',
+        region: 'gxy_gorddon',
+        ships: ['freighter'],
+        req: 'embassy'
+    },
+    {
+        area: 'galaxy',
+        region: 'gxy_alien1',
+        ships: ['super_freighter'],
+        req: 'embassy'
+    },
+    {
+        area: 'galaxy',
+        region: 'gxy_alien2',
+        ships: global.support.alien2.map(x => x.split(':')[1]),
+        req: 'foothold'
+    },
+    {
+        area: 'galaxy',
+        region: 'gxy_chthonian',
+        ships: ['minelayer','raider'],
+        req: 'starbase'
+    },
+    {
+        area: 'portal',
+        region: 'prtl_lake',
+        ships: global.support.lake.map(x => x.split(':')[1]),
+        req: 'harbor'
+    }
+];
 
 export function convertSpaceSector(part){
     let space = 'space';


### PR DESCRIPTION
When a new warship is powered on in Andromeda, it is assigned to the Gateway. When any of the requirements to operate the ship are insufficient (either crew or support), this will subsequently cause a ship to be unassigned.

This change reverses the system priority order, so ships will be removed from the Gateway first, then Stargate, all the way down to Chthonian. This means that building _new_ ships without enough crew will not disturb the existing location assignments. A larger ship that steals support from one or more smaller ships may still cause loss of security in the systems where smaller ships were (formerly) assigned, since the new ship will always default to the Gateway; caveat emptor.

Based on the following Discord bug report: https://discord.com/channels/586926974585274373/1350209481212170342

I tested the change with a post-Andromeda save file and it seemed to work.