### PR TITLE
Improve Accessibility of Manual Crafting Buttons

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -837,7 +837,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
         for (let i=0; i<inc.length; i++){
             craft.append($(`<span id="inc${name}${inc[i]}"><a @click="craft('${name}',${inc[i]})" aria-label="craft ${inc[i]} ${global.resource[name].name}" role="button">+<span class="craft" data-val="${inc[i]}">${inc[i]}</span></a></span>`));
         }
-        craft.append($(`<span id="inc${name}A"><a @click="craft('${name}','A')" aria-label="craft max ${name}" role="button">+<span class="craft" data-val="${'A'}">A</span></a></span>`));
+        craft.append($(`<span id="inc${name}A"><a @click="craft('${name}','A')" aria-label="craft max ${global.resource[name].name}" role="button">+<span class="craft" data-val="${'A'}">A</span></a></span>`));
         infopops = true;
     }
     else if(global.race['fasting'] && name === global.race.species){

--- a/src/resources.js
+++ b/src/resources.js
@@ -835,9 +835,9 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
 
         let inc = [1,5];
         for (let i=0; i<inc.length; i++){
-            craft.append($(`<span id="inc${name}${inc[i]}"><a @click="craft('${name}',${inc[i]})" aria-label="craft ${inc[i]} ${global.resource[name].name}">+<span class="craft" data-val="${inc[i]}">${inc[i]}</span></a></span>`));
+            craft.append($(`<span id="inc${name}${inc[i]}"><a @click="craft('${name}',${inc[i]})" aria-label="craft ${inc[i]} ${global.resource[name].name}" role="button">+<span class="craft" data-val="${inc[i]}">${inc[i]}</span></a></span>`));
         }
-        craft.append($(`<span id="inc${name}A"><a @click="craft('${name}','A')" aria-label="craft max ${name}">+<span class="craft" data-val="${'A'}">A</span></a></span>`));
+        craft.append($(`<span id="inc${name}A"><a @click="craft('${name}','A')" aria-label="craft max ${name}" role="button">+<span class="craft" data-val="${'A'}">A</span></a></span>`));
         infopops = true;
     }
     else if(global.race['fasting'] && name === global.race.species){


### PR DESCRIPTION
Currently, at least some screen readers interpret the manual crafting buttons (to craft 1, 5, or "max" of a resource) as unclickable plain text elements and separate out the aria-label from the visual text of "+1", "+5", or "A". This PR adds role="button" to these controls to force screen readers to treat them like single button elements. In addition, the aria-label for the "craft max" buttons still use the internal identifier for the resource name (which means it will use the incorrect name if the resource has been reskinned or localized to a different name). This PR, therefore, changes the label to retrieve the current name from the global.resource object. (The labels for the other buttons were fixed in #1360, but I had overlooked the "craft max" buttons when working on that PR.)