### PR TITLE
Fix mistakes introduced in #1384

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6888,7 +6888,7 @@ export function getStructNumActive(c_action,wiki){
 
     // Electricity: production is negative, consumption is positive
     if (c_action.hasOwnProperty('powered') && c_action.powered() > 0) {
-        if (global.city.hasOwnProperty('powered')){
+        if (global.city.hasOwnProperty('powered') && checkPowerRequirements(c_action)){
             // The p_on struct is empty in the wiki view
             if (!wiki){
                 num_on = p_on[parts[1]];

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { defineResources, resource_values, spatialReasoning, craftCost, plasmidB
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobName, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
-import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn } from './actions.js';
+import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, checkPowerRequirements, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn } from './actions.js';
 import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay, hellguard } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
@@ -2003,7 +2003,7 @@ function fastLoop(){
             const region = parts[0] === 'city' ? parts[0] : convertSpaceSector(parts[0]);
             const c_action = parts[0] === 'city' ? actions.city[struct] : actions[region][parts[0]][struct];
             if (global[region][struct]?.on){
-                if (region !== 'galaxy' || p_on['s_gate']){
+                if (checkPowerRequirements(c_action) && (region !== 'galaxy' || p_on['s_gate'])){
                     totalPowerDemand += global[region][struct].on * c_action.powered();
                     p_on[struct] = global[region][struct].on;
                 } else {

--- a/src/space.js
+++ b/src/space.js
@@ -4599,6 +4599,7 @@ const interstellarProjects = {
                         if (global.interstellar.ascension_machine.count >= 100){
                             global.tech['ascension'] = 7;
                             initStruct(interstellarProjects.int_sirius.ascension_trigger);
+                            incrementStruct('ascension_trigger','interstellar');
                             if (global.settings.alwaysPower){
                                 powerOnNewStruct(interstellarProjects.int_sirius.ascension_trigger);
                             }


### PR DESCRIPTION
Increment the ascension trigger count to 1 after it is initialized.
Check power requirements before supplying power to structures.

I tested both parts and they are working as expected.