### PR TITLE
Several minor fixes

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3458,7 +3458,7 @@ export const actions = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('casino','city');
-                    if (!global.race['joyless']){
+                    if (global.tech['theatre'] && !global.race['joyless']){
                         global.civic.entertainer.max += jobScale(1);
                         global.civic.entertainer.display = true;
                     }
@@ -5490,7 +5490,7 @@ export function casinoEarn(){
 export function casinoEffect(){
     let money = Math.round(casino_vault());
 
-    let joy = global.race['joyless'] ? '' : `<div>${loc('plus_max_resource',[jobScale(1),loc(`job_entertainer`)])}</div>`;
+    let joy = (global.tech['theatre'] && !global.race['joyless']) ? `<div>${loc('plus_max_resource',[jobScale(1),loc(`job_entertainer`)])}</div>` : '';
     let banker = global.race['orbit_decayed'] || global.tech['isolation'] ? `<div>${loc('plus_max_resource',[jobScale(1),loc('banker_name')])}</div>` : '';
     let desc = `<div>${loc('plus_max_resource',[`\$${money.toLocaleString()}`,loc('resource_Money_name')])}</div>${joy}${banker}<div>${loc('city_max_morale',[1])}</div>`;
     let cash = +(casinoEarn()).toFixed(2);
@@ -8898,11 +8898,14 @@ function aiStart(){
         global.tech['titanium'] = 1;
         global.tech['foundry'] = 7;
         global.tech['factory'] = 1;
-        global.tech['theatre'] = 3;
-        global.tech['broadcast'] = 1;
         global.tech['science'] = 7;
         global.tech['high_tech'] = 4;
         global.tech['theology'] = 2;
+
+        if (!global.race['joyless']){
+            global.tech['theatre'] = 3;
+            global.tech['broadcast'] = 1;
+        }
 
         global.settings.showIndustry = true;
         global.settings.showPowerGrid = true;
@@ -9095,6 +9098,11 @@ function cataclysm(){
         global.tech['satellite'] = 1;
         global.tech['space_explore'] = 4;
         global.tech['genesis'] = 2;
+
+        // Begin with a biodome: joyless is incompatible with Cataclysm
+        if (global.race['joyless']) {
+            delete global.race['joyless'];
+        }
 
         global.settings.showSpace = true;
         global.settings.space.home = true;

--- a/src/edenic.js
+++ b/src/edenic.js
@@ -677,7 +677,9 @@ const edenicModules = {
                 let max = 2;
 
                 let desc = `<div class="has-text-caution">${loc('space_used_support',[loc('eden_asphodel_name')])}</div>`;
-                desc += `<div>${loc('space_red_vr_center_effect1',[morale])}</div>`;
+                if (!global.race['joyless']){
+                    desc += `<div>${loc('space_red_vr_center_effect1',[morale])}</div>`;
+                }
                 desc += `<div>${loc('space_red_vr_center_effect2',[max])}</div>`;
 
                 return desc;
@@ -1350,7 +1352,7 @@ const edenicModules = {
                 if (!global.tech['isle'] || global.tech.isle === 1){
                     desc += `<div>${loc('eden_pillbox_effect',[rating])}</div>`;
                 }
-                if (global.tech['elysium'] && global.tech.elysium >= 12){
+                if (global.tech['elysium'] && global.tech.elysium >= 12 && !global.race['joyless']){
                     desc += `<div>${loc('eden_restaurant_effect',[0.35,loc(`eden_restaurant_bd`)])}</div>`;
                 }
                 desc += `<div class="has-text-caution">${loc('portal_guard_post_effect2',[jobScale(10),$(this)[0].powered()])}</div>`;
@@ -1393,7 +1395,10 @@ const edenicModules = {
                 morale += (global.civic?.elysium_miner?.workers ?? 0) * 0.15;
                 morale += global.eden.hasOwnProperty('archive') && p_on['archive'] ? 0.4 * p_on['archive'] : 0;
 
-                let desc =  `<div>${loc('space_red_vr_center_effect1',[morale.toFixed(1)])}</div>`
+                let desc =  '';
+                if (!global.race['joyless']){
+                    desc += `<div>${loc('space_red_vr_center_effect1',[morale.toFixed(1)])}</div>`;
+                }
                 desc += `<div class="has-text-caution">${loc('interstellar_alpha_starport_effect3',[sizeApproximation(food),global.resource.Food.name])}</div>`;
                 desc += `<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
                 return desc;

--- a/src/industry.js
+++ b/src/industry.js
@@ -147,7 +147,41 @@ export const f_rate = {
     }
 };
 
+export function smelterFuelConfig(){
+    let fuel = {
+        d_fuel: 'Lumber',
+        l_type: 'Lumber',
+        l_cost: 3,
+        // Discount coal cost for species that (usually) cannot burn lumber
+        c_cost: (global.race['kindling_kindred'] || global.race['smoldering']) ? 0.15 : 0.25,
+        // Oil bonus is free with Forge trait
+        o_cost: global.race['forge'] ? 0 : 0.35,
+    };
+
+    if (global.race['evil']){
+        if (global.race['soul_eater'] && global.race.species !== 'wendigo' && !global.race['artificial']){
+            fuel.l_type = 'Food';
+        }
+        else {
+            fuel.l_type = 'Furs';
+            fuel.l_cost = 1;
+        }
+    }
+    // Set default fuel to coal if it's not possible to burn lumber, souls, or flesh
+    else if (global.race['kindling_kindred'] || global.race['smoldering']){
+        fuel.d_fuel = 'Coal';
+    }
+
+    // Synthetics start with oil unlocked and always default to its use
+    if (global.race['artificial']) {
+        fuel.d_fuel = 'Oil';
+    }
+
+    return fuel;
+}
+
 function loadSmelter(parent,bind){
+    const fuel_config = smelterFuelConfig();
     let fuel = $(`<div><span class="has-text-warning">${loc('modal_smelter_fuel')}:</span> <span :class="level()">{{s.count | on}}/{{ s.cap }}</span></div>`);
     parent.append(fuel);
 
@@ -171,7 +205,7 @@ function loadSmelter(parent,bind){
 
     if (!global.race['forge']){
         if ((!global.race['kindling_kindred'] && !global.race['smoldering']) || global.race['evil']){
-            let f_label = global.race['evil'] ? (global.race['soul_eater'] && global.race.species !== 'wendigo' && !global.race['artifical'] ? global.resource.Food.name : global.resource.Furs.name) : global.resource.Lumber.name;
+            let f_label = global.resource[fuel_config.l_type].name;
             let wood = $(`<span :aria-label="buildLabel('wood') + ariaCount('Wood')" class="current wood">${f_label} {{ s.Wood }}</span>`);
             let subWood = $(`<span role="button" class="sub" @click="subFuel('Wood')" aria-label="Remove lumber fuel"><span>&laquo;</span></span>`);
             let addWood = $(`<span role="button" class="add" @click="addFuel('Wood')" aria-label="Add lumber fuel"><span>&raquo;</span></span>`);
@@ -221,18 +255,17 @@ function loadSmelter(parent,bind){
     parent.append(available);
 
     if (!bind && 1 === 2){
-        if (!global.race['kindling_kindred'] || global.race['evil']){
-            if (global.race['evil']){
-                if (global.race['soul_eater'] && global.race.species !== 'wendigo'){
-                    available.append(`<span :class="net('Lumber')">{{ food.diff | diffSize }}</span>`);
-                }
-                else {
-                    available.append(`<span :class="net('Lumber')">{{ fur.diff | diffSize }}</span>`);
-                }
-            }
-            else {
+        switch (fuel_config.l_type){
+            case 'Food':
+                available.append(`<span :class="net('Lumber')">{{ food.diff | diffSize }}</span>`);
+                break;
+            case 'Furs':
+                available.append(`<span :class="net('Lumber')">{{ fur.diff | diffSize }}</span>`);
+                break;
+            case 'Lumber':
+            default:
                 available.append(`<span :class="net('Lumber')">{{ lum.diff | diffSize }}</span>`);
-            }
+                break;
         }
 
         if (global.resource.Coal.display){
@@ -435,17 +468,17 @@ function loadSmelter(parent,bind){
     });
 
     function tooltip(type){
+        const fuel_config = smelterFuelConfig();
         switch(type){
             case 'wood':
-                return loc('modal_build_wood',[global.race['evil'] ? (global.race['soul_eater'] && global.race.species !== 'wendigo' && !global.race['artifical'] ? global.resource.Food.name : global.resource.Furs.name) : global.resource.Lumber.name, global.race['evil'] && !global.race['soul_eater'] || global.race.species === 'wendigo' ? 1 : 3]);
+                return loc('modal_build_wood',[global.resource[fuel_config.l_type].name, fuel_config.l_cost]);
             case 'coal':
                 {
-                    let coal_fuel = global.race['kindling_kindred'] ? 0.15 : 0.25;
                     if (global.tech['uranium'] && global.tech['uranium'] >= 3){
-                        return loc('modal_build_coal2',[coal_fuel,global.resource.Coal.name,global.resource.Uranium.name]);
+                        return loc('modal_build_coal2',[fuel_config.c_cost,global.resource.Coal.name,global.resource.Uranium.name]);
                     }
                     else {
-                        return loc('modal_build_coal1',[coal_fuel,global.resource.Coal.name]);
+                        return loc('modal_build_coal1',[fuel_config.c_cost,global.resource.Coal.name]);
                     }
                 }
             case 'oil':

--- a/src/main.js
+++ b/src/main.js
@@ -2976,7 +2976,7 @@ function fastLoop(){
         });
 
         let entertainment = 0;
-        if (global.tech['theatre']){
+        if (global.tech['theatre'] && !global.race['joyless']){
             entertainment += workerScale(global.civic.entertainer.workers,'entertainer') * global.tech.theatre;
             if (global.race['musical']){
                 entertainment += workerScale(global.civic.entertainer.workers,'entertainer') * traits.musical.vars()[0];
@@ -2999,11 +2999,20 @@ function fastLoop(){
         morale += entertainment;
 
         if (global.tech['broadcast'] && !global.race['joyless']){
-            let gasVal = govActive('gaslighter',0);
-            let signalVal = global.race['orbit_decayed'] ? (p_on['nav_beacon'] || 0) : (global.tech['isolation'] && global.race['truepath'] ? support_on['colony'] : p_on['wardenclyffe']);
-            if (global.race['orbit_decayed']){ signalVal /= 2; }
-            let mVal = gasVal ? gasVal + global.tech.broadcast : global.tech.broadcast;
-            if (global.tech['isolation']){ mVal *= 2; }
+            let gasVal = govActive('gaslighter',0) || 0;
+            let signalVal;
+            let mVal = gasVal + global.tech.broadcast;
+            if (global.race['orbit_decayed']) {
+                signalVal = p_on['nav_beacon'] || 0;
+                mVal /= 2; // 50% effectiveness also applies to Media governor
+            }
+            else if (global.tech['isolation'] && global.race['truepath']){
+                signalVal = support_on['colony'];
+                mVal *= 2;
+            }
+            else {
+                signalVal = p_on['wardenclyffe'];
+            }
             global.city.morale.broadcast = signalVal * mVal;
             morale += signalVal * mVal;
         }
@@ -3011,8 +3020,8 @@ function fastLoop(){
             global.city.morale.broadcast = 0;
         }
         if (support_on['vr_center'] && !global.race['joyless']){
-            let gasVal = govActive('gaslighter',1);
-            let vr_morale = gasVal ? gasVal + 1 : 1;
+            let gasVal = govActive('gaslighter',1) || 0;
+            let vr_morale = gasVal + 1;
             if (global.race['orbit_decayed']){
                 vr_morale += 2;
             }
@@ -8458,20 +8467,28 @@ function midLoop(){
             lCaps['entertainer'] += jobScale(athVal ? (global.city.amphitheatre.count * athVal) : global.city.amphitheatre.count);
         }
         if (global.city['casino']){
-            lCaps['entertainer'] += jobScale(global.city.casino.count);
+            if (global.tech['theatre'] && !global.race['joyless']){
+                lCaps['entertainer'] += jobScale(global.city.casino.count);
+            }
         }
         if (global.space['spc_casino']){
-            lCaps['entertainer'] += jobScale(global.space.spc_casino.count);
+            if (global.tech['theatre'] && !global.race['joyless']){
+                lCaps['entertainer'] += jobScale(global.space.spc_casino.count);
+            }
             if (global.race['orbit_decayed']){
                 lCaps['banker'] += jobScale(global.space.spc_casino.count);
             }
         }
         if (global.portal['hell_casino']){
-            lCaps['entertainer'] += jobScale(global.portal.hell_casino.count * 3);
+            if (global.tech['theatre'] && !global.race['joyless']){
+                lCaps['entertainer'] += jobScale(global.portal.hell_casino.count * 3);
+            }
             lCaps['banker'] += jobScale(global.portal.hell_casino.count);
         }
         if (global.tauceti['tauceti_casino']){
-            lCaps['entertainer'] += jobScale(global.tauceti.tauceti_casino.count);
+            if (global.tech['theatre'] && !global.race['joyless']){
+                lCaps['entertainer'] += jobScale(global.tauceti.tauceti_casino.count);
+            }
             if (global.tech['isolation']){
                 lCaps['banker'] += jobScale(global.tauceti.tauceti_casino.count);
 
@@ -8481,7 +8498,9 @@ function midLoop(){
             }
         }
         if (global.galaxy['resort']){
-            lCaps['entertainer'] += jobScale(p_on['resort'] * 2);
+            if (global.tech['theatre'] && !global.race['joyless']){
+                lCaps['entertainer'] += jobScale(p_on['resort'] * 2);
+            }
         }
         if (global.city['cement_plant']){
             lCaps['cement_worker'] += jobScale(global.city.cement_plant.count * 2);
@@ -11990,10 +12009,7 @@ function longLoop(){
                 global.tech.high_tech = 2;
                 global.city['power'] = 0;
                 global.city['powered'] = true;
-                global.city['coal_power'] = {
-                    count: 0,
-                    on: 0
-                };
+                initStruct(actions.city.coal_power);
                 global.settings.showPowerGrid = true;
                 setPowerGrid();
                 drawTech();
@@ -12004,8 +12020,8 @@ function longLoop(){
                 global.tech.high_tech = 4;
                 if (global.race['terrifying']){
                     global.tech['gambling'] = 1;
-                    global.city['casino'] = { count: 0 };
-                    global.space['spc_casino'] = { count: 0 };
+                    initStruct(actions.city.casino);
+                    initStruct(actions.space.spc_hell.spc_casino);
                 }
                 drawTech();
                 drawCity();
@@ -12013,10 +12029,7 @@ function longLoop(){
             if (global.resource.Knowledge.max >= (actions.tech.fission.cost.Knowledge() * know_adjust) && global.tech['high_tech'] && global.tech.high_tech === 4 && global.tech['uranium']){
                 messageQueue(loc(tech_source,[loc('tech_fission')]),'info',false,['progress']);
                 global.tech.high_tech = 5;
-                global.city['fission_power'] = {
-                    count: 0,
-                    on: 0
-                };
+                initStruct(actions.city.fission_power);
                 drawTech();
                 drawCity();
             }
@@ -12078,7 +12091,7 @@ function longLoop(){
                 if (global.resource.Knowledge.max >= (actions.tech.ai_core.cost.Knowledge() * know_adjust) && global.tech['high_tech'] && global.tech.high_tech === 14 && global.tech['blackhole'] && global.tech['blackhole'] >= 3){
                     messageQueue(loc(tech_source,[loc('tech_ai_core')]),'info',false,['progress']);
                     global.tech.high_tech = 15;
-                    global.interstellar['citadel'] = { count: 0, on: 0 };
+                    initStruct(actions.interstellar.int_neutron.citadel);
                     drawTech();
                     drawCity();
                 }

--- a/src/portal.js
+++ b/src/portal.js
@@ -851,8 +851,9 @@ const fortressModules = {
                 }
                 else if (payCosts($(this)[0])){
                     incrementStruct('hell_casino','portal');
-                    if (!global.race['joyless']){
+                    if (global.tech['theatre'] && !global.race['joyless']){
                         global.civic.entertainer.max += jobScale(3);
+                        global.civic.entertainer.display = true;
                     }
                     powerOnNewStruct($(this)[0]);
                     return true;
@@ -1645,7 +1646,10 @@ const fortressModules = {
                 Brick(offset){ return spaceCostMultiplier('tavern', offset, 138000, 1.25, 'portal'); },
             },
             effect(wiki){
-                let desc = `<div>${loc('plus_resource_per',[0.35,loc('morale'),loc('portal_shadow_mine_title')])}</div>`;
+                let desc = '';
+                if (!global.race['joyless']){
+                    desc += `<div>${loc('plus_resource_per',[0.35,loc('morale'),loc('portal_shadow_mine_title')])}</div>`;
+                }
                 desc += `<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
                 return desc;
             },
@@ -7307,7 +7311,6 @@ export function warlordSetup(){
         global.tech['banking'] = 11;
         global.tech['biotech'] = 1;
         global.tech['boot_camp'] = 2;
-        global.tech['broadcast'] = 2;
         global.tech['container'] = 7;
         global.tech['copper'] = 1;
         global.tech['currency'] = 6;
@@ -7376,7 +7379,6 @@ export function warlordSetup(){
         global.tech['swarm'] = 6;
         global.tech['syndicate'] = 0;
         global.tech['synthetic_fur'] = 1;
-        global.tech['theatre'] = 3;
         global.tech['theology'] = 2;
         global.tech['titanium'] = 3;
         global.tech['trade'] = 3;
@@ -7393,6 +7395,11 @@ export function warlordSetup(){
         global.tech['hell_lake'] = 1;
         global.tech['hell_spire'] = 1;
         global.tech['hellspawn'] = 1;
+
+        if (!global.race['joyless']){
+            global.tech['theatre'] = 3;
+            global.tech['broadcast'] = 2;
+        }
 
         if (!global.race['flier']){
             global.tech['cement'] = 5;
@@ -7678,7 +7685,7 @@ export function warlordSetup(){
         initStruct(actions.space.spc_red.ziggurat);
         initStruct(actions.space.spc_sun.swarm_control);
         initStruct(actions.space.spc_sun.swarm_satellite);
-        
+
         global.civic['garrison'] = {
             display: true,
             disabled: false,
@@ -7753,7 +7760,9 @@ export function warlordSetup(){
 
         global.civic.d_job = 'lumberjack';
         global.civic.miner.display = true;
-        global.civic.entertainer.display = true;
+        if (!global.race['joyless']){
+            global.civic.entertainer.display = true;
+        }
         global.civic.craftsman.display = true;
 
         let citizens = actions.portal.prtl_wasteland.dig_demon.citizens() + actions.portal.prtl_wasteland.hovel.citizens();
@@ -7769,9 +7778,11 @@ export function warlordSetup(){
         global.civic.cement_worker.workers = 5;
         global.civic.cement_worker.assigned = 5;
 
-        global.civic.entertainer.max = 3;
-        global.civic.entertainer.workers = 3;
-        global.civic.entertainer.assigned = 3;
+        if (!global.race['joyless']){
+            global.civic.entertainer.max = 3;
+            global.civic.entertainer.workers = 3;
+            global.civic.entertainer.assigned = 3;
+        }
 
         global.civic.banker.max = 1;
         global.civic.banker.workers = 1;

--- a/src/portal.js
+++ b/src/portal.js
@@ -1914,7 +1914,7 @@ const fortressModules = {
                 vault = +(vault).toFixed(0);
                 let containers = Math.round(get_qlevel(wiki)) * 10;
                 let container_string = `<div>${loc('plus_max_resource',[containers,global.resource.Crates.name])}</div><div>${loc('plus_max_resource',[containers,global.resource.Containers.name])}</div>`;
-                return `<div>${loc('plus_max_resource',[`\$${vault.toLocaleString()}`,loc('resource_Money_name')])}</div><div>${loc('plus_max_citizens',[$(this)[0].citizens()])}</div><div>${loc('plus_max_resource',[jobScale(5),loc('civics_garrison_soldiers')])}</div><div>${loc('portal_guard_post_effect1',[75])}</div>${container_string}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
+                return `<div>${loc('plus_max_resource',[`\$${vault.toLocaleString()}`,loc('resource_Money_name')])}</div><div>${loc('plus_max_citizens',[$(this)[0].citizens()])}</div><div>${loc('plus_max_resource',[$(this)[0].soldiers(),loc('civics_garrison_soldiers')])}</div><div>${loc('portal_guard_post_effect1',[75])}</div>${container_string}<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
             action(){
                 if (payCosts($(this)[0])){

--- a/src/space.js
+++ b/src/space.js
@@ -192,7 +192,7 @@ const spaceProjects = {
             support(){ return 1; },
             effect(){
                 let orbitEffect = '';
-                if (global.race['orbit_decayed'] && global.tech['broadcast']){
+                if (global.race['orbit_decayed'] && global.tech['broadcast'] && !global.race['joyless']){
                     orbitEffect = `<div class="has-text-caution">${loc('space_red_vr_center_effect1',[global.tech['broadcast'] / 2])}</div>`;
                 }
                 let effect1 = global.race['orbit_decayed'] ? '' : `<div>${loc('space_home_nav_beacon_effect1')}</div>`;
@@ -811,8 +811,8 @@ const spaceProjects = {
                 Soul_Gem(offset){ return spaceCostMultiplier('vr_center', offset, 1, 1.25); }
             },
             effect(){
-                let gasVal = govActive('gaslighter',1);
-                let morale = gasVal ? gasVal + 1 : 1;
+                let gasVal = govActive('gaslighter',1) || 0;
+                let morale = gasVal + 1;
                 if (global.race['orbit_decayed']){
                     morale += 2;
                 }
@@ -1597,7 +1597,7 @@ const spaceProjects = {
             action(){
                 if (payCosts($(this)[0])){
                     global.space.spc_casino.count++;
-                    if (!global.race['joyless']){
+                    if (global.tech['theatre'] && !global.race['joyless']){
                         global.civic.entertainer.max += jobScale(1);
                         global.civic.entertainer.display = true;
                     }
@@ -5790,7 +5790,7 @@ const galaxyProjects = {
             },
             effect(){
                 let money = spatialReasoning(global.tech['world_control'] ? 1875000 : 1500000);
-                let joy = global.race['joyless'] ? '' : `<div>${loc('plus_max_resource',[jobScale(2),loc(`job_entertainer`)])}</div>`;
+                let joy = (global.race['theatre'] && !global.race['joyless']) ? `<div>${loc('plus_max_resource',[jobScale(2),loc(`job_entertainer`)])}</div>` : '';
                 let desc = `<div>${loc('plus_max_resource',[`\$${money.toLocaleString()}`,loc('resource_Money_name')])}</div>${joy}<div>${loc('space_red_vr_center_effect2',[2])}</div>`;
                 return desc + `<div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
@@ -5799,7 +5799,7 @@ const galaxyProjects = {
                 if (payCosts($(this)[0])){
                     incrementStruct('resort','galaxy');
                     if (powerOnNewStruct($(this)[0])){
-                        if (!global.race['joyless']){
+                        if (global.race['theatre'] && !global.race['joyless']){
                             global.civic.entertainer.max += jobScale(2);
                             global.civic.entertainer.display = true;
                         }

--- a/src/space.js
+++ b/src/space.js
@@ -7874,6 +7874,9 @@ export function ascendLab(hybrid,wiki){
                         }
                         let formatError = false;
                         Object.keys(genome).forEach(function (type){
+                            if (type === 'fanaticism' && genome[type] === false){
+                                return;
+                            }
                             if (importCustom[type] && typeof genome[type] !== typeof importCustom[type]){
                                 formatError = true;
                                 return;

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -1871,7 +1871,7 @@ const tauCetiModules = {
                 
                 if (global.tech['isolation']){
                     let gasVal = govActive('gaslighter',0);
-                    let mVal = (gasVal ? gasVal + global.tech.broadcast : global.tech.broadcast) * 2;
+                    let mVal = ((gasVal || 0) + (global.tech.broadcast || 0)) * 2;
                     desc = desc + `<div>${loc('space_red_vr_center_effect1',[mVal])}</div>`;
                 }
                 
@@ -2579,7 +2579,7 @@ const tauCetiModules = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('tauceti_casino','tauceti');
-                    if (!global.race['joyless']){
+                    if (global.tech['theatre'] && !global.race['joyless']){
                         global.civic.entertainer.max += jobScale(1);
                         global.civic.entertainer.display = true;
                     }
@@ -5639,7 +5639,6 @@ export function loneSurvivor(){
         global.tech['banking'] = 11;
         global.tech['biotech'] = 1;
         global.tech['boot_camp'] = 2;
-        global.tech['broadcast'] = 2;
         global.tech['container'] = 7;
         global.tech['copper'] = 1;
         global.tech['currency'] = 6;
@@ -5714,7 +5713,6 @@ export function loneSurvivor(){
         global.tech['synthetic_fur'] = 1;
         global.tech['tau_home'] = 6;
         global.tech['tauceti'] = 4;
-        global.tech['theatre'] = 3;
         global.tech['theology'] = 2;
         global.tech['titan'] = 9;
         global.tech['titan_ai_core'] = 3;
@@ -5728,6 +5726,12 @@ export function loneSurvivor(){
         global.tech['wharf'] = 1;
         global.tech['world_control'] = 1;
         global.tech['wsc'] = 0;
+
+        // Note: Joyless cannot be completed in Lone Survivor, and there is no reward for trying.
+        if (!global.race['joyless']){
+            global.tech['theatre'] = 3;
+            global.tech['broadcast'] = 2;
+        }
 
         if (!global.race['flier']){
             global.tech['cement'] = 5;


### PR DESCRIPTION
Minor fixes to uranium ash
- Apply geology bonus to uranium ash from coal powerplants (Coal-fueled smelters already received geology bonuses)
- Display uranium ash on the right side of the breakdown instead of dividing its value by global production to fit on the left side

Fix a variety of Joyless edge cases
- Resolves #1339

Fix arcology description with grenadier trait
- Resolves #1325

Fix custom lab fanaticism trait import error
- Resolves #1254

Fix some corner cases related to smelting
- Probably resolves #1239, although I did not successfully reproduce the original error