### PR TITLE
Minor fixes for custom race lab

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -3242,7 +3242,8 @@ const altTraitDesc = {
 
 export function getTraitDesc(info, trait, opts){
     let fanatic = opts['fanatic'] || false;
-    let tpage = opts['tpage'] || false;
+    let tpage = opts['tpage'] || false; // Trait page (on wiki)
+    let rpage = opts['rpage'] || false; // Races page (on wiki)
     let trank = opts['trank'] || false;
     let wiki = opts['wiki'] || false;
     let species = opts['species']; // Intentionally keep undefined, not false, when undefined
@@ -3254,20 +3255,17 @@ export function getTraitDesc(info, trait, opts){
     if (tpage && ['genus','major'].includes(traits[trait].type)){
         rank = `<span><span role="button" @click="down()">&laquo;</span><span class="has-text-warning">${loc(`wiki_trait_rank`)} {{ rank }}</span><span role="button" @click="up()">&raquo;</span></span>`;
     }
-    if (wiki){
+    if (tpage || rpage){
         info.append(`<div class="type"><h2 class="has-text-warning">${traitName}</h2>${rank}</div>`);
-    }
-    if (wiki){
         if (tpage && traits[trait].hasOwnProperty('val')){
             info.append(`<div class="type has-text-caution">${loc(`wiki_trait_${traits[trait].type}`)}<span>${loc(`wiki_trait_value`,[traits[trait].val])}</span></div>`);
         }
         else {
             info.append(`<div class="type has-text-caution">${loc(`wiki_trait_${traits[trait].type}`)}</div>`);
         }
-    }
-
-    if (fanatic && wiki){
-        info.append(`<div class="has-text-danger">${loc(`wiki_trait_fanaticism`,[fanatic])}</div>`);
+        if (fanatic){
+            info.append(`<div class="has-text-danger">${loc(`wiki_trait_fanaticism`,[fanatic])}</div>`);
+        }
     }
 
     info.append(`<div class="desc">${traitDesc}</div>`);
@@ -3298,7 +3296,7 @@ export function getTraitDesc(info, trait, opts){
             info.append(`<div class="has-text-${color} effect">${trait_desc}</div>`);
         }
     }
-    if (traitExtra[trait] && wiki){
+    if (traitExtra[trait] && (tpage || rpage)){
         traitExtra[trait].forEach(function(te){
             if (typeof te !== 'string'){
                 te = te(opts);

--- a/src/space.js
+++ b/src/space.js
@@ -7479,7 +7479,8 @@ export function setUniverse(){
 }
 
 export function ascendLab(hybrid,wiki){
-    if (!wiki && !global.race['noexport']){
+    let isWiki = !!wiki;
+    if (!isWiki && !global.race['noexport']){
         if (webWorker.w){
             webWorker.w.terminate();
         }
@@ -7550,7 +7551,7 @@ export function ascendLab(hybrid,wiki){
         technophobe: global.stats.achieve['technophobe'] && global.stats.achieve.technophobe.l ? global.stats.achieve.technophobe.l : 0
     };
 
-    if (wiki){
+    if (isWiki){
         wiki.append(lab);
     }
     else {
@@ -7560,7 +7561,7 @@ export function ascendLab(hybrid,wiki){
     let labStatus = `<div><h3 class="has-text-danger">${loc('genelab_title')}</h3> - <span class="has-text-warning">${loc('genelab_genes')} {{ g.genes }}</span> - <span class="has-text-warning">${loc('trait_untapped_name')}: {{ g.genes | untapped }}</span> - <span class="has-text-caution">${loc('genelab_neg')} {{ td.neg }}/10</span></div>`;
     lab.append(labStatus);
 
-    if (wiki){
+    if (isWiki){
         lab.append(`
             <div class="has-text-caution">${loc('achieve_ascended_name')}</div>
         `);
@@ -7606,7 +7607,7 @@ export function ascendLab(hybrid,wiki){
     let dGenus = false;
     let genus = `<div class="genus_selection"><div class="has-text-caution">${loc('genelab_genus')}</div><template><section>`;
     Object.keys(genus_traits).forEach(function (type){
-        if (wiki || (global.stats.achieve[`genus_${type}`] && global.stats.achieve[`genus_${type}`].l > 0)){
+        if (isWiki || (global.stats.achieve[`genus_${type}`] && global.stats.achieve[`genus_${type}`].l > 0)){
             if (!dGenus){ dGenus = type; }
             genus = genus + `<div class="field ${type}"><b-radio v-model="g.genus" native-value="${type}">${loc(`genelab_genus_${type}`)}</b-radio></div>`;
         }
@@ -7620,13 +7621,13 @@ export function ascendLab(hybrid,wiki){
     Object.keys(races).forEach(function (race){
         let type = races[race].type;
         if (
-            wiki
+            isWiki
                 ||
             (global.stats.achieve[`extinct_${race}`] && global.stats.achieve[`extinct_${race}`].l > 0)
                 ||
             (global.stats.achieve[`genus_${type}`] && global.stats.achieve[`genus_${type}`].l > 0)
             ){
-            if (races[race].hasOwnProperty('traits') && !['junker','sludge','ultra_sludge'].includes(race)){
+            if (races[race].hasOwnProperty('traits') && !['custom','hybrid','junker','sludge','ultra_sludge'].includes(race)){
                 Object.keys(races[race].traits).forEach(function (trait){
                     unlockedTraits[trait] = true;
                 });
@@ -7662,7 +7663,7 @@ export function ascendLab(hybrid,wiki){
             <span>{{ err.msg }}</span>
         </div>
     `;
-    if (!wiki){
+    if (!isWiki){
         buttons += `
             <div class="create">
                 <button class="button" @click="setRace()">${loc('genelab_create')}</button>
@@ -7720,7 +7721,7 @@ export function ascendLab(hybrid,wiki){
         }
     }
 
-    genome.genes = calcGenomeScore(genome,(wiki ? wikiVars : false));
+    genome.genes = calcGenomeScore(genome,(isWiki ? wikiVars : false));
     let error = { msg: "" };
 
     var modal = {
@@ -7762,7 +7763,7 @@ export function ascendLab(hybrid,wiki){
                     }
                 }
                 trait_data.neg = neg_traits;
-                genome.genes = calcGenomeScore(genome,(wiki ? wikiVars : false));
+                genome.genes = calcGenomeScore(genome,(isWiki ? wikiVars : false));
             },
             setRace(){
                 if (genome.fanaticism && !genome.traitlist.includes(genome.fanaticism)){ return false; }
@@ -7824,7 +7825,7 @@ export function ascendLab(hybrid,wiki){
                 genome.eris = "";
                 genome.genus = dGenus;
                 genome.traitlist = [];
-                genome.genes = calcGenomeScore(genome,(wiki ? wikiVars : false));
+                genome.genes = calcGenomeScore(genome,(isWiki ? wikiVars : false));
                 genome.fanaticism = false;
             },
             fanatic(){
@@ -7907,7 +7908,7 @@ export function ascendLab(hybrid,wiki){
                         if (genome.desc.length > 255){
                             genome.desc = genome.desc.substring(0, 255);
                         }
-                        if (!wiki && !(global.stats.achieve[`genus_${genome.genus}`] && global.stats.achieve[`genus_${genome.genus}`].l > 0)){
+                        if (!isWiki && !(global.stats.achieve[`genus_${genome.genus}`] && global.stats.achieve[`genus_${genome.genus}`].l > 0)){
                             genome.genus = dGenus;
                         }
                         let fixTraitlist = [];
@@ -7918,7 +7919,7 @@ export function ascendLab(hybrid,wiki){
                         }
                         genome.fanaticism = importCustom.hasOwnProperty('fanaticism') ? importCustom.fanaticism : false,
                         genome.traitlist = fixTraitlist;
-                        genome.genes = calcGenomeScore(genome,(wiki ? wikiVars : false));
+                        genome.genes = calcGenomeScore(genome,(isWiki ? wikiVars : false));
 
                         let neg_traits = 0;
                         for (let i=0; i<genome.traitlist.length; i++){
@@ -7951,7 +7952,7 @@ export function ascendLab(hybrid,wiki){
             cost(trait){
                 if (traits[trait].val >= 0){
                     let max_complexity = 2;
-                    if (wiki){
+                    if (isWiki){
                         max_complexity += wikiVars.technophobe;
                     }
                     else if (global.stats.achieve['technophobe'] && global.stats.achieve.technophobe.l >= 1){
@@ -7992,14 +7993,19 @@ export function ascendLab(hybrid,wiki){
         }
     });
 
+    let genus_trank = (global.stats.achieve['pathfinder'] && global.stats.achieve.pathfinder.l >= 4) ? 2 : 1;
     Object.keys(genus_traits).forEach(function (type){
-        if (global.stats.achieve[`genus_${type}`] && global.stats.achieve[`genus_${type}`].l > 0){
+        if (isWiki || (global.stats.achieve[`genus_${type}`] && global.stats.achieve[`genus_${type}`].l > 0)){
             popover(`celestialLabgenusSelection${type}`, function(){
                 let desc = $(`<div><div>${loc(`genelab_genus_${type}_desc`)}</div></div>`);
                 Object.keys(genus_traits[type]).forEach(function (t){
                     if (traits[t]){
                         let des = $(`<div></div>`);
-                        getTraitDesc(des, t, { trank: 1 });
+                        let opts = {
+                            trank: genus_trank,
+                            wiki: isWiki
+                        }
+                        getTraitDesc(des, t, opts);
                         desc.append(des);
                     }
                 });
@@ -8016,7 +8022,11 @@ export function ascendLab(hybrid,wiki){
         if (traits.hasOwnProperty(trait) && traits[trait].type === 'major'){
             popover(`celestialLabtraitSelection${trait}`, function(){
                 let desc = $(`<div></div>`);
-                getTraitDesc(desc, trait, { trank: 1 });
+                let opts = {
+                    trank: 1,
+                    wiki: isWiki
+                }
+                getTraitDesc(desc, trait, opts);
                 return desc;
             },{
                 elm: `#celestialLab .trait_selection .t${trait}`,

--- a/src/wiki/species.js
+++ b/src/wiki/species.js
@@ -79,6 +79,8 @@ Object.keys(evolutionPath).forEach(function (key) {
 export function racesPage(content){
     content = sideMenu('create',content);
 
+    let genus_trank_pri = (global.stats.achieve['pathfinder'] && global.stats.achieve.pathfinder.l >= 4) ? 2 : 1;
+    let genus_trank_sec = (global.stats.achieve['pathfinder'] && global.stats.achieve.pathfinder.l >= 4) ? 1 : 0.5;
     let list = [];
     Object.keys(races).forEach(function (race){
         if ((race === 'custom' && !global.custom.hasOwnProperty('race0')) 
@@ -110,17 +112,18 @@ export function racesPage(content){
         let extraTraits = extraTraitList(race);
 
         let genes = $(`<div class="itemlist"></div>`);
-
+        let firstType = true; // For hybrids, arbitrarily display one type as primary and the other as secondary
 
         (typeList.includes('carnivore') && typeList.includes('herbivore') ? ['omnivore'] : typeList).forEach(function (gType){
             Object.keys(genus_traits[gType]).sort().forEach(function (trait){
                 let id = `raceTrait${race}${trait}`;
                 let color = races[race].fanaticism === trait ? 'danger' : 'caution';
                 genes.append(`<span class="has-text-${color}" id="${id}">${traitSkin('name', trait, race)}<span>`);
-                traitList.push({ t: trait, r: 1});
+                traitList.push({ t: trait, r: firstType ? genus_trank_pri : genus_trank_sec});
             });
+            firstType = false;
         });
-        
+
         Object.keys(races[race].traits).sort().forEach(function (trait){
             if (hallowed.active && ((race === 'tortoisan' && trait === 'slow') || (race === 'unicorn' && trait === 'rainbow'))){
                 return;
@@ -150,6 +153,7 @@ export function racesPage(content){
             getTraitDesc(desc, traitList[i].t, {
                 fanatic: traitList[i].t === races[race].fanaticism ? races[race].name : false, 
                 trank: traitList[i].r,
+                rpage: true,
                 wiki: true,
                 species: race
             });

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -8107,7 +8107,7 @@
   "genelab_genus_eldritch": "Eldritch",
   "genelab_genus_eldritch_desc": "Eldritch creatures are nightmarish horrors that live in subterranean cities. They often raid the surface world for thralls and resources.",
   "genelab_genus_hybrid": "Hybrid",
-  "genelab_genus_hybrid_desc": "This species is a blend of two genus.",
+  "genelab_genus_hybrid_desc": "This species is a blend of two genera.",
   "genelab_genus_none": "None",
   "genelab_reset": "Clear Fields",
   "genelab_import": "Import Species",


### PR DESCRIPTION
Display descriptions for genus and major traits on the wiki version of the custom race lab, even if the relevant achievements to learn that information have not yet been earned.

Exclude custom (and hybrid) races from trait eligibility check. This will prevent new custom races from adopting Frail, which exists only on Valdi, Sludge, Ultra Sludge, and some fraction of existing custom races.

Display genus traits as rank 2 on the wiki if Path Finder is at least 4/5 completed. For hybrid races, the first listed genus is given at rank 2, and the second listed genus is given at rank 1. This may be misleading, since the player can choose which is the primary genus, but it seems a little better than always showing rank 1 values for both genera.