### PR TITLE
Enforce condition() for power grid display

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -6751,6 +6751,9 @@ export function checkRequirements(action_set,region,action){
             isMet = false;
         }
     });
+    if (isMet && action_set[region][action].hasOwnProperty('condition') && !action_set[region][action].condition()){
+        isMet = false;
+    }
     if (isMet && action_set[region][action].grant && (global.tech[action_set[region][action].grant[0]] && global.tech[action_set[region][action].grant[0]] >= action_set[region][action].grant[1])){
         isMet = false;
     }


### PR DESCRIPTION
This means that Casino (Space) won't appear for players who aren't in Cataclysm and haven't completed Iron Will.