### PR TITLE
Fix Out of Date Reset List in Wiki

### DIFF
--- a/src/wiki/resets.js
+++ b/src/wiki/resets.js
@@ -7,7 +7,7 @@ import { massCalc } from './mechanics.js';
 export function resetsPage(content){
     let mainContent = sideMenu('create',content);
 
-    let resets = ['mad','bioseed','blackhole','ascension','cataclysm','vacuum','infusion','ai','terraform'];
+    let resets = ['mad','bioseed','blackhole','vacuum','ascension','cataclysm','terraform','infusion','apotheosis','ai','matrix','retired','eden'];
     let reset_labels = resets.map(x => `<span class="has-text-caution">${loc(`wiki_resets_${x}`)}</span>`);
 
     infoBoxBuilder(mainContent,{ name: 'intro', template: 'resets', paragraphs: 3, h_level: 2,


### PR DESCRIPTION
Previously, the top of the wiki page covering resets stated that there were currently 9 reset options and listed 9 reset types. This information appears to be out of date; specifically, the count and list were missing the new T6 (Apotheosis) reset, as well as the 3 TP4 resets (Matrix, Retirement, and Garden of Eden). This change adds the 4 missing resets to the array defining this list. I have also rearranged the order of the array to match the sequence in which resets are covered lower down on the same page for consistantcy: "vacuum" was moved after "blackhole", "terraform" was moved before "infusion", and all of the True Path-specific resets were grouped at the end.