### PR TITLE
Fix crash that can prevent earning Resonance

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -2147,7 +2147,7 @@ const fortressModules = {
                             global.stats.warlord.p = true;
                             checkWarlordAchieve();
                         }
-                        else {
+                        else if (global.tech?.hell_gate >= 2){
                             towerSize(true);
                             fortressModules.prtl_gate.west_tower.post(); //unlock towers if both are complete now
                             fortressModules.prtl_gate.east_tower.post();


### PR DESCRIPTION
If the Gate Key technology has not yet been researched, then the west and east towers don't exist yet. In that circumstance, skip updating their sizes when a pillar is infused.

I hacked up a save to test the change and it worked.