### PR TITLE
Add missing cases for smelter label fix

### DIFF
--- a/src/industry.js
+++ b/src/industry.js
@@ -206,7 +206,7 @@ function loadSmelter(parent,bind){
     if (!global.race['forge']){
         if ((!global.race['kindling_kindred'] && !global.race['smoldering']) || global.race['evil']){
             let f_label = global.resource[fuel_config.l_type].name;
-            let wood = $(`<span :aria-label="buildLabel('wood') + ariaCount('Wood')" class="current wood">${f_label} {{ s.Wood }}</span>`);
+            let wood = $(`<span :aria-label="buildLabel('wood') + ariaCount('Wood', '${f_label}')" class="current wood">${f_label} {{ s.Wood }}</span>`);
             let subWood = $(`<span role="button" class="sub" @click="subFuel('Wood')" aria-label="Remove ${f_label} fuel"><span>&laquo;</span></span>`);
             let addWood = $(`<span role="button" class="add" @click="addFuel('Wood')" aria-label="Add ${f_label} fuel"><span>&raquo;</span></span>`);
             fuelTypes.append(subWood);
@@ -422,8 +422,8 @@ function loadSmelter(parent,bind){
             buildLabel(type){
                 return tooltip(type);
             },
-            ariaCount(fuel){
-                return ` ${global.city.smelter[fuel]} ${fuel} fueled.`;
+            ariaCount(fuel, name=fuel){
+                return ` ${global.city.smelter[fuel]} ${name} fueled.`;
             },
             ariaProd(res){
                 return `. ${global.city.smelter[res]} producing ${res}.`;


### PR DESCRIPTION
The change on the dev branch mirroring PR #1404 is slightly incomplete. This change affects only the aria-label, which I would suppose is read aloud by a screen reader.

Before: aria-label="Consume 1 Flesh/s to fuel a smelter. 10 Wood fueled."
After: aria-label="Consume 1 Flesh/s to fuel a smelter. 10 Flesh fueled."