### PR TITLE
Add missing struct() for interstellar s_gate

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -4403,6 +4403,12 @@ const interstellarProjects = {
             },
             action(){
                 return false;
+            },
+            struct(){
+                return {
+                    d: { count: 0, on: 0 },
+                    p: ['s_gate','interstellar']
+                };
             }
         },
     },


### PR DESCRIPTION
Fix another critical mistake introduced by #1384 