### PR TITLE
Add missing refreshes and optimize existing ones

### DIFF
--- a/src/portal.js
+++ b/src/portal.js
@@ -2,7 +2,7 @@ import { global, seededRandom, keyMultiplier, p_on, support_on, gal_on, spire_on
 import { vBind, clearElement, popover, clearPopper, timeFormat, powerCostMod, spaceCostMultiplier, messageQueue, powerModifier, calcPillar, deepClone, popCost, calcPrestige, get_qlevel, shrineBonusActive, getShrineBonus } from './functions.js';
 import { unlockAchieve, alevel, universeAffix } from './achieve.js';
 import { traits, races, fathomCheck, traitCostMod, orbitLength } from './races.js';
-import { spatialReasoning, unlockContainers } from './resources.js';
+import { spatialReasoning, unlockContainers, drawResourceTab } from './resources.js';
 import { loadFoundry, jobScale, limitCraftsmen } from './jobs.js';
 import { armyRating, govCivics, garrisonSize, mercCost, soldierDeath } from './civics.js';
 import { payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, updateDesc, actions, initStruct, storageMultipler, casinoEffect, structName, absorbRace, buildTemplate } from './actions.js';
@@ -2722,6 +2722,7 @@ const fortressModules = {
                         initStruct(fortressModules.prtl_spire.purifier);
                         initStruct(fortressModules.prtl_spire.port);
                         messageQueue(loc('portal_transport_unlocked'),'info',false,['progress','hell']);
+                        drawResourceTab('supply');
                         renderFortress();
                     }
                     return true;
@@ -2795,6 +2796,7 @@ const fortressModules = {
                     if (global.portal.oven.count >= 100){
                         global.tech['dish'] = 3;
                         initStruct(fortressModules.prtl_lake.oven_complete);
+                        incrementStruct('oven_complete','portal');
                         if (global.settings.alwaysPower){
                             powerOnNewStruct(fortressModules.prtl_lake.oven_complete);
                         }

--- a/src/races.js
+++ b/src/races.js
@@ -3,7 +3,7 @@ import { loc } from './locale.js';
 import { defineIndustry } from './industry.js';
 import { setJobName, jobScale, loadFoundry } from './jobs.js';
 import { vBind, clearElement, popover, removeFromQueue, removeFromRQueue, calc_mastery, gameLoop, getEaster, getHalloween, randomKey, modRes, messageQueue } from './functions.js';
-import { setResourceName, atomic_mass } from './resources.js';
+import { setResourceName, drawResourceTab, atomic_mass } from './resources.js';
 import { buildGarrison, govEffect, govTitle, armyRating, govCivics } from './civics.js';
 import { govActive, removeTask, defineGovernor } from './governor.js';
 import { unlockAchieve, unlockFeat, alevel } from './achieve.js';
@@ -6612,9 +6612,12 @@ export function cleanAddTrait(trait){
                     global.resource[res].trade = 0;
                 }
             });
-            global.settings.showMarket = false;
-            if (global.settings.marketTabs === 0) {
-                global.settings.marketTabs = 1;
+            global.city.market.active = false;
+            if (!global.galaxy?.freighter?.count){
+                global.settings.showMarket = false;
+                if (global.settings.marketTabs === 0) {
+                    global.settings.marketTabs = 1;
+                }
             }
             removeFromQueue(['city-trade']);
             removeFromRQueue(['trade']);
@@ -6880,9 +6883,13 @@ export function cleanRemoveTrait(trait,rank){
             delete power_generated[loc('city_wind_power')];
             break;
         case 'terrifying':
-            global.settings.showMarket = true;
             checkPurgatory('tech','trade');
             checkPurgatory('city','trade');
+            if (global.tech['trade']){
+                global.settings.showMarket = true;
+                global.city.market.active = true;
+                drawResourceTab('market');
+            }
             break;
         case 'slaver':
             removeFromQueue(['city-slave_pen']);

--- a/src/space.js
+++ b/src/space.js
@@ -7,7 +7,7 @@ import { loadFoundry, jobScale } from './jobs.js';
 import { defineIndustry, addSmelter } from './industry.js';
 import { garrisonSize, describeSoldier, checkControlling, govTitle } from './civics.js';
 import { actions, payCosts, powerOnNewStruct, initStruct, setAction, setPlanet, storageMultipler, drawTech, bank_vault, updateDesc, actionDesc, templeEffect, templeCount, casinoEffect, wardenLabel, buildTemplate, structName } from './actions.js';
-import { outerTruthTech, syndicate } from './truepath.js';
+import { outerTruthTech, syndicate, drawShipYard } from './truepath.js';
 import { production, highPopAdjust } from './prod.js';
 import { defineGovernor, govActive } from './governor.js';
 import { ascend, terraform, apotheosis } from './resets.js';
@@ -2583,6 +2583,7 @@ const spaceProjects = {
                     global.tech['syard_engine'] = 2;
                     global.tech['syard_power'] = 3;
                     global.tech['syard_sensor'] = 3;
+                    drawShipYard();
                     return true;
                 }
                 return false;
@@ -2633,6 +2634,7 @@ const spaceProjects = {
                     if (global.space.mass_relay.count >= 100){
                         global.tech['outer'] = 6;
                         initStruct(spaceProjects.spc_dwarf.m_relay);
+                        incrementStruct('m_relay','space');
                         powerOnNewStruct(spaceProjects.spc_dwarf.m_relay);
                         drawTech();
                         renderSpace();
@@ -5565,6 +5567,7 @@ const galaxyProjects = {
                         global.tech['xeno'] = 5;
                         initStruct(galaxyProjects.gxy_gorddon.freighter);
                         global.galaxy['trade'] = { max: 0, cur: 0, f0: 0, f1: 0, f2: 0, f3: 0, f4: 0, f5: 0, f6: 0, f7: 0, f8: 0 };
+                        drawResourceTab('market');
                         messageQueue(loc('galaxy_embassy_complete',[races[global.galaxy.alien1.id].name,races[global.galaxy.alien2.id].name]),'info',false,['progress']);
                     }
                     if (global.race['fasting']){

--- a/src/tech.js
+++ b/src/tech.js
@@ -5,11 +5,11 @@ import { unlockAchieve, alevel, universeAffix, unlockFeat } from './achieve.js';
 import { payCosts, housingLabel, wardenLabel, structName, updateQueueNames, drawTech, fanaticism, checkAffordable, actions, initStruct } from './actions.js';
 import { races, checkAltPurgatory, renderPsychicPowers, renderSupernatural, traitCostMod } from './races.js';
 import { drawResourceTab, resource_values, atomic_mass } from './resources.js';
-import { loadFoundry, jobScale, jobName } from './jobs.js';
+import { loadFoundry, jobScale, jobName, limitCraftsmen } from './jobs.js';
 import { buildGarrison, checkControlling, govTitle } from './civics.js';
 import { renderSpace, planetName, int_fuel_adjust } from './space.js';
 import { drawHellObservations } from './portal.js';
-import { setOrbits, jumpGateShutdown } from './truepath.js';
+import { setOrbits, drawShipYard, jumpGateShutdown } from './truepath.js';
 import { arpa } from './arpa.js';
 import { setPowerGrid, defineIndustry, addSmelter } from './industry.js';
 import { defineGovernor, removeTask } from './governor.js';
@@ -129,6 +129,11 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            if (global.race['banana'] && !global.race['terrifying']){
+                drawResourceTab('market');
+            }
         }
     },
     wheel: {
@@ -2195,6 +2200,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineIndustry();
         }
     },
     rotary_kiln: {
@@ -3320,6 +3328,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            drawResourceTab('market');
         }
     },
     tax_rates: {
@@ -3432,6 +3443,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            drawResourceTab('market');
         }
     },
     diplomacy: {
@@ -4823,6 +4837,7 @@ const techs = {
             return false;
         },
         post(){
+            defineIndustry();
             defineGovernor();
         }
     },
@@ -11444,6 +11459,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            drawResourceTab('alchemy');
         }
     },
     secret_society: {
@@ -12099,6 +12117,7 @@ const techs = {
         action(){
             if (payCosts($(this)[0])){
                 global.resource.Quantium.display = true;
+                limitCraftsmen('Quantium');
                 return true;
             }
             return false;
@@ -12585,6 +12604,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineIndustry();
         }
     },
     adamantite_crates: {
@@ -13159,6 +13181,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            drawShipYard();
         }
     },
     alien_outpost: {
@@ -13640,6 +13665,9 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineIndustry();
         }
     },
     space_whaling: {
@@ -14289,6 +14317,10 @@ const techs = {
                 return true;
             }
             return false;
+        },
+        post(){
+            defineIndustry();
+            defineGovernor();
         }
     },
     womling_unlock: {

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -214,6 +214,9 @@ const outerTruth = {
                         global.civic[global.civic.d_job].workers -= hired;
                         global.civic.titan_colonist.workers += hired;
                     }
+                    if (global.space.titan_quarters.count === 1){
+                        renderSpace();
+                    }
                     return true;
                 }
                 return false;
@@ -260,8 +263,11 @@ const outerTruth = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('titan_mine');
-                    global.resource.Adamantite.display = true;
                     powerOnNewStruct($(this)[0]);
+                    if (global.space.titan_mine.count === 1){
+                        global.resource.Adamantite.display = true;
+                        defineIndustry();
+                    }
                     return true;
                 }
                 return false;
@@ -583,6 +589,7 @@ const outerTruth = {
                         if (global.space.ai_core.count >= 100){
                             global.tech['titan_ai_core'] = 1;
                             initStruct(outerTruth.spc_titan.ai_core2);
+                            incrementStruct('ai_core2','space');
                             powerOnNewStruct(outerTruth.spc_titan.ai_core2);
                             renderSpace();
                             drawTech();
@@ -822,6 +829,9 @@ const outerTruth = {
                 if (payCosts($(this)[0])){
                     incrementStruct('zero_g_lab');
                     powerOnNewStruct($(this)[0]);
+                    if (global.space.zero_g_lab.count === 1 && global.tech['quantium']){
+                        loadFoundry();
+                    }
                     return true;
                 }
                 return false;
@@ -831,9 +841,6 @@ const outerTruth = {
                     d: { count: 0, on: 0 },
                     p: ['zero_g_lab','space']
                 };
-            },
-            post(){
-                loadFoundry();
             },
             postPower(on){
                 limitCraftsmen('Quantium');
@@ -1555,6 +1562,7 @@ const tauCetiModules = {
                                 global.tech.matrix = 3;
                                 global.tauceti['matrix'] = { count: 1, on: 0 };
                             }
+                            drawTech();
                             renderTauCeti();
                             clearPopper();
                         }
@@ -2471,11 +2479,15 @@ const tauCetiModules = {
                     incrementStruct('tau_factory','tauceti');
                     if (powerOnNewStruct($(this)[0])){
                         global.city.factory.Alloy += $(this)[0].manufacturing();
-                        defineIndustry();
                     }
                     return true;
                 }
                 return false;
+            },
+            post(){
+                if (global.race['lone_survivor']){
+                    defineIndustry();
+                }
             },
             struct(){
                 return {
@@ -3290,7 +3302,17 @@ const tauCetiModules = {
             action(){
                 if (payCosts($(this)[0])){
                     incrementStruct('refueling_station','tauceti');
-                    powerOnNewStruct($(this)[0]);
+                    if (powerOnNewStruct($(this)[0])) {
+                        if (global.tech['isolation']){
+                            // Graphene allocation is stored on the Titan graphene factory even after isolation
+                            if (global.race['kindling_kindred'] || global.race['smoldering']){
+                                global.space.g_factory.Oil++;
+                            }
+                            else {
+                                global.space.g_factory.Lumber++;
+                            }
+                        }
+                    }
                     return true;
                 }
                 return false;
@@ -3304,6 +3326,7 @@ const tauCetiModules = {
             post(){
                 if (global.tech.tau_gas === 2){
                     global.tech.tau_gas = 3;
+                    defineIndustry();
                     drawTech();
                 }
             }
@@ -3555,6 +3578,9 @@ const tauCetiModules = {
                 if (payCosts($(this)[0])){
                     incrementStruct('mining_ship','tauceti');
                     powerOnNewStruct($(this)[0]);
+                    if (global.tauceti.mining_ship.count === 1){
+                        defineIndustry();
+                    }
                     return true;
                 }
                 return false;
@@ -3697,6 +3723,7 @@ const tauCetiModules = {
                         if (global.tauceti.alien_station.count >= 100){
                             global.tech.tau_gas2 = 5;
                             global.tauceti['alien_space_station'] = { count: 1, on: 0 };
+                            drawTech();
                         }
                         return true;
                     }
@@ -3710,10 +3737,12 @@ const tauCetiModules = {
                 };
             },
             post(){
-                if (global.resource.Elerium.diff >= 10){
-                    global.tauceti.alien_space_station.on = 1; 
+                if (global.tauceti.hasOwnProperty('alien_space_station')){
+                    if (global.resource.Elerium.diff >= 10){
+                        global.tauceti.alien_space_station.on = 1;
+                    }
+                    renderTauCeti();
                 }
-                renderTauCeti();
             }
         },
         alien_space_station: {
@@ -3837,6 +3866,7 @@ const tauCetiModules = {
                         incrementStruct('ignition_device','tauceti');
                         if (global.tauceti.ignition_device.count >= 10){
                             global.tech['m_ignite'] = 1;
+                            renderTauCeti();
                         }
                         return true;
                     }
@@ -5771,7 +5801,6 @@ export function loneSurvivor(){
         global.settings.showPowerGrid = true;
         global.settings.showResearch = true;
         global.settings.showCivic = true;
-        global.settings.showMil = true;
         global.settings.showResources = true;
         global.settings.showMarket = true;
         global.settings.showStorage = true;
@@ -5781,7 +5810,6 @@ export function loneSurvivor(){
         global.settings.arpa.physics = true;
         global.settings.arpa.genetics = true
 
-        //global.civic.garrison.display = true;
         global.resource[global.race.species].display = true;
         global.resource.Knowledge.display = true;
         global.resource.Money.display = true;
@@ -5976,7 +6004,7 @@ export function loneSurvivor(){
 
         initStruct(actions.city.factory);
         initStruct(actions.city.foundry);
-        initStruct(actions.city.smelter); addSmelter(1, 'Iron'); addSmelter(1, 'Steel');
+        initStruct(actions.city.smelter);
 
         initStruct(actions.city.amphitheatre);
         initStruct(actions.city.apartment);
@@ -6091,17 +6119,6 @@ export function loneSurvivor(){
         global.space['ai_core'] = { count: 100 };
         global.space['ai_core2'] = { count: 0, on: 0 };
         global.space['m_relay'] = { count: 0, on: 0 };
-        
-        global.civic['garrison'] = {
-            display: true,
-            disabled: false,
-            progress: 0,
-            tactic: 0,
-            workers: 2,
-            wounded: 0,
-            raid: 0,
-            max: 2
-        };
 
         global.arpa['sequence'] = {
             max: 50000,


### PR DESCRIPTION
Don't break completion of the mass relay, devilish dish, or AI supercore (fixes for issues introduced in #1384 ...again)

Add some sanity checks to avoid console errors in post() for Tau Ceti's alien_station struct: it may not be built all at once

To test most aspects of this change properly, enable Preload Tab Content. I tested all of the line items below to confirm that (1) the relevant content does not already load properly and (2) the patch is effective.

The following adjustments are made to synth starts:
- The industry tab isn't displayed for races without Deconstructor
- The military tab isn't displayed until a barracks is built
- The crafter UI draw, `loadFoundry()`, isn't uselessly called
- The government panel is redrawn
- The market and storage tabs are redrawn

The following adjustments are made to Lone Survivor starts:
- The military tab isn't displayed
- Some redundant initializations (such as 2 soldiers) are removed

The following cases will now call `defineIndustry()`:
- Building a rock quarry for the first time when chrysotile is available
- Building the first mine on Titan (true path)
- Researching Iridium Smelting (either version)
- Researching the Matter Replicator (either version)
- Building the first Tau Ceti extractor ship
- Researching Advanced Belt Mining
- Building the first High-Tech Factory in Lone Survivor (for an unhandled edge case: when there is no power available AND auto-power is disabled) -- also moved the call to `post()` to show 5/5, not 5/0, assembly lines on default Alloys
- Building the first Refueling Station in Lone Survivor, which will additionally select a default fuel after powering on

The following buildings will call `defineIndustry()` only the first time:
- Smelter
- Factory
- Nanite Factory (in other words, it will never call the function)

The following cases will now call `loadFoundry()`:
- Researching Quantium, via new call to limitCraftsmen('Quantium')
- When calling limitCraftsmen() for the first time on a resource after loading the page, the refresh flag should be true, not false
- limitCraftsmen() itself is now called on page load to avoid displaying 0 maximum assignable quantium / scarletite crafters for 1 second

The following buildings will now call `loadFoundry()` only one time:
- Zero-G Lab (and moved the call from `post()` to `action()` to permit this to work safely)

The following cases will now call `renderSpace()`:
- Building the first habitat on Titan (true path)

The following cases will now redraw the shipyard:
- Building the ship yard
- Researching the Interstellar Drive

The following cases will now redraw Tau Ceti:
- Building the final part of the Ignition Device

The following cases will now redraw the research tab:
- Completing the Alien Space Station repairs
- Completing the Ringworld

The following cases will now redraw the resources market tab:
- Researching Marketplace
- Researching Trade Routes
- Building the Sundial in Banana Republic
- Mutating in the Terrifying trait will not delete the market tab if galactic trade is available
- Building the Embassy

The following cases will now redraw the resources supply tab:
- Building the first lake transport

The following cases will now redraw the alchemy tab:
- Researching Advanced Transmutation