### PR TITLE
Make pause button easier to click

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -915,7 +915,9 @@ export function index(){
                 <b-tooltip :label="weather()" :aria-label="weather()" position="is-bottom" size="is-small" multilined animated><i id="weather" class="weather wi"></i></b-tooltip>
                 <b-tooltip :label="temp()" :aria-label="temp()" position="is-bottom" size="is-small" multilined animated><i id="temp" class="temp wi"></i></b-tooltip>
                 <b-tooltip :label="atRemain()" v-show="s.at" :aria-label="atRemain()" position="is-bottom" size="is-small" multilined animated><span class="atime has-text-caution">{{ s.at | remain }}</span></b-tooltip>
-                <span id="pausegame" class="atime" role="button" @click="pause" :aria-label="pausedesc()"></span>
+                <span role="button" class="atime" style="padding: 0 0.5rem; margin-left: 0.5rem; cursor: pointer" @click="pause" :aria-label="pausedesc()">
+                    <span id="pausegame"></span>
+                </span>
             </span>
         </span>
         <span class="version" id="versionLog"><a href="wiki.html#changelog" target="_blank"></a></span>


### PR DESCRIPTION
I couldn't find a way to enlarge the original `span` without stretching the icon, so I just wrapped it in a larger `span` and moved event handlers there. Stuff like `$("#pausegame").click()` still works.
Before and after (the orange part is the margin - the actual "hitbox" is green):
![image](https://github.com/user-attachments/assets/59189f80-b624-47c0-b43e-cca4364741ed)
![image](https://github.com/user-attachments/assets/c553519a-74af-4ef0-aa58-b813a74f89db)
