### PR TITLE
Unset buefy's tab border color

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1127,6 +1127,10 @@ Misc ---------> Main template
             color: @link-hover;
         }
 
+        .tabs > ul {
+            border-bottom: solid .0625rem;
+        }
+
         // .button
         .button {
             background-color: @button-background;


### PR DESCRIPTION
The css from buefy sets the `border-bottom-color` style, which is different from those used by the game's themes. Before and after (it's hard to see but the color of the mainTabs' border was inconsistent with the one above the building queue):
![image](https://github.com/user-attachments/assets/ce1d12b3-33f1-4dc9-953b-fcf8e7882866)
![image](https://github.com/user-attachments/assets/366b5cb9-4fc5-4869-b1b9-56e205088765)
