### PR TITLE
Guarantee timing and ratio of main game loops

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 evolve/* -diff
+evolve/evolve.js diff
 wiki/* -diff

--- a/evolve/evolve.js
+++ b/evolve/evolve.js
@@ -1,26 +1,56 @@
-var intervals = {};
+const loopN = 80;   // Store 80 samples of jitter history (10-20 seconds)
+var loopInterval;   // Target fastLoop interval with millisecond precision
+var loopHist;       // Sliding window of recent timer skew history
+var loopIdx = 0;    // Next index in loopHist[]
+var loopSkew;       // Sum of all entries in loopHist[]
+var loopTargTs;     // Target time for next timer to fire
+var timerId;        // For clearing the timer
+
 self.addEventListener('message', function(e){
-    var data = e.data;
+    const data = e.data;
     switch (data.loop) {
-        case 'short':
-            intervals['main_loop'] = setInterval(function(){
-                self.postMessage('fast');
-            }, data.period);
-            break;
-        case 'mid':
-            intervals['mid_loop'] = setInterval(function(){
-                self.postMessage('mid');
-            }, data.period);
-            break;
-        case 'long':
-            intervals['long_loop'] = setInterval(function(){
-                self.postMessage('long');
-            }, data.period);
+        case 'start':
+            loopInterval = data.period;
+            loopHist = new Array(loopN).fill(0);
+            loopSkew = 0;
+            loopTargTs = performance.now() + loopInterval;
+            timerId = setTimeout(lowDriftTimer, loopInterval);
             break;
         case 'clear':
-            clearInterval(intervals['main_loop']);
-            clearInterval(intervals['mid_loop']);
-            clearInterval(intervals['long_loop']);
+            clearTimeout(timerId);
             break;
     };
   }, false);
+
+function lowDriftTimer(){
+    const ts = performance.now();
+    const jitter = ts - loopTargTs;
+    let periods = 1;
+
+    if (jitter > loopInterval){
+        // High error mode: run multiple fastLoop calls at once
+        periods += Math.floor(jitter / loopInterval);
+
+        // Slowly discard skew history in case it's related to the cause of high skew
+        loopSkew -= loopHist[loopIdx];
+        loopHist[loopIdx] = 0;
+
+        // Create new baseline timestamp due to high drift
+        loopTargTs = ts + loopInterval;
+    }
+    else {
+        // Accumulate skew history normally
+        loopSkew += jitter - loopHist[loopIdx];
+        loopHist[loopIdx] = jitter;
+
+        // Use existing baseline timestamp
+        loopTargTs += loopInterval;
+    }
+
+    // Cancel out recent skew to center jitter near zero
+    const timeout = (loopTargTs - ts) - (loopSkew / loopN);
+    timerId = setTimeout(lowDriftTimer, timeout);
+    self.postMessage({ loop: 'main', periods: periods });
+
+    if (++loopIdx === loopN){ loopIdx = 0; }
+}

--- a/src/functions.js
+++ b/src/functions.js
@@ -151,7 +151,7 @@ export function loopTimers(){
     }
 
     // Main loop takes 250ms without any modifiers.
-    const webWorkerMainTimer = Math.floor(webWorker.mt * modifier);
+    const webWorkerMainTimer = Math.floor(250 * modifier);
     // Mid loop takes 1000ms without any modifiers.
     const baseMidTimer = webWorker.midRatio * webWorkerMainTimer;
     // Long loop (game day) takes 5000ms without any modifiers.
@@ -163,6 +163,7 @@ export function loopTimers(){
     return {
         webWorkerMainTimer,
         mainTimer: Math.ceil(webWorkerMainTimer * aTimeMultiplier),
+        longTimer: Math.ceil(baseLongTimer * aTimeMultiplier),
         baseLongTimer,
         timeAccelerationFactor,
     };

--- a/src/functions.js
+++ b/src/functions.js
@@ -114,11 +114,6 @@ export function gameLoop(act){
                 if (webWorker.w){
                     webWorker.w.postMessage({ loop: 'clear' });
                 }
-                else {
-                    clearInterval(intervals['main_loop']);
-                    clearInterval(intervals['mid_loop']);
-                    clearInterval(intervals['long_loop']);
-                }
                 if (global.settings.at > 0){
                     global.settings.at = atrack.t;
                 }
@@ -135,22 +130,8 @@ export function gameLoop(act){
                 webWorker.mt = timers.webWorkerMainTimer;
 
                 if (webWorker.w){
-                    webWorker.w.postMessage({ loop: 'short', period: timers.mainTimer });
-                    webWorker.w.postMessage({ loop: 'mid', period: timers.midTimer });
-                    webWorker.w.postMessage({ loop: 'long', period: timers.longTimer });
+                    webWorker.w.postMessage({ loop: 'start', period: timers.mainTimer });
                 }
-                else {
-                    intervals['main_loop'] = setInterval(function(){
-                        fastLoop();
-                    }, timers.mainTimer);
-                    intervals['mid_loop'] = setInterval(function(){
-                        midLoop();
-                    }, timers.midTimer);
-                    intervals['long_loop'] = setInterval(function(){
-                        longLoop();
-                    }, timers.longTimer);
-                }
-
                 webWorker.s = true;
             }
     }
@@ -170,11 +151,11 @@ export function loopTimers(){
     }
 
     // Main loop takes 250ms without any modifiers.
-    const webWorkerMainTimer = Math.floor(250 * modifier);
+    const webWorkerMainTimer = Math.floor(webWorker.mt * modifier);
     // Mid loop takes 1000ms without any modifiers.
-    const baseMidTimer = 4 * webWorkerMainTimer;
+    const baseMidTimer = webWorker.midRatio * webWorkerMainTimer;
     // Long loop (game day) takes 5000ms without any modifiers.
-    const baseLongTimer = 20 * webWorkerMainTimer;
+    const baseLongTimer = webWorker.longRatio * webWorkerMainTimer;
     // The constant by which the time is accelerated when atrack.t > 0.
     const timeAccelerationFactor = 2;
 
@@ -182,8 +163,6 @@ export function loopTimers(){
     return {
         webWorkerMainTimer,
         mainTimer: Math.ceil(webWorkerMainTimer * aTimeMultiplier),
-        midTimer: Math.ceil(baseMidTimer * aTimeMultiplier),
-        longTimer: Math.ceil(baseLongTimer * aTimeMultiplier),
         baseLongTimer,
         timeAccelerationFactor,
     };

--- a/src/vars.js
+++ b/src/vars.js
@@ -2257,7 +2257,7 @@ window.soft_reset = function reset(source){
     window.location.reload();
 }
 
-export var webWorker = { w: false, s: false, mt: 250 };
+export var webWorker = { w: false, s: false, mt: 250, midRatio: 4, longRatio: 20 };
 export var intervals = {};
 
 export function clearSavedMessages(){


### PR DESCRIPTION
Presently, the fast, mid, and long game loops are controlled by separate timers that can fall out of synchronization with each other. Furthermore, the time taken by setInterval is not a guarantee, so the game loop may run a little bit more slowly than intended.

On my home computer, I experience an average of roughly 18.29 `fastLoop()` calls and 4.91 `midLoop()` iterations per 1 `longLoop()`.

This patch makes the following improvements:
- The execution count ratio is always 20 `fastLoop()` to 5 `midLoop()` to 1 `longLoop()`.
- The sequence of loop execution is always to do the faster loops before the slower loops.
- The time elapsed in between each game tick will be more stable.
- The number of game ticks per real time interval will be guaranteed.
- The game will fast-execute several loop iterations (up to 12 game days) if the timer event was greatly throttled by the browser.

The fallback code for "no web worker available" has been broken for a very long time on account of missing import statements. I removed it.