### PR TITLE
Force Screen Readers to interpret Building and Research  Links Properly

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6042,7 +6042,7 @@ export function setAction(c_action,action,type,old,prediction){
         }
         if (prediction){ clss = ' precog'; }
         let active = c_action['highlight'] ? (c_action.highlight() ? `<span class="is-sr-only">${loc('active')}</span>` : `<span class="is-sr-only">${loc('not_active')}</span>`) : '';
-        element = $(`<a class="button is-dark${cst}${clss}"${data} v-on:click="action"><span class="aTitle" v-html="$options.filters.title(title)"></span>${active}</a><a role="button" v-on:click="describe" class="is-sr-only">{{ title }} description</a>`);
+        element = $(`<a class="button is-dark${cst}${clss}"${data} v-on:click="action" role="link"><span class="aTitle" v-html="$options.filters.title(title)"></span>${active}</a><a role="button" v-on:click="describe" class="is-sr-only">{{ title }} description</a>`);
     }
     parent.append(element);
 


### PR DESCRIPTION
In some browsers, screen readers do not automatically interpret <a> elements as links if they lack an href attribute. This issue removed the possibility of quickly moving between the links in the structure and research lists and also sometimes confused the screen reader, such that a different structure would be clicked than the one that was supposed to be in focus. This simple change just adds role="link" to all such links, which forces screen readers to interpret them as such. I played with this change applied on my last run and no longer experience the issues mentioned above.