### PR TITLE
Fix numerical values of Weak Genes on wiki

### DIFF
--- a/src/wiki/challenges.js
+++ b/src/wiki/challenges.js
@@ -128,13 +128,13 @@ export function challengesPage(content){
         }
 
         {   // Weak Genes
-            let weak_vals = global.race.universe === 'antimatter' ? [`20%`,`50%`,`50%`,`33%`] : [`50%`,`20%`,`50%`,`33%`];
+            let weak_vals = global.race.universe === 'antimatter' ? [`20%`,`50%`,`25%`,`12.5%`,`16.7%`] : [`50%`,`20%`,`10%`,`50%`,`33.3%`];
             infoBoxBuilder(genes,{ name: 'genes_weak', template: 'challenges', paragraphs: 5, break: [2,3,4,5], h_level: 2,
                 para_data: {
                     1: [weak_vals[0]],
                     2: [weak_vals[1]],
-                    3: [weak_vals[2]],
-                    4: [weak_vals[3]],
+                    3: [weak_vals[2], weak_vals[3]],
+                    4: [weak_vals[4]],
                     5: [loc(`wiki_challenges_gene`),loc(`evo_challenge_truepath`)]
                 },
                 data_link: {

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -10229,7 +10229,7 @@
   "wiki_challenges_genes_weak": "Weak Genes",
   "wiki_challenges_genes_weak_para1": "Mastery is reduced to %0.",
   "wiki_challenges_genes_weak_para2": "Plasmid and Anti-Plasmid production bonus reduced to %0.",
-  "wiki_challenges_genes_weak_para3": "Plasmid and Anti-Plasmid storage bonus reduced to %0.",
+  "wiki_challenges_genes_weak_para3": "Plasmid storage bonus reduced to %0 and Anti-Plasmid storage bonus reduced to %1.",
   "wiki_challenges_genes_weak_para4": "Phage storage bonus reduced to %0.",
   "wiki_challenges_genes_weak_para5": "This %0 is only available in the %1 Scenario.",
   "wiki_challenges_modes_intro": "Challenge Modes",


### PR DESCRIPTION
This commit sets the displayed storage nerf values for Weak Genes (true path only challenge) to the values used by the game itself.

The values for plasmids and anti-plasmids may seem strange at first glance, but they follow a pattern where the bleed effect is effectively one-half of the non-bleed effect.

I was surprised to discover that phage storage is reduced by an additional factor of 2 in the antimatter universe: 1/3rd active in normal universes and 1/6th active in antimatter.