### PR TITLE
Don't break the power grid in Warlord

### DIFF
--- a/src/industry.js
+++ b/src/industry.js
@@ -1644,11 +1644,11 @@ export function gridEnabled(c_action,region,p0,p1){
                 isOk = true;
             }
             else {
-                isOk = global.race['cataclysm'] || global.race['orbit_decayed'] || global.tech['isolation'] ? false : checkCityRequirements(p1);
+                isOk = global.race['cataclysm'] || global.race['orbit_decayed'] || global.tech['isolation'] || global.race['warlord'] ? false : checkCityRequirements(p1);
             }
             break;
         case 'space':
-            isOk = global.tech['isolation'] ? false : checkSpaceRequirements(region,p0,p1);
+            isOk = global.tech['isolation'] || global.race['warlord'] ? false : checkSpaceRequirements(region,p0,p1);
             break;
         case 'portal':
             isOk = checkRequirements(fortressTech(),p0,p1);
@@ -1712,10 +1712,6 @@ export function setPowerGrid(){
             let space = convertSpaceSector(parts[0]);
             let region = parts[0] === 'city' ? parts[0] : space;
             let c_action = parts[0] === 'city' ? actions.city[parts[1]] : actions[space][parts[0]][parts[1]];
-
-            if (!global[region][parts[1]]){
-                continue;
-            }
 
             let title = typeof c_action.title === 'function' ? c_action.title() : c_action.title;
             let extra = ``;

--- a/src/space.js
+++ b/src/space.js
@@ -6763,6 +6763,13 @@ export function checkRequirements(action_set,region,action){
     if (isMet && action_set[region][action].hasOwnProperty('condition') && !action_set[region][action].condition()){
         isMet = false;
     }
+    if (isMet && action_set[region][action].hasOwnProperty('not_trait')){
+        for (let trait of action_set[region][action].not_trait){
+            if (global.race[trait]){
+                isMet = false;
+            }
+        }
+    }
     if (isMet && action_set[region][action].grant && (global.tech[action_set[region][action].grant[0]] && global.tech[action_set[region][action].grant[0]] >= action_set[region][action].grant[1])){
         isMet = false;
     }


### PR DESCRIPTION
The change in 45965b1b80d42fbcfbc815f7af7a89b0165c0933 eliminated an exception that interrupted power grid rendering, but it broke the sorting functionality. This change prevents the exception without breaking the ability to sort the power grid.

Also, it hides display of structs that are blocked by `not_trait: []` in a similar manner to the `condition()` check added in #1403.