### PR TITLE
Warlord stuff

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8233,6 +8233,7 @@ function midLoop(){
 
         if (global.race.universe === 'evil' && global.tech['primitive'] && global.tech.primitive >= 3){
             global.resource.Authority.display = true;
+            let garrison = garrisonSize() || 0;
 
             if (global.civic.govern.type === 'autocracy'){
                 let gain = 10;
@@ -8317,7 +8318,6 @@ function midLoop(){
                 if (global.tech['evil']){
                     adjust += 0.1 * global.tech.evil;
                 }
-                let garrison = garrisonSize() || 0;
                 if (global.portal['fortress']){
                     garrison += global.portal.fortress.garrison - (global.portal.fortress.patrols * global.portal.fortress.patrol_size);
                 }

--- a/src/main.js
+++ b/src/main.js
@@ -3164,7 +3164,7 @@ function fastLoop(){
                 if (global.city['wonder_lighthouse']){ monuments += 5; }
                 if (global.city['wonder_pyramid']){ monuments += 5; }
                 if (global.space['wonder_statue']){ monuments += 5; }
-                if (global.interstellar['wonder_gardens'] || global.space['wonder_gardens']){ monuments += 5; }
+                if (global.interstellar['wonder_gardens'] || global.space['wonder_gardens'] || global.portal['wonder_gardens']){ monuments += 5; }
             }
             moraleCap += monuments * mcap;
         }

--- a/src/portal.js
+++ b/src/portal.js
@@ -8554,7 +8554,6 @@ export function warlordSetup(){
         global.tech['kuiper'] = 2;
         global.tech['launch_facility'] = 1;
         global.tech['luna'] = 2;
-        global.tech['m_smelting'] = 2;
         global.tech['marines'] = 2;
         global.tech['mars'] = 5;
         global.tech['mass'] = 1;

--- a/src/races.js
+++ b/src/races.js
@@ -8410,13 +8410,19 @@ function majorWish(parent){
                                     wonders.push('statue');
                                 }
                                 if (global.race['warlord']){
-                                    wonders.push('gardens');
+                                    if (!global.portal.hasOwnProperty('wonder_gardens')){
+                                        wonders.push('gardens');
+                                    }
                                 }
-                                else if (!global.race['truepath'] && !global.interstellar.hasOwnProperty('wonder_gardens') && global.tech['alpha'] && global.tech.alpha >= 2){
-                                    wonders.push('gardens');
+                                else if (global.race['truepath']){
+                                    if (!global.space.hasOwnProperty('wonder_gardens') && global.tech['titan'] && global.tech.titan >= 2){
+                                        wonders.push('gardens');
+                                    }
                                 }
-                                else if (global.race['truepath'] && !global.space.hasOwnProperty('wonder_gardens') && global.tech['titan'] && global.tech.titan >= 2){
-                                    wonders.push('gardens');
+                                else {
+                                    if (!global.interstellar.hasOwnProperty('wonder_gardens') && global.tech['alpha'] && global.tech.alpha >= 2){
+                                        wonders.push('gardens');
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
Fixes for things in the Warlord scenario. Will add as they show up.

1. Remove truepath Mercury Smelting technology series from Warlord scenario initialization, so that iridium smelting requires researching the false path version of the technology
2. Avoid calling `garrisonSize()` in the middle of Authority value computation, since the number of soldiers manning the Soul Forge depends on this value. Instead, call it before making any adjustments.
3. The Pillar of Skulls should count as 5 monuments for morale cap, not only for income adjustment.
4. The Pillar of Skulls should not be an eligible reward for Wish if it has already been received.