### PR TITLE
Fix smelter fuel removal bugs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4845,7 +4845,7 @@ function fastLoop(){
             if (global.race['forge']){
                 global.city.smelter.Wood = 0;
                 global.city.smelter.Coal = 0;
-                global.city.smelter.Oil = global.city.smelter.cap - global.city.smelter.Star - global.city.smelter.Inferno;
+                global.city.smelter.Oil = Math.max(0, global.city.smelter.cap - global.city.smelter.Star - global.city.smelter.Inferno);
             }
 
             if ((global.race['kindling_kindred'] || global.race['smoldering']) && !global.race['evil']){

--- a/src/main.js
+++ b/src/main.js
@@ -4849,7 +4849,10 @@ function fastLoop(){
             }
 
             if ((global.race['kindling_kindred'] || global.race['smoldering']) && !global.race['evil']){
-                global.city.smelter.Wood = 0;
+                if (global.city.smelter.Wood !== 0){
+                    global.city.smelter.Coal += global.city.smelter.Wood;
+                    global.city.smelter.Wood = 0;
+                }
             }
 
             let total_fuel = 0;

--- a/src/main.js
+++ b/src/main.js
@@ -4871,6 +4871,9 @@ function fastLoop(){
                         overflow = global.city.smelter.Iridium;
                         global.city.smelter.Iridium = 0;
                     }
+                    else {
+                        overflow = 0;
+                    }
                     global.city.smelter.Steel += overflow;
                     if (global.city.smelter.Steel < 0){
                         global.city.smelter.Steel = 0;


### PR DESCRIPTION
Prevent the number of "Forge" smelters from becoming negative when (1) smelters are powered off and (2) inferno fuel is in use.

When adjusting smelter products for the loss of fuel, do not excessively remove steel smelters if iron and iridium smelters alone can satisfy the demand.

When forcing wood smelters to 0 after gaining either Smoldering or Kindling Kindred, reassign them to coal. This can be done even when coal hasn't yet been unlocked, because the effect is the same as the case where there was no lumber in the first place.