### PR TITLE
Improve behavior of post and postPower

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,4 @@
-import { global, save, seededRandom, webWorker, keyMultiplier, keyMap, srSpeak, sizeApproximation, p_on, support_on, int_on, gal_on, spire_on, tmp_vars, setupStats } from './vars.js';
+import { global, save, seededRandom, webWorker, keyMultiplier, keyMap, srSpeak, sizeApproximation, p_on, support_on, int_on, gal_on, spire_on, tmp_vars, setupStats, callback_queue } from './vars.js';
 import { loc } from './locale.js';
 import { timeCheck, timeFormat, vBind, popover, clearPopper, flib, tagEvent, clearElement, costMultiplier, darkEffect, genCivName, powerModifier, powerCostMod, calcPrestige, adjustCosts, modRes, messageQueue, buildQueue, format_emblem, shrineBonusActive, calc_mastery, calcPillar, calcGenomeScore, getShrineBonus, eventActive, easterEgg, getHalloween, trickOrTreat, deepClone, hoovedRename, get_qlevel } from './functions.js';
 import { unlockAchieve, challengeIcon, alevel, universeAffix, checkAdept } from './achieve.js';
@@ -5968,6 +5968,7 @@ export function gainTech(action){
     renderEdenic();
 }
 
+export var cLabels = global.settings['cLabels'];
 export function drawCity(){
     if (!global.settings.tabLoad && (global.settings.civTabs !== 1 || global.settings.spaceTabs !== 0)){
         return;
@@ -6031,6 +6032,8 @@ export function drawCity(){
             });
         }
     });
+
+    cLabels = global.settings['cLabels'];
 }
 
 export function drawTech(){
@@ -6346,9 +6349,7 @@ export function setAction(c_action,action,type,old,prediction){
                     }
                 }
                 if (c_action['postPower']){
-                    setTimeout(function(){
-                        c_action.postPower(true);
-                    }, 250);
+                    callback_queue.set([c_action, 'postPower'], [true]);
                 }
             },
             power_off(){
@@ -6362,9 +6363,7 @@ export function setAction(c_action,action,type,old,prediction){
                     }
                 }
                 if (c_action['postPower']){
-                    setTimeout(function(){
-                        c_action.postPower(false);
-                    }, 250);
+                    callback_queue.set([c_action, 'postPower'], [false]);
                 }
             },
             repair(){
@@ -6463,9 +6462,7 @@ function runAction(c_action,action,type){
                 if (!(global.settings.qKey && keyMap.q) && checkTechRequirements(type,false) && c_action.action({isQueue: false})){
                     gainTech(type);
                     if (c_action['post']){
-                        setTimeout(function(){
-                            c_action.post();
-                        }, 250);
+                        callback_queue.set([c_action, 'post'], []);
                     }
                 }
                 else {
@@ -6497,9 +6494,7 @@ function runAction(c_action,action,type){
                         gainBlood(type);
                     }
                     if (c_action['post']){
-                        setTimeout(function(){
-                            c_action.post();
-                        }, 250);
+                        callback_queue.set([c_action, 'post'], []);
                     }
                 }
                 break;
@@ -6619,9 +6614,7 @@ export function postBuild(c_action,action,type){
         }
     }
     if (c_action['post']){
-        setTimeout(function(){
-            c_action.post();
-        }, 250);
+        callback_queue.set([c_action, 'post'], []);
     }
     updateDesc(c_action,action,type);
 }
@@ -9703,4 +9696,20 @@ export function start_cataclysm(){
         delete global.race['start_cataclysm'];
         sentience();
     }
+}
+
+var callback_repeat = new Map();
+export function doCallbacks(){
+    for (const [[c_action, func], args] of callback_queue){
+        // If the function returns true, then it wants to be called again in the future
+        if (c_action[func](...args)){
+            callback_repeat.set([c_action, func], args);
+        }
+    }
+    // Remove all registered callbacks, then reinsert any callbacks that want to be repeated
+    callback_queue.clear();
+    for (const [[c_action, func], args] of callback_repeat){
+        callback_queue.set([c_action, func], args);
+    }
+    callback_repeat.clear();
 }

--- a/src/industry.js
+++ b/src/industry.js
@@ -1,4 +1,4 @@
-import { global, keyMultiplier, sizeApproximation, p_on, support_on, quantum_level } from './vars.js';
+import { global, keyMultiplier, sizeApproximation, p_on, support_on, quantum_level, callback_queue } from './vars.js';
 import { loc } from './locale.js';
 import { vBind, popover, clearElement, powerGrid, easterEgg, trickOrTreat } from './functions.js';
 import { actions, checkCityRequirements, checkPowerRequirements } from './actions.js';
@@ -1753,9 +1753,7 @@ export function setPowerGrid(){
                                 }
                             }
                             if (c_action['postPower']){
-                                setTimeout(function(){
-                                    c_action.postPower(true);
-                                }, 250);
+                                callback_queue.set([c_action, 'postPower'], [true]);
                             }
                         },
                         power_off(){
@@ -1769,9 +1767,7 @@ export function setPowerGrid(){
                                 }
                             }
                             if (c_action['postPower']){
-                                setTimeout(function(){
-                                    c_action.postPower(false);
-                                }, 250);
+                                callback_queue.set([c_action, 'postPower'], [false]);
                             }
                         },
                         higher(){

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level } from './vars.js';
+import { global, save, seededRandom, webWorker, intervals, keyMap, atrack, resizeGame, breakdown, sizeApproximation, keyMultiplier, power_generated, p_on, support_on, int_on, gal_on, spire_on, set_qlevel, quantum_level, callback_queue } from './vars.js';
 import { loc } from './locale.js';
 import { unlockAchieve, checkAchievements, drawAchieve, alevel, universeAffix, challengeIcon, unlockFeat, checkAdept } from './achieve.js';
 import { gameLoop, vBind, popover, clearPopper, flib, tagEvent, timeCheck, arpaTimeCheck, timeFormat, powerModifier, modRes, initMessageQueue, messageQueue, calc_mastery, calcPillar, darkEffect, calcQueueMax, calcRQueueMax, buildQueue, shrineBonusActive, getShrineBonus, eventActive, easterEggBind, trickOrTreatBind, powerGrid, deepClone, addATime, exceededATimeThreshold, loopTimers, calcQuantumLevel, drawPet } from './functions.js';
@@ -2133,6 +2133,10 @@ function fastLoop(){
                 if (p_on[struct] !== global[region][struct].on){
                     $(`#${region}-${struct} .on`).addClass('warn');
                     $(`#${region}-${struct} .on`).prop('title',`ON ${p_on[struct]}/${global[region][struct].on}`);
+                    // Remove the reset actions for reset structures that lose power
+                    if (['matrix', 'atmo_terraformer', 'ascension_trigger'].includes(struct)){
+                        callback_queue.set([c_action, 'postPower'], [true]);
+                    }
                 }
                 else {
                     $(`#${region}-${struct} .on`).removeClass('warn');

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import { defineResources, resource_values, spatialReasoning, craftCost, plasmidB
 import { defineJobs, job_desc, loadFoundry, farmerValue, jobName, jobScale, workerScale, limitCraftsmen, loadServants} from './jobs.js';
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, luxGoodPrice, smelterUnlocked, smelterFuelConfig } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
-import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, checkPowerRequirements, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn } from './actions.js';
+import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, checkPowerRequirements, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn, doCallbacks, cLabels } from './actions.js';
 import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes, galaxyRegions, gatewayArmada, galaxy_ship_types } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay, hellguard, buildMechQueue, mechCost } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
@@ -837,6 +837,9 @@ export function execGameLoops(periods = 1){
         // Always run a faster loop before a slower loop
         fastLoop();
         if (doMid){ midLoop(); }
+
+        // Perform callbacks before longLoop, so that any permanent results can be saved during longLoop
+        doCallbacks();
         if (doLong){ longLoop(); }
 
         // Overflow prevention
@@ -11440,23 +11443,26 @@ function longLoop(){
     const date = new Date();
     const astroSign = astrologySign();
     if (global.race.species !== 'protoplasm'){
-        let grids = gridDefs();
-        let updatePowerGrid = false;
-        Object.keys(grids).forEach(function(grid){
-            grids[grid].l.forEach(function(struct){
-                let parts = struct.split(":");
-                let space = convertSpaceSector(parts[0]);
-                let region = parts[0] === 'city' ? parts[0] : space;
-                let c_action = parts[0] === 'city' ? actions.city[parts[1]] : actions[space][parts[0]][parts[1]];
-                let breaker = $(`#pg${c_action.id}${grid}`);
 
-                if (grids[grid].s && (breaker.length === 0 || (gridEnabled(c_action,region,parts[0],parts[1]) && breaker.hasClass('inactive')))){
-                    updatePowerGrid = true;
-                }
+        if (global.settings.tabLoad || (global.settings.civTabs === 2 && global.settings.govTabs === 2)){
+            let grids = gridDefs();
+            let updatePowerGrid = false;
+            Object.keys(grids).forEach(function(grid){
+                grids[grid].l.forEach(function(struct){
+                    let parts = struct.split(":");
+                    let space = convertSpaceSector(parts[0]);
+                    let region = parts[0] === 'city' ? parts[0] : space;
+                    let c_action = parts[0] === 'city' ? actions.city[parts[1]] : actions[space][parts[0]][parts[1]];
+                    let breaker = $(`#pg${c_action.id}${grid}`);
+
+                    if (grids[grid].s && (breaker.length === 0 || (gridEnabled(c_action,region,parts[0],parts[1]) && breaker.hasClass('inactive')))){
+                        updatePowerGrid = true;
+                    }
+                });
             });
-        });
-        if (updatePowerGrid){
-            setPowerGrid();
+            if (updatePowerGrid){
+                setPowerGrid();
+            }
         }
 
         if (global.tech['syphon'] && global.tech.syphon >= 80){
@@ -11952,10 +11958,7 @@ function longLoop(){
             drawTech();
         }
 
-        if (global.settings['cLabels'] && $('#city-dist-outskirts').length === 0){
-            drawCity();
-        }
-        if (!global.settings['cLabels'] && $('#city-dist-outskirts').length > 0){
+        if (global.settings['cLabels'] !== cLabels){
             drawCity();
         }
 

--- a/src/races.js
+++ b/src/races.js
@@ -7136,8 +7136,6 @@ export function cleanAddTrait(trait){
         case 'unified':
             global.tech['world_control'] = 1;
             global.tech['unify'] = 2;
-            clearElement($('#garrison'));
-            clearElement($('#c_garrison'));
             buildGarrison($('#garrison'),true);
             buildGarrison($('#c_garrison'),false);
             for (let i=0; i<3; i++){

--- a/src/space.js
+++ b/src/space.js
@@ -658,15 +658,21 @@ const spaceProjects = {
                 return powerCostMod((wiki ? wiki.truepath : global.race['truepath']) ? 500 : 5000);
             },
             postPower(o){
-                if (o){
-                    setTimeout(function(){
-                        global.tech.terraforming = p_on['atmo_terraformer'] ? 3 : 2;
-                        renderSpace();
-                    }, 250);
+                if (o && p_on['atmo_terraformer']){
+                    // Powered on and energized
+                    global.tech.terraforming = 3;
+                    renderSpace();
                 }
                 else {
-                    global.tech.terraforming = 2;
-                    renderSpace();
+                    if (global.tech.terraforming > 2){
+                        // Disabled or lost power
+                        global.tech.terraforming = 2;
+                        renderSpace();
+                    }
+                    if (o){
+                        // Not powered yet, check again soon
+                        return true;
+                    }
                 }
             },
             effect(wiki){
@@ -4664,15 +4670,21 @@ const interstellarProjects = {
                 deepSpace();
             },
             postPower(o){
-                if (o){
-                    setTimeout(function(){
-                        global.tech.ascension = p_on['ascension_trigger'] ? 8 : 7;
-                        deepSpace();
-                    }, 250);
+                if (o && p_on['ascension_trigger']){
+                    // Powered on and energized
+                    global.tech.ascension = 8;
+                    deepSpace();
                 }
                 else {
-                    global.tech.ascension = 7;
-                    deepSpace();
+                    if (global.tech.ascension > 7){
+                        // Disabled or lost power
+                        global.tech.ascension = 7;
+                        deepSpace();
+                    }
+                    if (o){
+                        // Not powered yet, check again soon
+                        return true;
+                    }
                 }
             },
             effect(){
@@ -5355,14 +5367,6 @@ const galaxyProjects = {
                 return global.galaxy.hasOwnProperty('starbase') ? [{ s: global.galaxy.starbase.s_max - global.galaxy.starbase.support }] : false;
             },
             postPower(o){
-                let powered = o ? p_on['telemetry_beacon'] + keyMultiplier() : p_on['telemetry_beacon'] - keyMultiplier();
-                if (powered > global.galaxy.telemetry_beacon.count){
-                    powered = global.galaxy.telemetry_beacon.count;
-                }
-                else if (powered < 0){
-                    powered = 0;
-                }
-                p_on['telemetry_beacon'] = powered;
                 updateDesc($(this)[0],'galaxy','telemetry_beacon');
             },
             action(args){

--- a/src/tech.js
+++ b/src/tech.js
@@ -15666,8 +15666,6 @@ const techs = {
 
 function uniteEffect(){
     global.tech['world_control'] = 1;
-    clearElement($('#garrison'));
-    clearElement($('#c_garrison'));
     buildGarrison($('#garrison'),true);
     buildGarrison($('#c_garrison'),false);
     for (let i=0; i<3; i++){

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -1588,15 +1588,21 @@ const tauCetiModules = {
             cost: {},
             powered(){ return 10000; },
             postPower(o){
-                if (o){
-                    setTimeout(function(){
-                        global.tech.matrix = p_on['matrix'] ? 4 : 3;
-                        renderTauCeti();
-                    }, 250);
+                if (o && p_on['matrix']){
+                    // Powered on and energized
+                    global.tech.matrix = 4;
+                    renderTauCeti();
                 }
                 else {
-                    global.tech.matrix = 3;
-                    renderTauCeti();
+                    if (global.tech.matrix > 3){
+                        // Disabled or lost power
+                        global.tech.matrix = 3;
+                        renderTauCeti();
+                    }
+                    if (o){
+                        // Not powered yet, check again soon
+                        return true;
+                    }
                 }
             },
             effect(){
@@ -1793,9 +1799,7 @@ const tauCetiModules = {
                         global.civic[global.civic.d_job].workers -= hired;
                         global.civic.pit_miner.workers += hired;
                     }
-                    if (global.settings.tabLoad){
-                        drawShips();
-                    }
+                    drawShips();
                     return true;
                 }
                 return false;

--- a/src/vars.js
+++ b/src/vars.js
@@ -59,6 +59,7 @@ export var message_logs = {
     view: 'all'
 };
 export const message_filters = ['all','progress','queue','building_queue','research_queue','combat','spy','events','major_events','minor_events','achievements','hell'];
+export var callback_queue = new Map();
 
 Math.rand = function(min, max) {
     return Math.floor(Math.random() * (max - min)) + min;


### PR DESCRIPTION
The `post()` and `postPower()` functions of various structures are now called by the game loop, not by 250ms delay `setTimeout` invocations. This means that they cannot be delayed by event queue congestion. These functions are invoked at the same frequency as `fastLoop`, but the actual call site is placed between `midLoop` and `longLoop`.

Remove some incorrect code from `postPower()` for telemetry beacons.

Use a more precise method to detect when the `longLoop` should redraw the city tab in response to an updated value for city categorization.

Don't attempt to redraw the power grid in `longLoop` when the power grid isn't visible and preload tab content is disabled.

Resolves #1440. In particular, the actions to perform the ascension, terraforming, and matrix resets will gain predictable behavior. These three reset buttons will be removed if the player no longer has enough power, even if the building has not been manually powered down.