### PR TITLE
Skip drawTech() when auto-stabilize has to wait

### DIFF
--- a/src/governor.js
+++ b/src/governor.js
@@ -1286,7 +1286,6 @@ export const gov_tasks = {
 
             if (global.genes.hasOwnProperty('governor') && global.genes.governor >= 3 && global.race.governor.config.trash.stab){
                 stabilize_blackhole();
-                drawTech();
             }
         }
     },

--- a/src/tech.js
+++ b/src/tech.js
@@ -15729,6 +15729,7 @@ export function stabilize_blackhole(){
     if (global.interstellar['stellar_engine'] && global.interstellar.stellar_engine.exotic >= 0.025 && global.tech['whitehole']){
         if (techs.stabilize_blackhole.action()){
             global.tech['stablized'] = 1;
+            drawTech();
         }
     }
 }


### PR DESCRIPTION
Redraws to the canvas can nullify attempts to click action buttons. It doesn't happen very often, but it's frustrating enough that I currently don't use this otherwise convenient quality of life feature.