### PR TITLE
Schedule postPower() for autopowered structs

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6959,7 +6959,7 @@ function buildPlanet(aspect,opt,args){
 }
 
 // Returns true when side effects associated with the new structure being powered on should occur. Can return false even when alwaysPowered is enabled.
-export function powerOnNewStruct(c_action,extra){
+export function powerOnNewStruct(c_action){
     let parts = c_action.id.split('-');
     if (!global.hasOwnProperty(parts[0]) || !global[parts[0]].hasOwnProperty(parts[1])){
         return false;
@@ -6995,8 +6995,8 @@ export function powerOnNewStruct(c_action,extra){
                 gov_tasks.replicate.task();
             }
         }
-        if (extra && typeof extra === 'function'){
-            return extra(c_action);
+        if (c_action['postPower']){
+            callback_queue.set([c_action, 'postPower'], [true]);
         }
         return true;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -2572,6 +2572,7 @@ function fastLoop(){
                 }
                 if (army < jobScale(global.portal.guard_post.on)){
                     global.portal.guard_post.on = Math.floor(army / jobScale(1));
+                    p_on['guard_post'] = Math.min(global.portal.guard_post.on, p_on['guard_post']);
                 }
             }
 
@@ -3900,7 +3901,7 @@ function fastLoop(){
             let missing = Math.min(global.civic.homeless, global.resource[global.race.species].max - global.resource[global.race.species].amount);
             global.civic.homeless -= missing;
             global.resource[global.race.species].amount += missing;
-            global.civic[global.civic.d_job].workers++;
+            global.civic[global.civic.d_job].workers += missing;
         }
         else if (((fed && global['resource']['Food'].amount > 0) || global.race['fasting']) && global['resource'][global.race.species].max > global['resource'][global.race.species].amount){
             if (global.race['artifical'] || (global.race['spongy'] && global.city.calendar.weather === 0)){

--- a/src/portal.js
+++ b/src/portal.js
@@ -1292,23 +1292,14 @@ const fortressModules = {
                 return false;
             },
             postPower(o){
-                let count = $(this)[0].citizens();
-                if (o){
-                    global.resource[global.race.species].max += count;
-                    global.resource[global.race.species].amount += count;
-                    global.civic.miner.max += count;
-                    global.civic.miner.workers += count;
-                    global.civic.miner.assigned += count;
-                }
-                else {
-                    global.resource[global.race.species].max -= count;
-                    global.resource[global.race.species].amount -= count;
-                    if (global.resource[global.race.species].amount < 0){ global.resource[global.race.species].amount = 0; }
-                    if (global.resource[global.race.species].max < 0){ global.resource[global.race.species].max = 0; }
-                    global.civic.miner.max -= count;
-                    global.civic.miner.workers -= count;
-                    global.civic.miner.assigned -= count;
-                }
+                const prev_count = global.civic.miner.max;
+                const new_count = $(this)[0].citizens() * global.portal.dig_demon.on;
+                const delta = new_count - prev_count;
+                global.resource[global.race.species].max = Math.max(0, global.resource[global.race.species].max + delta);
+                global.resource[global.race.species].amount = Math.max(0, global.resource[global.race.species].amount + delta);
+                global.civic.miner.max = new_count;
+                global.civic.miner.workers = new_count;
+                global.civic.miner.assigned = new_count;
             },
             struct(){
                 return {
@@ -1926,7 +1917,18 @@ const fortressModules = {
             action(args){
                 if (payCosts($(this)[0])){
                     incrementStruct('guard_post','portal');
-                    powerOnNewStruct($(this)[0]);
+
+                    let army = global.portal.fortress.garrison - (global.portal.fortress.patrols * global.portal.fortress.patrol_size);
+                    if (p_on['soul_forge']){
+                        let forge = soulForgeSoldiers();
+                        if (forge <= army){
+                            army -= forge;
+                        }
+                    }
+                    if (army >= jobScale(global.portal.guard_post.on + 1)){
+                        // Don't power on unless there are enough guards
+                        powerOnNewStruct($(this)[0]);
+                    }
                     return true;
                 }
                 return false;
@@ -2112,10 +2114,6 @@ const fortressModules = {
                     return true;
                 }
                 return false;
-            },
-            post(){
-                vBind({el: `#srprtl_ruins`},'update');
-                drawTech();
             },
             postPower(){
                 vBind({el: `#srprtl_ruins`},'update');
@@ -2499,9 +2497,6 @@ const fortressModules = {
                     d: { count: 0, on: 0 },
                     p: ['gate_turret','portal']
                 };
-            },
-            post(){
-                vBind({el: `#srprtl_gate`},'update');
             },
             postPower(){
                 vBind({el: `#srprtl_gate`},'update');

--- a/src/space.js
+++ b/src/space.js
@@ -5482,9 +5482,6 @@ const galaxyProjects = {
                     d: { count: 0, on: 0 },
                     p: ['defense_platform','galaxy']
                 };
-            },
-            post(){
-                vBind({el: `#gxy_stargate`},'update');
             }
         },
     },
@@ -6301,7 +6298,7 @@ const galaxyProjects = {
             action(args){
                 if (payCosts($(this)[0])){
                     incrementStruct('minelayer','galaxy');
-                    global.galaxy.minelayer.on++;
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -6313,9 +6310,6 @@ const galaxyProjects = {
                 };
             },
             postPower(){
-                vBind({el: `#gxy_chthonian`},'update');
-            },
-            post(){
                 vBind({el: `#gxy_chthonian`},'update');
             }
         },
@@ -6396,7 +6390,7 @@ const galaxyProjects = {
             action(args){
                 if (payCosts($(this)[0])){
                     incrementStruct('raider','galaxy');
-                    global.galaxy.raider.on++;
+                    powerOnNewStruct($(this)[0]);
                     return true;
                 }
                 return false;
@@ -6408,9 +6402,6 @@ const galaxyProjects = {
                 };
             },
             postPower(){
-                vBind({el: `#gxy_chthonian`},'update');
-            },
-            post(){
                 vBind({el: `#gxy_chthonian`},'update');
             }
         },


### PR DESCRIPTION
Fixes a lingering issue where #1447 did not spawn reset buttons from ascension trigger, atmosphere terraformer, or matrix now that they can be automatically enabled by the settings switch.

This commit also removes a couple of newly redundant post() functions and resolves some funniness related to powering on or off guard posts or dig demon burrows.

Homeless citizens who find new housing can now all find default jobs at once. If none of them find new housing, then the default job will not flicker back and forth between its expected value and that value+1.