### PR TITLE
Fix Clearing of Disabled Governor Tasks

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -14,7 +14,7 @@ import { tauCetiTech, renderTauCeti, loneSurvivor } from './truepath.js';
 import { arpa, gainGene, gainBlood } from './arpa.js';
 import { production, highPopAdjust } from './prod.js';
 import { techList, techPath } from './tech.js';
-import { govActive, removeTask, gov_tasks } from './governor.js';
+import { defineGovernor, govActive, removeTask, gov_tasks } from './governor.js';
 import { bioseed } from './resets.js';
 import { loadTab } from './index.js';
 
@@ -8025,6 +8025,7 @@ export function orbitDecayed(){
             global.resource.Slave.display = false;
             global.resource.Slave.amount = 0;
             removeTask('slave');
+            defineGovernor();
         }
         if (global.race['deconstructor']){
             nf_resources.forEach(function (res){

--- a/src/governor.js
+++ b/src/governor.js
@@ -837,7 +837,7 @@ export function govActive(trait,val){
 
 export function removeTask(task){
     if (global.genes['governor'] && global.tech['governor'] && global.race['governor'] && global.race.governor['g'] && global.race.governor['tasks']){
-        for (let i=0; i<global.race.governor.tasks.length; i++){
+        for (let i=0; i<Object.keys(global.race.governor.tasks).length; i++){
             if (global.race.governor.tasks[`t${i}`] === task){
                 global.race.governor.tasks[`t${i}`] = 'none';
             }

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@ import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
 import { renderTauCeti, syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, tpStorageMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift, drawMap, tauEnabled, shipCosts, buildTPShipQueue } from './truepath.js';
 import { arpa, buildArpa, sequenceLabs } from './arpa.js';
 import { events, eventList } from './events.js';
-import { govern, govActive, removeTask } from './governor.js';
+import { defineGovernor, govern, govActive, removeTask } from './governor.js';
 import { production, highPopAdjust, teamster, factoryBonus } from './prod.js';
 import { swissKnife } from './tech.js';
 import { vacuumCollapse } from './resets.js';
@@ -12255,6 +12255,7 @@ function longLoop(){
                     global.tech.focus_cure = 7;
                     messageQueue(loc('tech_vaccine_campaign_msg2'),'info',false,['progress']);
                     removeTask('assemble');
+                    defineGovernor();
                 }
             }
         }

--- a/src/races.js
+++ b/src/races.js
@@ -7207,6 +7207,7 @@ export function cleanAddTrait(trait){
             }
             removeTask('spy');
             removeTask('spyop');
+            removeTask('combo_spy');
             defineGovernor();
             break;
         case 'noble':

--- a/src/races.js
+++ b/src/races.js
@@ -7207,6 +7207,7 @@ export function cleanAddTrait(trait){
             }
             removeTask('spy');
             removeTask('spyop');
+            defineGovernor();
             break;
         case 'noble':
             if (global.civic.taxes.tax_rate < 10) {

--- a/src/tech.js
+++ b/src/tech.js
@@ -15680,6 +15680,7 @@ function uniteEffect(){
     }
     removeTask('spy');
     removeTask('spyop');
+    defineGovernor();
 }
 
 export function swissKnife(cheeseOnly,cheeseList){

--- a/src/tech.js
+++ b/src/tech.js
@@ -15680,6 +15680,7 @@ function uniteEffect(){
     }
     removeTask('spy');
     removeTask('spyop');
+    removeTask('combo_spy');
     defineGovernor();
 }
 

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -5672,6 +5672,7 @@ export function jumpGateShutdown(){
 
     removeTask('spy');
     removeTask('spyop');
+    removeTask('combo_spy');
     defineGovernor();
 
     clearElement($(`#infoTimer`));

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -7,7 +7,7 @@ import { jobScale, job_desc, loadFoundry, limitCraftsmen } from './jobs.js';
 import { production, highPopAdjust } from './prod.js';
 import { actions, payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, buildTemplate, casinoEffect, housingLabel, structName, initStruct } from './actions.js';
 import { fuel_adjust, int_fuel_adjust, spaceTech, renderSpace, checkRequirements, incrementStruct, planetName } from './space.js';
-import { removeTask, govActive } from './governor.js';
+import { defineGovernor, removeTask, govActive } from './governor.js';
 import { defineIndustry, nf_resources, addSmelter } from './industry.js';
 import { arpa } from './arpa.js';
 import { matrix, retirement, gardenOfEden } from './resets.js';
@@ -5672,6 +5672,7 @@ export function jumpGateShutdown(){
 
     removeTask('spy');
     removeTask('spyop');
+    defineGovernor();
 
     clearElement($(`#infoTimer`));
     global.race['inactive'] = inactive;


### PR DESCRIPTION
Fixes a bug that prevented the removeTask() function from actually deactivating an active task and clearing its slot. Specifically, the function attempted to get the .length of the "global.race.governor.tasks" object directly instead of counting its keys by using "Object.keys()".

Adds several calls to defineGovernor() to redraw the governor tab after removing a task. Without these, the disabled tasks would remain in the dropdown of selectable tasks until the page was refreshed.

Adds lines to remove "ADV. Spy Operator" when removing the standard "Spy Recruitment" and "Spy Operator" tasks. Mainly, after unifying, gaining the unification trait, and when the jump gate shuts down in True Path.

With these changes, task slots with disabled tasks should automatically reset to "none" and those tasks should be unavailable for selection immediately after being disabled.