### PR TITLE
Raise Chrysotile base cap with the Adept Perk.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8265,7 +8265,12 @@ function midLoop(){
 
         if (global.stats.feat['adept']){
             let rank = checkAdept();
-            caps['Lumber'] += rank * 60;
+            if (global.race['smoldering']){
+                caps['Chrysotile'] += rank * 60;
+            }
+            else {
+                caps['Lumber'] += rank * 60;
+            }
             caps['Stone'] += rank * 60;
         }
 


### PR DESCRIPTION
The code already attempted to add extra starting Chrysotile if the player had both the Evolve Adept perk and the Smoldering trait. However, it did not increase the base storage, so the extra resource was discarded.