### PR TITLE
Update strings.pt-BR.json

### DIFF
--- a/strings/strings.pt-BR.json
+++ b/strings/strings.pt-BR.json
@@ -5525,7 +5525,7 @@
   "gov_name_Mindflayer": "Mindflayer",
   "gov_name_Paranoia": "Paranóia",
   "gov_name_Horror": "Horror",
-  "governor_fire": "Governador do Fogo",
+  "governor_fire": "Demitir Governador",
   "gov_trait_tactician": "Tático",
   "gov_trait_tactician_desc": "A experiência tática ajuda a melhorar o desempenho de combate de suas forças.",
   "gov_trait_tactician_effect": "+%0% Eficácia de Combate.",


### PR DESCRIPTION
correction in translation fire_governor was translated for governor of fire like the element, to fire someone in portuguese are "Demitir"