### PR TITLE
Add Resource Level Gauges

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -162,6 +162,9 @@ Misc ---------> Main template
             @market-item-order-hover-background: @secondary-color;
             @market-item-order-hover-border: #eee;
 
+            // .resource
+            @resource-overlay-color: #888888ee;
+
             // .modalBox
             @modalBox-background: #282f2f;
 
@@ -284,6 +287,9 @@ Misc ---------> Main template
             @market-item-order-hover-background: #ccc;
             @market-item-order-hover-border: #333;
 
+            // .resource
+            @resource-overlay-color: #000000;
+
             // .modalBox
             @modalBox-background: @white;
 
@@ -324,6 +330,9 @@ Misc ---------> Main template
 
             // .market-item
             @market-item-background: #1b1b1b;
+
+            // .resource
+            @resource-overlay-color: #888888;
 
             // -webkit-scrollbar
             @webkit-scrollbar-thumb-background: #727272;
@@ -483,6 +492,9 @@ Misc ---------> Main template
             @market-item-order-hover-background: @secondary-color;
             @market-item-order-hover-border: @link-hover;
 
+            // .resource
+            @resource-overlay-color: #a89984;
+
             // .modalBox
             @modalBox-background: @html-background;
 
@@ -604,6 +616,9 @@ Misc ---------> Main template
             @market-item-background: #1d2021;
             @market-item-order-hover-background: @secondary-color;
             @market-item-order-hover-border: @link-hover;
+
+            // .resource
+            @resource-overlay-color: #ebdbb2;
 
             // .modalBox
             @modalBox-background: @html-background;
@@ -766,6 +781,9 @@ Misc ---------> Main template
             @market-item-order-hover-background: @secondary-color;
             @market-item-order-hover-border: @link-hover;
 
+            // .resource
+            @resource-overlay-color: #a89259;
+
             // .modalBox
             @modalBox-background: @html-background;
 
@@ -888,6 +906,9 @@ Misc ---------> Main template
             @market-item-background: #1d2021;
             @market-item-order-hover-background: @secondary-color;
             @market-item-order-hover-border: @link-hover;
+
+            // .resource
+            @resource-overlay-color: #3c4888;
 
             // .modalBox
             @modalBox-background: @html-background;
@@ -1607,7 +1628,13 @@ Misc ---------> Main template
         }
 
         .resource {
-          background-image: linear-gradient(to right, #fff3 0%, #fff4 calc(var(--percent-full) - 2px), #fffa calc(var(--percent-full) - 2px), #fffa var(--percent-full), transparent var(--percent-full), transparent 100%);
+          background-image: linear-gradient(
+            to right, fade(@resource-overlay-color, 10%) 0%,
+            fade(@resource-overlay-color, 10%) calc(var(--percent-full) - 2px),
+            fade(@resource-overlay-color, 50%) calc(var(--percent-full) - 2px),
+            fade(@resource-overlay-color, 50%) var(--percent-full),
+            transparent var(--percent-full),
+            transparent 100%);
           padding: 3px;
         }
 

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -1606,6 +1606,11 @@ Misc ---------> Main template
             }
         }
 
+        .resource {
+          background-image: linear-gradient(to right, #fff3 0%, #fff4 calc(var(--percent-full) - 2px), #fffa calc(var(--percent-full) - 2px), #fffa var(--percent-full), transparent var(--percent-full), transparent 100%);
+          padding: 3px;
+        }
+
         .inactive-row {
             background-color: @market-item-background;
         }

--- a/src/resources.js
+++ b/src/resources.js
@@ -829,7 +829,7 @@ function loadResource(name,wiki,max,rate,tradable,stackable,color){
         res_container = $(`<div id="res${name}" class="resource crafted" v-show="display"><div><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | diffSize }}</span></div></div>`);
     }
     else {
-        res_container = $(`<div id="res${name}" class="resource" v-show="display"><div><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | size }} / {{ max | size }}</span></div></div>`);
+        res_container = $(`<div id="res${name}" class="resource" v-show="display" :style="{ '--percent-full': ((amount/max)*100) + '%' }"><div><h3 class="res has-text-${color}">{{ name | namespace }}</h3><span id="cnt${name}" class="count">{{ amount | size }} / {{ max | size }}</span></div></div>`);
     }
 
     if (stackable){


### PR DESCRIPTION
This pull request adds gauges to the resource list, which show how full that particular resources is. It also adds a color to each of the color schemes, which determines the color of the gauge.

Here are the gauges in a few color schemes:
<img height="300" alt="screenshot" src="https://github.com/user-attachments/assets/cdd36bef-3041-4af5-8ef5-849d760e3ea5" />
<img height="300" alt="screenshot" src="https://github.com/user-attachments/assets/55e90779-305c-43c7-84c7-6fa5550f7b0f" />
<img height="300" alt="screenshot" src="https://github.com/user-attachments/assets/822b79a4-72c9-44e8-b3ca-aa5109086c6a" />