### PR TITLE
Misc fixes

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -600,7 +600,7 @@ export const events = {
             global.resource[global.race.species].amount -= dead;
             blubberFill(dead);
             if(type === 7){
-                return loc('event_chicken',[loc(`event_chicken_eaten${type}`, [flib('name')]),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
+                return loc('event_chicken',[loc(`event_chicken_eaten${type}`,[flib('name')]),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
             }
             return loc('event_chicken',[loc(`event_chicken_eaten${type}`),dead,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
         }
@@ -774,7 +774,11 @@ export const events = {
         effect(){
             global.resource[global.race.species].amount--;
             blubberFill(1);
-            return loc('event_chicken',[loc(`event_chicken_eaten${Math.rand(0,10)}`),1,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
+            let type = Math.floor(seededRandom(0,10));
+            if(type === 7){
+                return loc('event_chicken',[loc(`event_chicken_eaten${type}`,[flib('name')]),1,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
+            }
+            return loc('event_chicken',[loc(`event_chicken_eaten${type}`),1,loc(`event_chicken_seasoning${Math.floor(seededRandom(0,10))}`)]);
         }
     },
     fight:{ 

--- a/src/portal.js
+++ b/src/portal.js
@@ -5051,7 +5051,7 @@ function addHellEnemy(type = [], allowRecursion = true, allowRepeat = false){
 }
 
 function soulCapacitor(souls){
-    if (global.race['witch_hunter'] && global.portal.hasOwnProperty('soul_capacitor') && p_on['soul_capacitor'] > 0){
+    if (global.race['witch_hunter'] && global.portal.hasOwnProperty('soul_capacitor')){
         global.portal.soul_capacitor.energy += souls;
         if (global.portal.soul_capacitor.energy > global.portal.soul_capacitor.ecap){
             global.portal.soul_capacitor.energy = global.portal.soul_capacitor.ecap;

--- a/src/races.js
+++ b/src/races.js
@@ -8903,7 +8903,7 @@ function majorWish(parent){
                     else {
                         switch(spell){
                             case 'flower':
-                                messageQueue(loc('wish_peace_flower',[govTitle(spell.substring(3))]),'warning',false,['events']);
+                                messageQueue(loc('wish_peace_flower'),'warning',false,['events']);
                                 break;
                             case 'gov3':
                                 global.civic.foreign[spell].hstl = 0;

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -386,9 +386,9 @@ const outerTruth = {
             reqs: { titan: 6 },
             path: ['truepath'],
             cost: {
-                Money(offset){ return spaceCostMultiplier('titan_bank', offset, 2500000, 1.32); },
-                Titanium(offset){ return spaceCostMultiplier('titan_bank', offset, 380000, 1.32); },
-                Neutronium(offset){ return spaceCostMultiplier('titan_bank', offset, 5000, 1.32); }
+                Money(offset){ return spaceCostMultiplier('titan_bank', offset, traitCostMod('untrustworthy',2500000), 1.32); },
+                Titanium(offset){ return spaceCostMultiplier('titan_bank', offset, traitCostMod('untrustworthy',380000), 1.32); },
+                Neutronium(offset){ return spaceCostMultiplier('titan_bank', offset, traitCostMod('untrustworthy',5000), 1.32); }
             },
             effect(){
                 let vault = bank_vault() * 2;
@@ -4530,7 +4530,7 @@ export function shipPower(ship, wiki){
             break;
     }
 
-    watts = Math.round(powerModifier(watts));
+    watts = Math.round(Math.max(watts, powerModifier(watts)));
 
     switch (ship.weapon){
         case 'railgun':

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -11,6 +11,7 @@ import { defineGovernor, removeTask, govActive } from './governor.js';
 import { defineIndustry, nf_resources, addSmelter, setupRituals, cancelRituals } from './industry.js';
 import { arpa } from './arpa.js';
 import { matrix, retirement, gardenOfEden } from './resets.js';
+import { traitCostMod } from './races.js';
 import { loc } from './locale.js';
 
 const outerTruth = {


### PR DESCRIPTION
Untrustworthy now affects Titan banks
Soul capacitors now lose stored energy if you turn off all capacitors at once.
Leo + untrustworthy can now no longer reduce the power of truepath ships and make the explorer ship unusable.
^ note that this can still cause impossibly powered ships if the Leo starsign ends with an overpowered ship. (this shouldn't cause any real issues)
Fixed the chicken hunter minor event and wish peace event message.

Warning: I did not test the soul capacitor change at all.