### PR TITLE
Improve Screen Reader Descriptions

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7179,7 +7179,7 @@ function srDesc(c_action,old){
                                 num_on = getStructNumActive(actions[region][struct]);
                             }
                         }
-                        desc = desc + `${label}. `;
+                        desc = desc + `${label}: ${structs[region][struct].count}. `;
 
                         if (!global[region][struct]){
                             desc = desc + `${loc('insufficient')} ${label}. `;

--- a/src/actions.js
+++ b/src/actions.js
@@ -7216,6 +7216,26 @@ function srDesc(c_action,old){
                     }
                 }
             }
+            else if (res === 'HellArmy'){
+                let res_cost = costs[res]();
+                if (res_cost > 0){
+                    let label = loc('fortress_troops');
+                    desc = desc + `${label}: ${res_cost}. `;
+                    if (global.portal.fortress.garrison - (global.portal.fortress.patrols * global.portal.fortress.patrol_size) < res_cost){
+                        desc = desc + `${loc('insufficient')} ${label}. `;
+                    }
+                }
+            }
+            else if (res === 'Troops'){
+                let res_cost = costs[res]();
+                if (res_cost > 0){
+                    let label = loc('fortress_troops');
+                    desc = desc + `${label}: ${res_cost}. `;
+                    if (garrisonSize() < res_cost){
+                        let label = global.tech['world_control'] && !global.race['truepath'] ? loc('civics_garrison_peacekeepers') : loc('civics_garrison_soldiers');
+                    }
+                }
+            }
             else if (res !== 'Morale' && res !== 'Army' && res !== 'Bool'){
                 let res_cost = costs[res]();
                 let f_res = res === 'Species' ? global.race.species : res;

--- a/src/actions.js
+++ b/src/actions.js
@@ -7253,6 +7253,10 @@ function srDesc(c_action,old){
         });
     }
 
+    if (desc.endsWith('Affordable. Costs: ')){
+        desc = desc.slice(0, -19);
+    }
+
     if (c_action.effect){
         let effect = typeof c_action.effect === 'string' ? c_action.effect : c_action.effect();
         if (effect){

--- a/src/actions.js
+++ b/src/actions.js
@@ -7143,7 +7143,12 @@ export function planetGeology(geology){
 
 function srDesc(c_action,old){
     let desc = typeof c_action.desc === 'string' ? c_action.desc : c_action.desc();
-    desc = desc + '. ';
+    if (desc.endsWith('</div>')){
+        desc = desc.slice(0, -6) + '. </div>'; // the period was sometimes spoken when outside the div
+    }
+    else {
+        desc = desc + '. ';
+    }
     if (c_action.cost && !old){
         if (checkAffordable(c_action)){
             desc = desc + loc('affordable') + '. ';
@@ -7260,7 +7265,13 @@ function srDesc(c_action,old){
     if (c_action.effect){
         let effect = typeof c_action.effect === 'string' ? c_action.effect : c_action.effect();
         if (effect){
-            desc = desc + effect + '. ';
+            desc = desc + effect;
+            if (desc.endsWith('</div>')){
+                desc = desc.slice(0, -6) + '. </div>';
+            }
+            else {
+                desc = desc + '. ';
+            }
         }
     }
     if (c_action.flair){

--- a/src/actions.js
+++ b/src/actions.js
@@ -7370,6 +7370,26 @@ function srDesc(c_action,old){
                     }
                 }
             }
+            else if (res === 'HellArmy'){
+                let res_cost = costs[res]();
+                if (res_cost > 0){
+                    let label = loc('fortress_troops');
+                    desc = desc + `${label}: ${res_cost}. `;
+                    if (global.portal.fortress.garrison - (global.portal.fortress.patrols * global.portal.fortress.patrol_size) < res_cost){
+                        desc = desc + `${loc('insufficient')} ${label}. `;
+                    }
+                }
+            }
+            else if (res === 'Troops'){
+                let res_cost = costs[res]();
+                if (res_cost > 0){
+                    let label = global.tech['world_control'] && !global.race['truepath'] ? loc('civics_garrison_peacekeepers') : loc('civics_garrison_soldiers');
+                    desc = desc + `${label}: ${res_cost}. `;
+                    if (garrisonSize() < res_cost){
+                        desc = desc + `${loc('insufficient')} ${label}. `;
+                    }
+                }
+            }
             else if (res !== 'Morale' && res !== 'Army' && res !== 'Bool'){
                 let res_cost = costs[res]();
                 let f_res = res === 'Species' ? global.race.species : res;

--- a/src/actions.js
+++ b/src/actions.js
@@ -7297,6 +7297,12 @@ export function planetGeology(geology){
 
 function srDesc(c_action,old){
     let desc = typeof c_action.desc === 'string' ? c_action.desc : c_action.desc();
+    if (desc.endsWith('</div>')){
+        desc = desc.slice(0, -6) + '. </div>'; // the period was sometimes spoken when outside the div
+    }
+    else {
+        desc = desc + '. ';
+    }
     let preAffordableLen = desc.length;
     let preResCostsLen = 0;
     if (c_action.cost && !old){
@@ -7417,7 +7423,13 @@ function srDesc(c_action,old){
     if (c_action.effect){
         let effect = typeof c_action.effect === 'string' ? c_action.effect : c_action.effect();
         if (effect){
-            desc = desc + effect + '. ';
+            desc = desc + effect;
+            if (desc.endsWith('</div>')){
+                desc = desc.slice(0, -6) + '. </div>';
+            }
+            else {
+                desc = desc + '. ';
+            }
         }
     }
     if (c_action.flair){

--- a/src/actions.js
+++ b/src/actions.js
@@ -7297,7 +7297,8 @@ export function planetGeology(geology){
 
 function srDesc(c_action,old){
     let desc = typeof c_action.desc === 'string' ? c_action.desc : c_action.desc();
-    desc = desc + '. ';
+    let preAffordableLen = desc.length;
+    let preResCostsLen = 0;
     if (c_action.cost && !old){
         if (checkAffordable(c_action)){
             desc = desc + loc('affordable') + '. ';
@@ -7306,6 +7307,7 @@ function srDesc(c_action,old){
             desc = desc + loc('not_affordable') + '. ';
         }
         desc = desc + 'Costs: ';
+        preResCostsLen = desc.length;
         let type = c_action.id.split('-')[0];
         var costs = type !== 'genes' && type !== 'blood' ? adjustCosts(c_action) : c_action.cost;
         Object.keys(costs).forEach(function (res){
@@ -7405,6 +7407,11 @@ function srDesc(c_action,old){
                 }
             }
         });
+    }
+
+    // if no res costs were found remove the stray text "affordable Costs:" or the equivalent for the current language
+    if (desc.length === preResCostsLen){
+        desc = desc.slice(0, preAffordableLen);
     }
 
     if (c_action.effect){

--- a/src/actions.js
+++ b/src/actions.js
@@ -7335,7 +7335,7 @@ function srDesc(c_action,old){
                                 num_on = getStructNumActive(actions[region][struct]);
                             }
                         }
-                        desc = desc + `${label}. `;
+                        desc = desc + `${label}: ${structs[region][struct].count}. `;
 
                         if (!global[region][struct]){
                             desc = desc + `${loc('insufficient')} ${label}. `;


### PR DESCRIPTION
Fix a few issues in how the screen reader descriptions for structures and researches are put together.

* Added handling for "HellArmy" (fortress troop) requirements when building the screen reader descriptions. Previously, attempting to describe a structure with such a requirement would throw an error and not speak anything. "Secure the Pit" was the earliest affected structure, and there were a few more later in the Elysium Fields.

* Added the count of structures required for things with a requirement of a minimum number of structures to be built. I think "Second Contact" is the earliest item to have such a requirement.

* Removed some extraneous text from screen reader descriptions. First, costless structures (such as completed ones or manual gathering options) now remove the text "Affordable. Costs:" from the description, as it doesn't apply when there are no costs at all. This change also adds code to append periods after the name and effect parts of the description inside the divs for those sections. Some screen readers would previously speak the descriptions as if there were a space before the periods.
