### PR TITLE
Fix crash in midLoop when mimicing Avian/Plant while Cement Plants/Rock Quarries are queued

### DIFF
--- a/src/races.js
+++ b/src/races.js
@@ -7124,6 +7124,8 @@ export function cleanAddTrait(trait){
             global.civic.cement_worker.display = false;
             global.civic.cement_worker.workers = 0;
             global.civic.cement_worker.assigned = 0;
+            removeFromRQueue(['cement']);
+            removeFromQueue(['city-cement_plant', 'eden-eden_cement']);
             setPurgatory('tech','cement');
             setPurgatory('city','cement_plant');
             setPurgatory('eden','eden_cement');
@@ -7136,6 +7138,8 @@ export function cleanAddTrait(trait){
             global.civic.quarry_worker.workers = 0;
             global.civic.quarry_worker.assigned = 0;
             setResourceName('Stone');
+            removeFromRQueue(['hammer']);
+            removeFromQueue(['city-rock_quarry']);
             setPurgatory('tech','hammer');
             setPurgatory('city','rock_quarry');
             break;


### PR DESCRIPTION
It's possible to queue Rock Quarries or Cement Plants, then mimic Plant or Avian. This will then cause a TypeError in midLoop. This can be exploited in the Orbital Decay challenge to freeze the moon impact timer.

This can be fixed by calling removeFromQueue/removeFromRQueue when the relevant traits are added.