### PR TITLE
Add scrollbars to in-game custom lab traits tabs, remove spurious }

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -5156,6 +5156,14 @@ div.bigbang {
             }
         }
 
+        .b-tabs {
+            overflow-x: auto;
+            ul {
+                max-width: ~"calc(100% - 1rem)";
+                .hscroll
+            }
+        }
+
         .trait_selection {
             margin-top: .5rem;
             display: flex;

--- a/src/space.js
+++ b/src/space.js
@@ -7723,7 +7723,7 @@ export function ascendLab(hybrid,wiki){
             return;
         }
         let negative = '';
-        let trait_list_header = `<b-tab-item><template slot="header"><h2 class="is-sr-only">${loc(`genelab_traits_${tax}`)}}</h2><span aria-hidden="true">${loc(`genelab_traits_${tax}`)}</span></template>`;
+        let trait_list_header = `<b-tab-item><template slot="header"><h2 class="is-sr-only">${loc(`genelab_traits_${tax}`)}</h2><span aria-hidden="true">${loc(`genelab_traits_${tax}`)}</span></template>`;
         let trait_list = ``;
         Object.keys(taxomized[tax]).sort().forEach(function (trait){
             if (traits.hasOwnProperty(trait) && traits[trait].type === 'major'){


### PR DESCRIPTION
On my screen/browser (1536px wide by default), the "Summary" and "All" tab headers in the custom race lab aren't visible when ascending in-game. The only way to see them is to zoom out the browser. The included evolve.less changes will add a horizontal scrollbar if the tab headers overflow. The horizontal scrollbar will not be displayed if there is no overflow, as is the case when accessing the custom lab from the wiki. The scrollbar is styled to be similar to the one used for the message queue filters.

This PR also removes a spurious "}" that I found.