### PR TITLE
update wiki mechanics-gameplay-pillar explanation

### DIFF
--- a/src/wiki/hell.js
+++ b/src/wiki/hell.js
@@ -69,7 +69,7 @@ export function hellPage(content){
             2: ['1%',loc(`harmonic`)],
             3: ['3%'],
             4: [loc(`harmonic`),'2%','6%'],
-            5: [loc(`wiki_hell_pillar_para5d1`),12],
+            5: [loc(`wiki_hell_pillar_para5d1`),4,12,`${(Math.abs(1000 - towerSize()))}%`],
             6: [loc(`harmonic`),`${((harmonic[0] - 1) * 100).toFixed(0)}%`,`${((harmonic[1] - 1) * 100).toFixed(0)}%`],
         },
         data_link: {

--- a/src/wiki/mechanics.js
+++ b/src/wiki/mechanics.js
@@ -11,6 +11,7 @@ import { actions, structName } from './../actions.js';
 import { astroVal, astrologySign } from './../seasons.js';
 import { shipAttackPower, sensorRange, shipCrewSize, shipPower } from './../truepath.js';
 import { sideMenu, infoBoxBuilder, createRevealSection, createCalcSection, getSolarName } from './functions.js';
+import { towerSize } from '../portal.js';
 
 export function mechanicsPage(content){
     let mainContent = sideMenu('create',content);
@@ -664,7 +665,7 @@ export function mechanicsPage(content){
                 2: ['1%',loc(`harmonic`)],
                 3: ['3%'],
                 4: [loc(`harmonic`),'2%','6%'],
-                5: [loc(`wiki_hell_pillar_para5d1`),12]
+                5: [loc(`wiki_hell_pillar_para5d1`),4,12,`${(Math.abs(1000 - towerSize()))}`]
             },
             data_link: {
                 5: ['wiki.html#hell-structures-west_tower']

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -10940,7 +10940,7 @@
   "wiki_hell_pillar_para2": "This provides a stacking permanent bonus that gives you +%0 production bonus for each pillared species, called %1.",
   "wiki_hell_pillar_para3": "An additional +%0 bonus is gained if you have ever pillared your current species.",
   "wiki_hell_pillar_para4": "%0 also provides a storage bonus of %1 for each pillared species and %2 if the current species is pillared.",
-  "wiki_hell_pillar_para5": "Additionally, each activated pillar discounts the number of %0 segments you need to build to open the ancient gate by %1.",
+  "wiki_hell_pillar_para5": "Additionally, each activated pillar discounts the number of %0 segments you need to build to open the ancient gate by between %1 and %2, based on it's completed challenge level. You are currently receiving a total discount from pillars of %3 segments.",
   "wiki_hell_pillar_para5d1": "Tower",
   "wiki_hell_pillar_para6": "Your current %0 bonus is: %1 Production, %2 Storage.",
   "wiki_hell_spire": "The Hell Spire",


### PR DESCRIPTION
updating the wiki mechanics Pillar section to reflect the new way the Tower segment count per Pillar works, based on achievement level rather than flat number per pillar