### PR TITLE
Avoid overflow in foreign power level outputs

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -3223,7 +3223,7 @@ a {
 
             .glevel {
                 display: inline-block;
-                width: 8rem;
+                width: 12rem;
             }
 
             button {


### PR DESCRIPTION
When the text reads 'Above Average (137)', it does not fit within 8rem and therefore wraps to two lines. There is enough space for this text to be wider within the layout. (Tested at various widths and layout break-points.)

8rem is too narrow.  9rem is too narrow.  10rem is just wide enough, but does not have much room to grow.  12rem was chosen as a value which fits well in the layouts available (at different break-points), and might work for other languages too.  I have not tested with languages other than English.

Before:
<img width="299" height="147" alt="Screenshot_2025-11-28_17-59-02" src="https://github.com/user-attachments/assets/e61a77a3-686e-4ef5-a83b-efd328be38ca" />

After:
<img width="325" height="124" alt="Screenshot_2025-11-28_17-59-34" src="https://github.com/user-attachments/assets/3456b330-8904-467d-bd03-67e8729a9341" />
