### PR TITLE
Improve Accessibility of Andromeda Armada Display

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -7496,10 +7496,11 @@ function armada(parent,id){
                 for (let i = 0; i < gatewayArmada.length; i++){
                     const ship = gatewayArmada[i];
                     if (global.galaxy.hasOwnProperty(ship)){
+                        let areaLabel = typeof galaxyProjects[area].info.name === 'string' ? galaxyProjects[area].info.name : galaxyProjects[area].info.name();
                         let shipSpan = $(`<span class="ship"></span>`);
-                        let sub = $(`<span role="button" aria-label="remove ${ship}" class="sub has-text-danger" @click="sub('${area}','${ship}')"><span>&laquo;</span></span>`);
+                        let sub = $(`<span role="button" aria-label="remove ${loc('galaxy_' + ship)} from ${areaLabel}" class="sub has-text-danger" @click="sub('${area}','${ship}')"><span>&laquo;</span></span>`);
                         let count = $(`<span class="current">{{ ${r}.${ship} }}</span>`);
-                        let add = $(`<span role="button" aria-label="add ${ship}" class="add has-text-success" @click="add('${area}','${ship}')"><span>&raquo;</span></span>`);
+                        let add = $(`<span role="button" aria-label="add ${loc('galaxy_' + ship)} to ${areaLabel}" class="add has-text-success" @click="add('${area}','${ship}')"><span>&raquo;</span></span>`);
                         cols[i+1].append(shipSpan);
                         shipSpan.append(sub);
                         shipSpan.append(count);

--- a/src/space.js
+++ b/src/space.js
@@ -7477,11 +7477,15 @@ function armada(parent,id){
 
         cols[0].append($(`<span></span>`));
         cols[0].append($(`<span id="armadagateway" class="has-text-danger">${galaxyProjects.gxy_gateway.info.name}</span>`));
+        cols[0].attr('aria-hidden', 'true');
 
         for (let i = 0; i < gatewayArmada.length; i++){
             const ship = gatewayArmada[i];
             if (global.galaxy.hasOwnProperty(ship)){
-                cols[i+1].append($(`<span id="armada${ship}" class="ship has-text-advanced">${typeof galaxyProjects.gxy_gateway[ship].title === 'string' ? galaxyProjects.gxy_gateway[ship].title : galaxyProjects.gxy_gateway[ship].title()}</span>`));
+                let shipTitle = typeof galaxyProjects.gxy_gateway[ship].title === 'string' ? galaxyProjects.gxy_gateway[ship].title : galaxyProjects.gxy_gateway[ship].title();
+                cols[i+1].append($(`<h4 class="is-sr-only">${shipTitle} class</h4>`));
+                cols[i+1].append($(`<span class="is-sr-only">${typeof galaxyProjects.gxy_gateway.info.name === 'string' ? galaxyProjects.gxy_gateway.info.name : galaxyProjects.gxy_gateway.info.name()}: </span>`));
+                cols[i+1].append($(`<span id="armada${ship}" class="ship has-text-advanced" aria-hidden="true">${shipTitle}</span>`));
                 cols[i+1].append($(`<span class="ship">{{ gateway.${ship} }}</span>`));
             }
         }


### PR DESCRIPTION
The current controls for Andromeda ships are confusing when navigating with a screen reader, since it's supposed to visually be a grid (I believe). The changes in this PR improve things, at least during my testing. All changes only change the aria or the contents of "is-sr-only" elements, so I am pretty sure nothing changes visually.

1. `is-sr-only` h4 elements are placed before the columns of each ship type with movement controls.
2. Another `is-sr-only` span is added after the h4 elements to better signify that the next number represents the count of that type of ship in the Gateway System.
3. The column consisting of available systems is now hidden using "aria-hidden", as it was simply read as a list of names and was therefore unhelpful for screen readers.
4. Adds the target system's name to the ARIA labels for the buttons used to move ships within Andromeda. Which is to say, the labels now indicate the system a ship will be removed from or added to.
5. The labels also now use the proper, localized names of the ships instead of their internal identifiers.
