### PR TITLE
Add Planet and Universe Screen Reader Description Buttons

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -6831,6 +6831,9 @@ export function setPlanet(opt){
 
     $('#evolution').append(parent);
 
+    let srDescButton = $(`<a class="is-sr-only" role="button">${title} description</a>`);
+    $('#evolution').append(srDescButton);
+
     let popper = false;
     let gecked = 0;
     popover(id,function(obj){
@@ -6873,6 +6876,7 @@ export function setPlanet(opt){
             }
             title = `${traits}${biomes[biome].label} ${num}`;
             $(`#${id} .aTitle`).html(title);
+            srDescButton.html(title + ' description');
             gecked++;
             global.race.geck--;
             if (!global.race.hasOwnProperty('gecked')){
@@ -6901,6 +6905,10 @@ export function setPlanet(opt){
         }
     });
 
+    srDescButton.on('click', function() {
+        srPlanetDesc(title, biome, orbit, trait, geology, gecked);
+    });
+
     return custom ? custom : (biome === 'eden' ? 'hellscape' : biome);
 }
 
@@ -6921,6 +6929,31 @@ function planetDesc(obj,title,biome,orbit,trait,geology,gecked){
         obj.popper.append($(`<div class="has-text-special">${loc(`rejuvenated`)}</div>`));
     }
     return undefined;
+}
+
+function srPlanetDesc(title,biome,orbit,trait,geology,gecked){
+    let desc = '';
+    desc = desc + `<div>${loc('set_planet',[title,biomes[biome].label,orbit])}</div>`;
+    desc = desc + `<div>${biomes[biome].desc}</div>`;
+    if (trait.length > 0){
+        trait.forEach(function(t){
+            desc = desc + `<div>${planetTraits[t].desc}</div>`;
+        });
+    }
+
+    let pg = planetGeology(geology);
+    if (pg.length > 0){
+        // modify geology text to have it be spoken better
+        pg = pg.replaceAll(': <span', '<span');
+        pg = pg.replaceAll('</span></div>', ',</span></div>'); // add commas after each list item
+        pg = pg.replace(/,(?!.*,)/, '.'); // replace trailing comma with period
+
+        desc = desc + `<div>${pg}</div>`;
+    }
+    if (gecked && gecked > 0){
+        desc = desc + `<div class="has-text-special">${loc(`rejuvenated`)}</div>`;
+    }
+    srSpeak(desc);
 }
 
 function buildPlanet(aspect,opt,args){

--- a/src/space.js
+++ b/src/space.js
@@ -1,4 +1,4 @@
-import { save, global, seededRandom, webWorker, keyMultiplier, sizeApproximation, p_on, support_on, int_on, gal_on } from './vars.js';
+import { save, global, seededRandom, webWorker, keyMultiplier, sizeApproximation, p_on, support_on, int_on, gal_on, srSpeak } from './vars.js';
 import { vBind, messageQueue, clearElement, popover, clearPopper, flib, powerModifier, powerCostMod, calcPrestige, spaceCostMultiplier, darkEffect, eventActive, calcGenomeScore, randomKey, getTraitDesc, deepClone, get_qlevel, timeFormat } from './functions.js';
 import { unlockAchieve, unlockFeat, universeAffix } from './achieve.js';
 import { races, traits, genus_def, genusVars, planetTraits, biomes, traitCostMod } from './races.js';
@@ -7713,11 +7713,22 @@ export function setUniverse(){
 
         $('#evolution').append(parent);
 
+        let srDescButton = $(`<a class="is-sr-only" role="button">${universe_types[universe].name} description</a>`);
+        $('#evolution').append(srDescButton);
+
         $('#'+id).on('click',function(){
             global.race['universe'] = universe;
             clearElement($('#evolution'));
             genPlanets();
             clearPopper();
+        });
+
+        srDescButton.on('click',function(){
+            let desc = '';
+            desc = desc + universe_types[universe].name + ' universe: ';
+            desc = desc + universe_types[universe].desc + '. ';
+            desc = desc + universe_types[universe].effect + '.';
+            srSpeak(desc);
         });
 
         popover(id,function(obj){


### PR DESCRIPTION
Most selectable / purchasable items have visually hidden buttons which read their tooltips aloud. One of the current exceptions is new planets and universes, which this PR adds. Planet description buttons are especially helpful since the tooltips contain a lot of info needed for selecting one that screen readers are inconsistent in reading.

Codewise, the biggest change aside from the creation of the buttons themselves was a new function, "srPlanetDesc", which was added. It is essentially a modified version of "planetDesc" but reads the text aloud instead, and contains a few text modifications to improve how the text is read aloud.
