### PR TITLE
BugFix: Correct Interaction Between Scanvenger and Optical Power: Telekinesis

### DIFF
--- a/src/jobs.js
+++ b/src/jobs.js
@@ -160,6 +160,9 @@ export const job_desc = {
         if (global.city.ptrait.includes('trashed') && global.race['scavenger']){
             scavenger *= 1 + (traits.scavenger.vars()[1] / 100);
         }
+        if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.t){
+            scavenger *= 1 + (traits.ocular_power.vars()[1] / 500);
+        }
         if (global.race['high_pop'] && !servant){
             scavenger *= traits.high_pop.vars()[1] / 100;
         }

--- a/src/main.js
+++ b/src/main.js
@@ -1042,6 +1042,9 @@ function fastLoop(){
             if (global.city.ptrait.includes('trashed')){
                 bonus *= planetTraits.trashed.vars()[1];
             }
+            if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.t){
+                bonus *= 1 + (traits.ocular_power.vars()[1] / 500);
+            }
             if (global.race['high_pop']){
                 bonus = highPopAdjust(bonus);
             }

--- a/src/races.js
+++ b/src/races.js
@@ -6653,7 +6653,7 @@ export function racialTrait(workers,type){
         modifier *= 1.25;
     }
     if (global.race['ocular_power'] && global.race['ocularPowerConfig'] && global.race.ocularPowerConfig.t 
-        && ['farmer','miner','lumberjack','scavenger','factory'].includes(type)){
+        && ['farmer','miner','lumberjack','factory'].includes(type)){
         let labor = 20 * (traits.ocular_power.vars()[1] / 100);
         modifier *= 1 + (labor / 100);
     }


### PR DESCRIPTION
Current State: Optical Power: Telekinesis attempts to set a bonus for scavenger, but cannot do so due to incompatibility related to the function that sets trait bonuses for jobs and the scavenger job.

New State: Optical Power: Telekinesis sets a bonus of 20% of optical power, as intended. Code has been added directly to the jobs.js and main.js files where other bonuses for scavenger are applied.

Basic testing confirms that it is working as intended.