### PR TITLE
Fix interaction between Sky Lover and Elysium Miner

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3000,7 +3000,7 @@ function fastLoop(){
                         workers /= traits.high_pop.vars()[0];
                     }
 
-                    if (global.race['sky_lover'] && ['miner','coal_miner','crystal_miner','pit_miner'].includes(job)){
+                    if (global.race['sky_lover'] && ['miner','coal_miner','crystal_miner','pit_miner','elysium_miner'].includes(job)){
                         workers *= 1 + (traits.sky_lover.vars()[0] / 100);
                     }
 


### PR DESCRIPTION
Previously, Sky Lover did not apply the morale penalty to Elysium Miners. This is fixed with this commit.

Sky Lover also does not impact the Quarry Worker, but I thought this was intended so it has not been changed.