### PR TITLE
Diminishing Returns on Linked

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1240,10 +1240,11 @@ export function calcQuantumLevel(load){
         }
         if (global.race['linked']){
             let factor = traits.linked.vars()[0] / 100 * global.resource[global.race.species].amount;
-            if (factor > traits.linked.vars()[1] / 100){
-                factor -= traits.linked.vars()[1] / 100;
-                factor = factor / (factor + 200 - traits.linked.vars()[1]);
-                factor += traits.linked.vars()[1] / 100;
+            let softCapFactor = traits.linked.vars()[1] / 100;
+            if (factor > softCapFactor){
+                factor -= softCapFactor;
+                factor = factor * softCapFactor / (2 * (factor + softCapFactor));
+                factor += softCapFactor;
             }
             qbits *= 1 + factor;
         }

--- a/src/functions.js
+++ b/src/functions.js
@@ -1243,7 +1243,7 @@ export function calcQuantumLevel(load){
             let softCapFactor = traits.linked.vars()[1] / 100;
             if (factor > softCapFactor){
                 factor -= softCapFactor;
-                factor = factor * softCapFactor / (2 * (factor + softCapFactor));
+                factor = factor * softCapFactor / (factor + softCapFactor);
                 factor += softCapFactor;
             }
             qbits *= 1 + factor;

--- a/src/races.js
+++ b/src/races.js
@@ -4170,19 +4170,19 @@ export const traits = {
             // [Quantum Bonus per Citizen, Softcap]
             switch (r || traitRank('linked') || 1){
                 case 0.1:
-                    return [0.02,40];
+                    return [0.02,22];
                 case 0.25:
-                    return [0.03,40];
+                    return [0.03,22];
                 case 0.5:
-                    return [0.05,40];
+                    return [0.06,22];
                 case 1:
-                    return [0.1,80];
+                    return [0.10,45];
                 case 2:
-                    return [0.12,100];
+                    return [0.12,55];
                 case 3:
-                    return [0.14,100];
+                    return [0.14,55];
                 case 4:
-                    return [0.15,100];
+                    return [0.16,55];
             }
         }
     },


### PR DESCRIPTION
The Linked trait has a diminshing returns calculation. But I'm not sure that it's working as intended.

In many places in Evolve, numbers are transformed back and forth between a percentage (100 meaning 100%) and a factor (1 meaning 100%).

In the diminishing returns formula for Linked, it appears that the extra factor over the soft cap was intended to be input as a percentage, because the other numbers involved are represented in percentages (a flat amount of 200 and the percentage value of the cap, which is 80 at rank 1).

However, at this point in the calculation, the value is already represented as a factor! This means that the diminishing returns are so punishing that at rank 1, the 80% cap is reached at 800 population, but even by the time 3000 population is reached the effect of linked has not yet risen to 82%!

At this point, there may as well just be a hard cap instead of diminishing returns, so I'm not sure why the diminishing returns were implemented at all, unless this was unintended and the numbers were all meant to be in the same scale (all percentages, or all factors).

It looks like the current setup attempts to scale asymptotically to (soft cap + 100%), with higher ranks getting faster scaling. Implementing this exact change would probably make Linked too powerful, as it is already considered strong in its current state with the unintendedly harsh diminishing returns.

So I propose that we instead attempt asymptotic scaling to 1.5 times the soft cap, with the scaling halving at the same number that is required to get to the soft cap. This change is implemented here. This means that every time you double your population after the soft cap, you get 50% closer to reaching 1.5 times the soft cap.

You can see some modeling of what this looks like over the first 3000 population at rank 1 here with a chart:

https://docs.google.com/spreadsheets/d/19kp9VDfOcciSLXnxw1PInQMd3DtmKqAj8l0EseEoGUY/edit?usp=sharing

I also noticed that the effect of Linked is not scaled for High Population. I am unsure if this is intended or not.