### PR TITLE
Fix cases when changing traits wouldn't update some resource names.

### DIFF
--- a/src/races.js
+++ b/src/races.js
@@ -7078,6 +7078,7 @@ export function cleanAddTrait(trait){
                 break;
             }
             purgeLumber();
+            setResourceName('Useless');
             break;
         case 'smoldering':
             global.resource.Chrysotile.display = true;
@@ -7085,6 +7086,7 @@ export function cleanAddTrait(trait){
                 break;
             }
             purgeLumber();
+            setResourceName('Useless');
             break;
         case 'iron_wood':
             if (global.race['smoldering']){
@@ -7120,6 +7122,7 @@ export function cleanAddTrait(trait){
         case 'flier':
             setResourceName('Stone');
             setResourceName('Brick');
+            defineGovernor(); // Rename resource in storage balance config
             global.resource.Cement.display = false;
             global.civic.cement_worker.display = false;
             global.civic.cement_worker.workers = 0;
@@ -7136,6 +7139,7 @@ export function cleanAddTrait(trait){
             global.civic.quarry_worker.workers = 0;
             global.civic.quarry_worker.assigned = 0;
             setResourceName('Stone');
+            defineGovernor(); // Rename resource in storage balance config
             setPurgatory('tech','hammer');
             setPurgatory('city','rock_quarry');
             break;
@@ -7354,9 +7358,10 @@ export function cleanRemoveTrait(trait,rank){
             if ((global.tech['axe'] || global.tech['reclaimer']) && !global.race['orbit_decayed']){
                 global.civic.lumberjack.display = true;
             }
+            setResourceName('Useless');
             break;
         case 'smoldering':
-            releaseResource('Chrysotile')
+            releaseResource('Chrysotile');
             if (global.race['kindling_kindred']){
                 break;
             }
@@ -7376,6 +7381,7 @@ export function cleanRemoveTrait(trait,rank){
             if ((global.tech['axe'] || global.tech['reclaimer']) && !global.race['orbit_decayed']){
                 global.civic.lumberjack.display = true;
             }
+            setResourceName('Useless');
             break;
         case 'iron_wood':
             if (global.tech['foundry']){
@@ -7399,6 +7405,7 @@ export function cleanRemoveTrait(trait,rank){
         case 'flier':
             setResourceName('Stone');
             setResourceName('Brick');
+            defineGovernor(); // Rename resource in storage balance config
             checkPurgatory('tech','cement');
             if (global.tech['cement']){
                 checkPurgatory('city','cement_plant');
@@ -7409,6 +7416,7 @@ export function cleanRemoveTrait(trait,rank){
             break;
         case 'sappy':
             setResourceName('Stone');
+            defineGovernor(); // Rename resource in storage balance config
             checkPurgatory('tech','hammer');
             if (global.tech['mining'] >= 1) {
                 checkPurgatory('city','rock_quarry',{ count: 0, asbestos: 0 });


### PR DESCRIPTION
- Rename Useless resource (wish) between chrysotile and lumber when gaining/losing smoldering.
- Rename Stone in governor crate management ui when gaining/losing sappy/flier.