### PR TITLE
Fix for Thermite error during summer event

### DIFF
--- a/src/resources.js
+++ b/src/resources.js
@@ -742,6 +742,7 @@ export function defineResources(wiki){
     loadResource('Nanoweave',wiki,-1,0,false,false,'danger');
     loadResource('Scarletite',wiki,-1,0,false,false,'danger');
     loadResource('Quantium',wiki,-1,0,false,false,'danger');
+    loadResource('Thermite',wiki,-1,0,false,false,'danger');
     loadResource('Corrupt_Gem',wiki,-2,0,false,false,'caution');
     loadResource('Codex',wiki,-2,0,false,false,'caution');
     loadResource('Cipher',wiki,0,1,false,false,'caution');


### PR DESCRIPTION
The summer event is causing issues with the game which prevents people from playing due to the Thermite value not being initialized at all. This patch fixes that.
