### PR TITLE
Assortment of fixes for mobile interface

### DIFF
--- a/src/evolve.less
+++ b/src/evolve.less
@@ -5785,7 +5785,6 @@ div.bigbang {
     // Stack columns vertically, full width, minimal side margins
     .main {
         margin: 0.75rem;
-        overflow-y: unset;
 
         .content {
             .settings {
@@ -5818,8 +5817,9 @@ div.bigbang {
 
         .resTabs {
             > section {
-                top: 0.75rem;
-                height: calc(100vh - 10.1rem);
+                position: static !important;
+                overflow-y: auto !important;
+                overflow-x: hidden !important;
             }
 
             > .tab-content {
@@ -5827,15 +5827,40 @@ div.bigbang {
             }
         }
 
+        .govTabs2 {
+            > section {
+                position: static !important;
+                overflow-y: auto !important;
+                overflow-x: hidden !important;
+            }
+        }
+
         .civics {
             padding: 0;
+        }
+
+        .job .controls {
+            flex: none;
+            white-space: nowrap;
+        }
+
+        .theme,
+        .localization,
+        .queue {
+            span, .dropdown {
+                vertical-align: middle;
+                margin-right: 0.2rem;
+            }
         }
 
         #mainTabs {
             > .tab-content {
 
-                #settings {
-                    padding-bottom: 1rem !important; // makes sure the settings tab content doesn't get cut off at the bottom of the screen
+                #settings,
+                #evolution {
+                    position: static !important;
+                    overflow-y: auto !important;
+                    overflow-x: hidden !important;
                 }
             }
         }
@@ -5938,11 +5963,6 @@ div.bigbang {
 
             #sideQueue {
                 display: block;
-
-                #msgQueue {
-                    height: auto;
-                    overflow-y: visible;
-                }
             }
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1375,26 +1375,6 @@ export function index(){
         $(this).addClass('is-active');
     });
 
-    // Keep #mobileNav and .promoBar visually anchored when browser toolbars toggle or user zooms.
-    // visualViewport tracks the *visible* window; position:fixed tracks the layout viewport —
-    // when they diverge (toolbar changes, zoom) we correct with a CSS transform offset.
-    if ('visualViewport' in window) {
-        const $navBar = $('#mobileNav');
-        const $promoBar = $('.promoBar');
-
-        const syncFixedToViewport = () => {
-            const vv = window.visualViewport;
-            // How many px the visual viewport is inset from the bottom of the layout viewport
-            const offsetFromBottom = window.innerHeight - (vv.height + vv.offsetTop);
-            const translateY = -Math.round(Math.max(0, offsetFromBottom));
-            $navBar.css('transform', `translateY(${translateY}px)`);
-            $promoBar.css('transform', `translateY(${translateY}px)`);
-        };
-
-        window.visualViewport.addEventListener('resize', syncFixedToViewport);
-        window.visualViewport.addEventListener('scroll', syncFixedToViewport);
-    }
-
     // Bottom Bar
     $('body').append(`
         <div class="promoBar">
@@ -1418,4 +1398,47 @@ export function index(){
             </span>
         </div>
     `);
+
+    if ('visualViewport' in window) {
+        const $navBar = $('#mobileNav');
+        const $promoBar = $('.promoBar');
+
+        const syncFixedToViewport = () => {
+            const vv = window.visualViewport;
+            if (vv.scale !== 1) {
+                return;
+            }
+            const offsetFromBottom = window.innerHeight - (vv.height + vv.offsetTop);
+            const translateY = -Math.round(Math.max(0, offsetFromBottom));
+            $navBar.css('transform', `translateY(${translateY}px)`);
+            $promoBar.css('transform', `translateY(${translateY}px)`);
+        };
+
+        syncFixedToViewport();
+        window.visualViewport.addEventListener('resize', syncFixedToViewport);
+    }
+
+    // Mobile self-scrolling panels (#settings, #evolution, resTabs/govTabs2 sections) get
+    // their height set here instead of a CSS calc(): measure each panel's actual
+    // top position and size it to reach exactly to the bottom bar, on any screen/nesting.
+    const sizeScrollPanels = () => {
+        if (window.innerWidth > 768) {
+            return;
+        }
+        const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
+        const barsPx = 3.7 * remPx;
+        document.querySelectorAll('#settings, #evolution, .resTabs > section, .govTabs2 > section').forEach((el) => {
+            if (!el.offsetParent) {
+                return;
+            }
+            const top = el.getBoundingClientRect().top;
+            el.style.height = `${Math.max(0, window.innerHeight - top - barsPx)}px`;
+        });
+    };
+
+    sizeScrollPanels();
+    window.addEventListener('resize', sizeScrollPanels);
+    // Re-measure after any click (tab switches, panel switches) — delayed past the 300ms
+    // slide-transition so we measure the settled position, not mid-animation.
+    document.addEventListener('click', () => setTimeout(sizeScrollPanels, 400));
 }


### PR DESCRIPTION
Fixes a series of bugs in the current mobile UI.

1. Aligns the settings textboxes with their dropdown menus, when one is associated with it. They now display aligned to the center of the dropdown, not the top. Note: this bug exists in Desktop as well, I opted to apply the fix only to mobile though since it's not noticeable on Desktop browsers.
2. Government tab fixes: the government tab was displaying very awkwardly, with several parts of the content being hidden and the employment +/- buttons breaking lines. This has been fixed.
3. Navbar and Promobar have been affixed to the bottom of the screen where they belong. Previously they were uhh, moving around the screen when zooming in/out, and that caused all kinds of shenanigans. Their behavior now mirrors the behavior on Desktop.
4. Fixed page size to exactly the size of the display screen, as it is on Desktop. The page can no longer be scrolled around, but rather sizes itself appropriately from the start.
5. Tab panels have been fixed to scroll correctly. They were rendering a part of the contents behind the Navbar/Promobar, which made those contents inaccessible. Their behavior now mirrors that of Desktop.

I tested the changes on both a Galaxy Tab 6 and a Pixel phone.

Notes:
- The `!important` flags used here and there in the CSS aren't great. Ideally, each stylesheet should load independently based on the environment the game is running on. I opted to use `!important` here so I could keep to the existing pattern of inheriting some of the desktop behavior, so that it would be overridden where appropriate.
- I changed the `index.js` navbar logic for mobile to run _after_ the promobar is loaded. Since the navbar is anchored to the promobar, loading its javascript above the promobar (where it sits on screen) ends up with it anchoring to a non-existent object, and JavaScript breaks down into all kinds of shenanigans.
- I added panel size calculations into `index.js` (moved out from `evolve.less`) so that they could be truly, fully relative, rather than requiring some finagling of magic numbers that might not work on certain screen sizes.