### PR TITLE
New bluecollar should boost factories, not cement

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3286,20 +3286,30 @@ export const actions = {
             },
             effect(wiki){
                 let xeno = global.tech['monument'] && global.tech.monument >= 3 && isStargateOn(wiki) ? 3 : 1;
-                let amp = (global.civic.govern.type === 'corpocracy' ? 2 : 1) * xeno;
-                let cas = (global.civic.govern.type === 'corpocracy' ? 10 : 5) * xeno;
-                let mon = (global.civic.govern.type === 'corpocracy' ? 4 : 2) * xeno;
+                let modifier = xeno;
+                if (global.civic.govern.type === 'corpocracy'){
+                    modifier *= 1 + (govEffect.corpocracy()[2] / 100);
+                }
+                else if (global.civic.govern.type === 'socialist'){
+                    modifier *= 1 - (govEffect.socialist()[3] / 100);
+                }
+
+                let amp = +(1 * modifier).toFixed(2);
+                let cas = +(5 * modifier).toFixed(2);
+                let mon = +(2 * modifier).toFixed(2);
+                let trd = +(3 * modifier).toFixed(2);
 
                 let desc = `<div class="has-text-caution">${loc('city_tourist_center_effect1',[global.resource.Food.name])}</div>`;
                 desc += `<div>${loc('city_tourist_center_effect2',[amp,actions.city.amphitheatre.title()])}</div>`;
                 desc += `<div>${loc('city_tourist_center_effect2',[cas,structName('casino')])}</div>`;
                 desc += `<div>${loc('city_tourist_center_effect2',[mon,loc(`arpa_project_monument_title`)])}</div>`;
                 if (global.stats.achieve['banana'] && global.stats.achieve.banana.l >= 4){
-                    desc += `<div>${loc(`city_tourist_center_effect2`,[(global.civic.govern.type === 'corpocracy' ? 6 : 3) * xeno, loc('city_trade')])}</div>`;
+                    desc += `<div>${loc(`city_tourist_center_effect2`,[trd, loc('city_trade')])}</div>`;
                 }
                 let piousVal = govActive('pious',1);
                 if (piousVal){
-                    desc += `<div>${loc(`city_tourist_center_effect2`,[(global.civic.govern.type === 'corpocracy' ? (piousVal * 2) : piousVal) * xeno, structName('temple')])}</div>`;
+                    piousVal *= modifier;
+                    desc += `<div>${loc(`city_tourist_center_effect2`,[piousVal, structName('temple')])}</div>`;
                 }
 
                 return desc;

--- a/src/civics.js
+++ b/src/civics.js
@@ -1063,14 +1063,8 @@ function taxCap(min){
     }
     else {
         let cap = 30;
-        if (global.race['noble']){
-            cap = traits.noble.vars()[1];
-        }
-        else if (extreme || global.race['terrifying']){
+        if (extreme || global.race['terrifying']){
             cap += 20;
-        }
-        if (global.civic.govern.type === 'oligarchy'){
-            cap += govEffect.oligarchy()[1];
         }
         let aristoVal = govActive('aristocrat',1);
         if (aristoVal){
@@ -1078,6 +1072,13 @@ function taxCap(min){
         }
         if (global.race['wish'] && global.race['wishStats']){
             cap += global.race.wishStats.tax;
+        }
+        // The trait "Noble" overrides extreme taxation policy (/ terrifying), governors, and wish, but not oligarchy
+        if (global.race['noble']){
+            cap = traits.noble.vars()[1];
+        }
+        if (global.civic.govern.type === 'oligarchy'){
+            cap += govEffect.oligarchy()[1];
         }
         return cap;
     }
@@ -1089,30 +1090,14 @@ function adjustTax(a,n){
             {
                 let inc = n || keyMultiplier();
                 let cap = taxCap(false);
-                if (global.race['noble']){
-                    global.civic.taxes.tax_rate += inc;
-                    if (global.civic.taxes.tax_rate > (global.civic.govern.type === 'oligarchy' ? traits.noble.vars()[1] + 20 : traits.noble.vars()[1])){
-                        global.civic.taxes.tax_rate = global.civic.govern.type === 'oligarchy' ? traits.noble.vars()[1] + 20 : traits.noble.vars()[1];
-                    }
-                }
-                else if (global.civic.taxes.tax_rate < cap){
-                    global.civic.taxes.tax_rate += inc;
-                    if (global.civic.taxes.tax_rate > cap){
-                        global.civic.taxes.tax_rate = cap;
-                    }
-                }
+                global.civic.taxes.tax_rate = Math.min(cap, global.civic.taxes.tax_rate + inc);
             }
             break;
         case 'sub':
             {
                 let dec = n || keyMultiplier();
                 let min = taxCap(true);
-                if (global.civic.taxes.tax_rate > min){
-                    global.civic.taxes.tax_rate -= dec;
-                    if (global.civic.taxes.tax_rate < min){
-                        global.civic.taxes.tax_rate = min;
-                    }
-                }
+                global.civic.taxes.tax_rate = Math.max(min, global.civic.taxes.tax_rate - dec);
             }
             break;
     }

--- a/src/governor.js
+++ b/src/governor.js
@@ -2,7 +2,7 @@ import { global, seededRandom, p_on, breakdown } from './vars.js';
 import { vBind, popover, tagEvent, calcQueueMax, calcRQueueMax, clearElement, adjustCosts, decodeStructId, timeCheck, arpaTimeCheck, hoovedRename, buildQueue } from './functions.js';
 import { races } from './races.js';
 import { actions, checkCityRequirements, housingLabel, wardenLabel, updateQueueNames, checkAffordable, checkCosts, drawTech, drawCity } from './actions.js';
-import { govCivics, govTitle } from './civics.js';
+import { govCivics, govTitle, govEffect } from './civics.js';
 import { crateGovHook, atomic_mass } from './resources.js';
 import { gridDefs, dualReplicator } from './industry.js';
 import { checkHellRequirements, mechSize, mechCost, validWeapons, validEquipment } from './portal.js';

--- a/src/governor.js
+++ b/src/governor.js
@@ -192,7 +192,10 @@ export const gov_traits = {
         effect(b,wiki){
             let val = $(this)[0].vars(b)[1];
             let xeno = global.tech['monument'] && global.tech.monument >= 3 && isStargateOn(wiki) ? 3 : 1;
-            val = (global.civic.govern.type === 'corpocracy' ? (val * 2) : val) * xeno;
+            val *= xeno;
+            if (global.civic.govern.type === 'corpocracy'){
+                val *= 1 + (govEffect.corpocracy()[2] / 100);
+            }
             return loc(`gov_trait_pious_effect`,[$(this)[0].vars(b)[0],val]);
         },
         vars(b){ 

--- a/src/industry.js
+++ b/src/industry.js
@@ -9,6 +9,7 @@ import { fortressTech } from './portal.js';
 import { edenicTech } from './edenic.js';
 import { checkPathRequirements } from './truepath.js';
 import { highPopAdjust, production } from './prod.js';
+import { govEffect } from './civics.js';
 
 export function loadIndustry(industry,parent,bind){
     switch (industry){
@@ -810,10 +811,10 @@ export function luxGoodPrice(demand){
         demand *= 1 + (traits.toxic.vars(1)[0] / 100 * fathom);
     }
     if (global.civic.govern.type === 'corpocracy'){
-        demand *= 2.5;
+        demand *= 1 + (govEffect.corpocracy()[1] / 100);
     }
     if (global.civic.govern.type === 'socialist'){
-        demand *= 0.8;
+        demand *= 1 - (govEffect.socialist()[3] / 100);
     }
     if (global.stats.achieve['iron_will'] && global.stats.achieve.iron_will.l >= 2){
         demand *= 1.1;

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -236,7 +236,7 @@ export const job_desc = {
             interest *= 1 - (traits.truthful.vars()[0] / 100);
         }
         if (global.civic.govern.type === 'republic'){
-            interest *= 1.25;
+            interest *= 1 + (govEffect.republic()[0] / 100);
         }
         if (global.race['high_pop']){
             interest *= traits.high_pop.vars()[1] / 100;
@@ -290,7 +290,7 @@ export const job_desc = {
             professor *= 1 + (templeCount() * 0.05);
         }
         if (global.civic.govern.type === 'theocracy'){
-            professor *= 0.75;
+            professor *= 1 - (govEffect.theocracy()[1] / 100);
         }
         professor = +professor.toFixed(2);
         return loc('job_professor_desc',[professor]);
@@ -305,7 +305,7 @@ export const job_desc = {
             impact *= 1 + (global.space.satellite.count * 0.01);
         }
         if (global.civic.govern.type === 'theocracy'){
-            impact *= global.tech['high_tech'] && global.tech['high_tech'] >= 12 ? ( global.tech['high_tech'] >= 16 ? 0.75 : 0.6 ) : 0.5;
+            impact *= 1 - (govEffect.theocracy()[2] / 100);
         }
         impact = +impact.toFixed(2);
         return global.race.universe === 'magic' ? loc('job_wizard_desc',[impact,+(0.025 * darkEffect('magic')).toFixed(4)]) : loc('job_scientist_desc',[impact]);

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -3,7 +3,7 @@ import { vBind, clearElement, popover, darkEffect, eventActive, easterEgg, getHa
 import { loc } from './locale.js';
 import { highPopAdjust } from './prod.js';
 import { racialTrait, servantTrait, races, traits, biomes, planetTraits, fathomCheck } from './races.js';
-import { armyRating } from './civics.js';
+import { armyRating, govEffect } from './civics.js';
 import { govActive } from './governor.js';
 import { craftingRatio, craftCost, craftingPopover } from './resources.js';
 import { planetName } from './space.js';

--- a/src/main.js
+++ b/src/main.js
@@ -5020,10 +5020,6 @@ function fastLoop(){
             if (global.civic.govern.type === 'socialist'){
                 factory_output *= 1 + (govEffect.socialist()[1] / 100);
             }
-            let dirtVal = govActive('dirty_jobs',2);
-            if (dirtVal){
-                factory_output *= 1 + (dirtVal / 100);
-            }
 
             let powered_mult = 1;
             let power_single = 1;

--- a/src/main.js
+++ b/src/main.js
@@ -3360,11 +3360,14 @@ function fastLoop(){
         if (global.civic.govern.type === 'anarchy'){
             stress /= 2;
         }
-        if (global.civic.govern.type === 'autocracy'){
+        else if (global.civic.govern.type === 'autocracy'){
             stress *= 1 + (govEffect.autocracy()[0] / 100);
         }
-        if (global.civic.govern.type === 'socialist'){
+        else if (global.civic.govern.type === 'socialist'){
             stress *= 1 + (govEffect.socialist()[2] / 100);
+        }
+        else if (global.civic.govern.type === 'dictator'){
+            stress *= 1 + (govEffect.dictator()[0] / 100);
         }
         if (global.race['emotionless']){
             stress *= 1 - (traits.emotionless.vars()[1] / 100);
@@ -3375,9 +3378,6 @@ function fastLoop(){
             }
         }
 
-        if (global.civic.govern.type === 'dictator'){
-            stress *= 1 + (govEffect.dictator()[0] / 100);
-        }
 
         stress = +(stress).toFixed(1);
         global.city.morale.stress = stress;

--- a/src/prod.js
+++ b/src/prod.js
@@ -606,6 +606,10 @@ export function factoryBonus(factory){
     if (global.civic.govern.type === 'socialist'){
         factory *= 1 + (govEffect.socialist()[1] / 100);
     }
+    let dirtVal = govActive('dirty_jobs', 2);
+    if (dirtVal){
+        factory *= 1 + (dirtVal / 100);
+    }
     if (global.stats.achieve['iron_will'] && global.stats.achieve.iron_will.l >= 2){
         factory *= 1.1;
     }

--- a/src/prod.js
+++ b/src/prod.js
@@ -243,10 +243,10 @@ export function production(id,val,wiki){
         {
             let vitreloy = 0.18;
             if (global.civic.govern.type === 'corpocracy'){
-                vitreloy *= global.tech['high_tech'] && global.tech['high_tech'] >= 16 ? 1.4 : 1.3;
+                vitreloy *= 1 + (govEffect.corpocracy()[4] / 100);
             }
             if (global.civic.govern.type === 'socialist'){
-                vitreloy *= 1.1;
+                vitreloy *= 1 + (govEffect.socialist()[1] / 100);
             }
             return vitreloy;
         }

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -2,7 +2,7 @@ import { global, p_on, support_on, sizeApproximation, keyMap, seededRandom } fro
 import { vBind, clearElement, popover, clearPopper, messageQueue, powerCostMod, powerModifier, spaceCostMultiplier, deepClone, calcPrestige, flib, darkEffect, adjustCosts, get_qlevel, timeCheck, timeFormat, buildQueue } from './functions.js';
 import { races, traits, orbitLength } from './races.js';
 import { spatialReasoning, unlockContainers } from './resources.js';
-import { armyRating, garrisonSize, soldierDeath, buildGarrison } from './civics.js';
+import { armyRating, garrisonSize, soldierDeath, buildGarrison, govEffect } from './civics.js';
 import { jobScale, job_desc, loadFoundry, limitCraftsmen } from './jobs.js';
 import { production, highPopAdjust } from './prod.js';
 import { actions, payCosts, powerOnNewStruct, setAction, drawTech, bank_vault, buildTemplate, casinoEffect, housingLabel, structName, initStruct } from './actions.js';

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -2837,15 +2837,15 @@ const tauCetiModules = {
                 let womling = 8;
                 let modifier = 1;
                 if (global.civic.govern.type === 'corpocracy'){
-                    modifier = 2;
+                    modifier = 1 + (govEffect.corpocracy()[2] / 100);
                 }
                 else if (global.civic.govern.type === 'socialist'){
-                    modifier = 0.8;
+                    modifier = 1 - (govEffect.socialist()[3] / 100);
                 }
 
-                let cas = 20 * modifier;
-                let mon = 5 * modifier;
-                let bake = 15 * modifier;
+                let cas = +(20 * modifier).toFixed(2);
+                let mon = +(5 * modifier).toFixed(2);
+                let bake = +(15 * modifier).toFixed(2);
 
                 let desc = `<div class="has-text-caution">${loc('tau_home_cultureal_effect1',[$(this)[0].p_fuel().a,global.resource[$(this)[0].p_fuel().r].name,typeof $(this)[0].title === 'string' ? $(this)[0].title : $(this)[0].title()])}</div>`;
                 desc += `<div>${loc('city_tourist_center_effect2',[cas,structName('casino')])}</div>`;


### PR DESCRIPTION
Correction for one of the changes in #1500.

I also scrubbed the code for places where `govEffect` should have been used but wasn't.

Behavior updated:
- The luxury goods bonus/penalty under Corpocracy or Socialist was not modified by either Bureaucrat or Bureaucratic Efficiency.
- The vitreloy plant bonus production under Corpocracy or Socialist was not modified by either Bureaucrat or Bureaucratic Efficiency.
- Races with the Noble trait did not gain an additional 5% to maximum tax rate under Oligarchy with Bureaucrat.
    
Description updated:
- The description for professor knowledge penalty under Theocracy was incorrect when using Bureaucrat governor. The actual knowledge penalty was already correct.
- The description for banker income effectiveness under Republic was incorrect when using Bureaucrat governor and after purchasing Bureaucratic Efficiency. The actual income bonus was already correct.
- The descriptions for tourism income from tourist centers and cultural center under Corpocracy or Socialist was not modified by either Bureaucrat or Bureaucratic Efficiency.
- The description for increased tourism income provided by the Spiritualist governor was not increased by Bureaucratic Efficiency.

Rebased version of #1510 