### PR TITLE
Fixes for condition checks

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ import { defineResources, unlockCrates, unlockContainers, crateValue, containerV
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
 import { loadIndustry, defineIndustry, nf_resources, gridDefs, addSmelter, cancelRituals } from './industry.js';
 import { defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating, garrisonSize, govEffect } from './civics.js';
-import { spaceTech, interstellarTech, galaxyTech, incrementStruct, universe_affixes, renderSpace, piracy, fuel_adjust, isStargateOn } from './space.js';
+import { spaceTech, interstellarTech, galaxyTech, incrementStruct, universe_affixes, renderSpace, piracy, fuel_adjust, isStargateOn, spaceSectors } from './space.js';
 import { renderFortress, fortressTech, warlordSetup } from './portal.js';
 import { edenicTech, renderEdenic } from './edenic.js';
 import { tauCetiTech, renderTauCeti, loneSurvivor } from './truepath.js';
@@ -8409,11 +8409,10 @@ export function structName(type){
 
 export function updateQueueNames(both, items){
     if (global.tech['queue'] && global.queue.display){
-        let deepScan = ['space','interstellar','galaxy','portal','tauceti'];
         for (let i=0; i<global.queue.queue.length; i++){
             let currItem = global.queue.queue[i];
             if (!items || items.indexOf(currItem.id) > -1){
-                if (deepScan.includes(currItem.action)){
+                if (spaceSectors.includes(currItem.action)){
                     let scan = true; Object.keys(actions[currItem.action]).forEach(function (region){
                         if (actions[currItem.action][region][currItem.type] && scan){
                             global.queue.queue[i].label = 

--- a/src/actions.js
+++ b/src/actions.js
@@ -7,7 +7,7 @@ import { defineResources, unlockCrates, unlockContainers, crateValue, containerV
 import { loadFoundry, defineJobs, jobScale, workerScale, job_desc } from './jobs.js';
 import { loadIndustry, defineIndustry, nf_resources, gridDefs, addSmelter, cancelRituals } from './industry.js';
 import { defineGovernment, defineGarrison, buildGarrison, commisionGarrison, foreignGov, armyRating, garrisonSize, govEffect } from './civics.js';
-import { spaceTech, interstellarTech, galaxyTech, incrementStruct, universe_affixes, renderSpace, piracy, fuel_adjust, isStargateOn, spaceSectors } from './space.js';
+import { spaceTech, interstellarTech, galaxyTech, incrementStruct, universe_affixes, renderSpace, piracy, fuel_adjust, isStargateOn, spaceSectors, checkRequirements } from './space.js';
 import { renderFortress, fortressTech, warlordSetup } from './portal.js';
 import { edenicTech, renderEdenic } from './edenic.js';
 import { tauCetiTech, renderTauCeti, loneSurvivor } from './truepath.js';
@@ -5903,23 +5903,15 @@ export function storageMultipler(scale = 1, wiki = false){
 }
 
 export function checkCityRequirements(action){
-    if ((global.race['kindling_kindred'] || global.race['smoldering']) && action === 'lumber'){
+    if (action === 'lumber' && (global.race['kindling_kindred'] || global.race['smoldering'])){
         return false;
     }
-    else if ((global.race['kindling_kindred'] || global.race['smoldering']) && action === 'stone'){
+    else if (action === 'stone' && (global.race['kindling_kindred'] || global.race['smoldering'])){
         return true;
     }
-    let c_path = global.race['truepath'] ? 'truepath' : 'standard';
-    if (actions.city[action].hasOwnProperty('path') && !actions.city[action].path.includes(c_path)){
-        return false;
+    else {
+        return checkRequirements(actions, 'city', action);
     }
-    var isMet = true;
-    Object.keys(actions.city[action].reqs).forEach(function (req){
-        if (!global.tech[req] || global.tech[req] < actions.city[action].reqs[req]){
-            isMet = false;
-        }
-    });
-    return isMet;
 }
 
 function checkTechPath(tech){

--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@ import { defineJobs, job_desc, loadFoundry, farmerValue, jobName, jobScale, work
 import { defineIndustry, f_rate, manaCost, setPowerGrid, gridEnabled, gridDefs, nf_resources, replicator, replicatorLines, luxGoodPrice, smelterUnlocked, smelterFuelConfig, setupRituals, maxRitualNum, ritual_types } from './industry.js';
 import { checkControlling, garrisonSize, armyRating, govTitle, govCivics, govEffect, weaponTechModifer } from './civics.js';
 import { actions, updateDesc, checkTechRequirements, drawEvolution, BHStorageMulti, storageMultipler, checkAffordable, checkPowerRequirements, drawCity, drawTech, gainTech, housingLabel, updateQueueNames, wardenLabel, planetGeology, resQueue, bank_vault, start_cataclysm, orbitDecayed, postBuild, skipRequirement, structName, templeCount, initStruct, casino_vault, casinoEarn, doCallbacks, cLabels } from './actions.js';
-import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes, galaxyRegions, gatewayArmada, galaxy_ship_types } from './space.js';
+import { renderSpace, convertSpaceSector, fuel_adjust, int_fuel_adjust, zigguratBonus, planetName, genPlanets, setUniverse, universe_types, gatewayStorage, piracy, spaceTech, universe_affixes, galaxyRegions, gatewayArmada, galaxy_ship_types, spaceSectors } from './space.js';
 import { renderFortress, bloodwar, soulForgeSoldiers, hellSupression, genSpireFloor, mechRating, mechCollect, updateMechbay, hellguard, buildMechQueue, mechCost } from './portal.js';
 import { asphodelResist, mechStationEffect, renderEdenic } from './edenic.js';
 import { renderTauCeti, syndicate, shipFuelUse, spacePlanetStats, genXYcoord, shipCrewSize, tpStorageMultiplier, tritonWar, sensorRange, erisWar, calcAIDrift, drawMap, tauEnabled, shipCosts, buildTPShipQueue, trackInfestation, salvageShip, randomCoord, atShipyard, pinSalvage } from './truepath.js';
@@ -11098,9 +11098,8 @@ function midLoop(){
             }
         });
 
-        let spc_locations = ['space','interstellar','galaxy','portal','tauceti','eden'];
-        for (let i=0; i<spc_locations.length; i++){
-            let location = spc_locations[i];
+        for (let i=0; i<spaceSectors.length; i++){
+            let location = spaceSectors[i];
             Object.keys(actions[location]).forEach(function (region){
                 Object.keys(actions[location][region]).forEach(function (action){
                     let s_region = actions[location][region][action] && actions[location][region][action].hasOwnProperty('region') ? actions[location][region][action].region : location;
@@ -11441,7 +11440,7 @@ function midLoop(){
 
                 if (t_action['grant'] && global.tech[t_action.grant[0]] && global.tech[t_action.grant[0]] >= t_action.grant[1]){
                     global.r_queue.queue.splice(i,1);
-                    clearPopper(`rq${c_action.id}`);
+                    clearPopper(`rq${t_action.id}`);
                     break;
                 }
                 else {
@@ -11532,7 +11531,6 @@ function midLoop(){
         let idx = -1;
         let c_action = false;
         let stop = global.queue.pause;
-        let deepScan = ['space','interstellar','galaxy','portal','tauceti','eden'];
         let time = 0;
         let spent = { t: {t:0,rt:0}, r: {}, rr: {}, id: {}};
         let arpa = false;
@@ -11568,7 +11566,7 @@ function midLoop(){
                     doNotAdjustCost: true,
                 };
             }
-            else if (deepScan.includes(struct.action)){
+            else if (spaceSectors.includes(struct.action)){
                 for (let region in actions[struct.action]) {
                     if (actions[struct.action][region][struct.type]){
                         t_action = actions[struct.action][region][struct.type];
@@ -13250,7 +13248,8 @@ function longLoop(){
         }
 
         if (global.race['living_materials']){
-            ['city','space','interstellar','galaxy','portal','eden','tauceti'].forEach(function(sector){
+            const structSectors = ['city'].concat(spaceSectors);
+            structSectors.forEach(function(sector){
                 Object.keys(global[sector]).forEach(function(struct){
                     if (global[sector][struct].hasOwnProperty('l_m')){
                         global[sector][struct].l_m++;

--- a/src/portal.js
+++ b/src/portal.js
@@ -1708,7 +1708,7 @@ const fortressModules = {
             },
             action(args){
                 if (global.portal.soul_capacitor.count < 40 && payCosts($(this)[0])){
-                    global.portal.soul_capacitor.count++;
+                    incrementStruct('soul_capacitor','portal');
                     powerOnNewStruct($(this)[0]);
                     return true;
                 }
@@ -2944,7 +2944,7 @@ const fortressModules = {
             },
             action(args){
                 if (global.portal.oven.count < 100 && payCosts($(this)[0])){
-                    global.portal['oven'].count++;
+                    incrementStruct('oven','portal');
                     if (global.portal.oven.count >= 100){
                         global.tech['dish'] = 3;
                         initStruct(fortressModules.prtl_lake.oven_complete);
@@ -3036,7 +3036,7 @@ const fortressModules = {
             },
             action(args){
                 if (payCosts($(this)[0])){
-                    global.portal['dish_soul_steeper'].count++;
+                    incrementStruct('dish_soul_steeper','portal');
                     global.portal['dish_soul_steeper'].on++;
                     return true;
                 }
@@ -3068,7 +3068,7 @@ const fortressModules = {
             },
             action(args){
                 if (payCosts($(this)[0])){
-                    global.portal['dish_life_infuser'].count++;
+                    incrementStruct('dish_life_infuser','portal');
                     global.portal['dish_life_infuser'].on++;
                     return true;
                 }

--- a/src/races.js
+++ b/src/races.js
@@ -14,6 +14,7 @@ import { renderEdenic } from './edenic.js';
 import { events, eventList } from './events.js';
 import { swissKnife } from './tech.js';
 import { warhead, big_bang } from './resets.js';
+import { spaceSectors } from './space.js';
 
 const date = new Date();
 const easter = getEaster();
@@ -6817,6 +6818,44 @@ function setPurgatory(s,t){
     if (global[s].hasOwnProperty(t)){
         global.race.purgatory[s][t] = global[s][t];
         delete global[s][t];
+    }
+    // Remove tech from research queue
+    if (s === 'tech'){
+        if (global.tech['r_queue'] && global.r_queue.display){
+            for (let i=0; i<global.r_queue.queue.length; i++){
+                const struct = global.r_queue.queue[i];
+                const t_action = actions[struct.action][struct.type];
+                if (t_action['grant'] && t_action.grant[0] === t){
+                    global.r_queue.queue.splice(i,1);
+                    clearPopper(`rq${t_action.id}`);
+                }
+            }
+        }
+    }
+    // Remove structures from building queue
+    else {
+        if (global.tech['queue'] && global.queue.display){
+            for (let i=0; i<global.queue.queue.length; i++){
+                const struct = global.queue.queue[i];
+                if (struct.action === s && struct.type === t){
+                    global.queue.queue.splice(idx,1);
+                    // Remove info dialog (different code for city and space)
+                    if (spaceSectors.includes(struct.action)){
+                        for (const region in actions[struct.action]) {
+                            if (actions[struct.action][region][struct.type]){
+                                const c_action = actions[struct.action][region][struct.type];
+                                clearPopper(`q${c_action.id}${idx}`);
+                                break;
+                            }
+                        }
+                    }
+                    else {
+                        const c_action = actions[struct.action][struct.type];
+                        clearPopper(`q${c_action.id}${idx}`);
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/space.js
+++ b/src/space.js
@@ -14,6 +14,8 @@ import { ascend, terraform, apotheosis } from './resets.js';
 import { loadTab } from './index.js';
 import { loc } from './locale.js';
 
+export const spaceSectors = ['space','interstellar','galaxy','portal','tauceti','eden'];
+
 const spaceProjects = {
     spc_home: {
         info: {

--- a/src/space.js
+++ b/src/space.js
@@ -1250,14 +1250,14 @@ const spaceProjects = {
             },
             action(args){
                 if (payCosts($(this)[0])){
+                    incrementStruct('university','city');
+                    global.space.red_university.count = global.city.university.count;
                     let gain = global.tech['science'] && global.tech['science'] >= 8 ? 700 : 500;
                     if (global.tech['supercollider']){
                         let ratio = global.tech['particles'] && global.tech['particles'] >= 3 ? 12.5: 25;
                         gain *= (global.tech['supercollider'] / ratio) + 1;
                     }
                     global['resource']['Knowledge'].max += gain;
-                    global.city.university.count++;
-                    global.space.red_university.count = global.city.university.count;
                     global.civic.professor.display = true;
                     global.civic.professor.max = jobScale(global.city.university.count);
                     return true;
@@ -1905,11 +1905,9 @@ const spaceProjects = {
                 }
             },
             action(args){
-                if (payCosts($(this)[0])){
-                    if (global.space.jump_gate.count < 100){
-                        global.space.jump_gate.count++;
-                        return true;
-                    }
+                if (global.space.jump_gate.count < 100 && payCosts($(this)[0])){
+                    incrementStruct('jump_gate','space');
+                    return true;
                 }
                 return false;
             },
@@ -2838,7 +2836,7 @@ const spaceProjects = {
             },
             action(args){
                 if (global.space.mass_relay.count < 100 && payCosts($(this)[0])){
-                    global.space.mass_relay.count++;
+                    incrementStruct('mass_relay','space');
                     if (global.space.mass_relay.count >= 100){
                         global.tech['outer'] = 6;
                         initStruct(spaceProjects.spc_dwarf.m_relay);

--- a/src/space.js
+++ b/src/space.js
@@ -7052,7 +7052,7 @@ export function checkRequirements(action_set,region,action){
     if (action_set[region][action].hasOwnProperty('path') && !action_set[region][action].path.includes(path)){
         return false;
     }
-    var isMet = true;
+    let isMet = true;
     Object.keys(action_set[region][action].reqs).forEach(function (req){
         if (!global.tech[req] || global.tech[req] < action_set[region][action].reqs[req]){
             isMet = false;


### PR DESCRIPTION
Use the `incrementStruct()` function on several structures that weren't updated to use it. Resolves #1492.

Fix condition checks for structures in the "City" region to include all expected checks by calling `checkRequirements()` instead of duplicating the code.

When purging structs for any reason, also purge from build queues. This is a general solution and is expected to supersede #1524, which also covers the most important known cases (cement plants and rock quarries) in a more manual way.
- The code as I originally wrote it partially duplicates the functions `removeFromQueue()` and `removeFromRQueue()`. Pushing the "remove popper" changes into those functions for better reuse would be a reasonable request.

Rebased version of #1532