### PR TITLE
Cosmetic fixes to descriptions

### DIFF
--- a/src/achieve.js
+++ b/src/achieve.js
@@ -3,7 +3,7 @@ import { clearElement, popover, flib, calc_mastery, masteryType, calcPillar, svg
 import { races, genus_def } from './races.js';
 import { actions } from './actions.js';
 import { universe_affixes, universe_types, piracy } from './space.js';
-import { monsters } from './portal.js';
+import { monsters, towerSize } from './portal.js';
 import { loc } from './locale.js'
 
 const achieve_list = {
@@ -2684,7 +2684,7 @@ export const perkList = {
             {
                 desc(wiki){
                     let harmonic = calcPillar();
-                    return loc("perks_harmonic2",[loc("portal_west_tower"), loc("portal_east_tower"), wiki ? `12-${(Object.keys(races).length - 1) * 12}` : +(Object.keys(global.pillars).length * 12)]);
+                    return loc("perks_harmonic2",[loc("portal_west_tower"), loc("portal_east_tower"), wiki ? '4-750' : 1000-towerSize()]);
                 },
                 active(){
                     let harmonic = calcPillar();

--- a/src/achieve.js
+++ b/src/achieve.js
@@ -1581,7 +1581,7 @@ export const perkList = {
             },
             {
                 desc(wiki){
-                    let bonus = wiki ? "4/8/12/16/20" : global.stats.achieve['technophobe'] ? global.stats.achieve.technophobe.l : 0;
+                    let bonus = wiki ? "4/8/12/16/20" : global.stats.achieve['technophobe'] ? (4 * global.stats.achieve.technophobe.l) : 0;
                     return loc("achieve_perks_technophobe5",[bonus]);
                 },
                 active(){

--- a/src/actions.js
+++ b/src/actions.js
@@ -2093,6 +2093,7 @@ export const actions = {
                 if (milVal){
                     rate *= 1 + (milVal / 100);
                 }
+                rate = +rate.toFixed(2);
                 let effect = global.tech['spy'] && global.tech['spy'] >= 3 ? `<div>${loc('city_boot_camp_effect',[rate])}</div><div>${loc('city_boot_camp_effect2',[10])}</div>` : `<div>${loc('city_boot_camp_effect',[rate])}</div>`;
                 if (global.race['artifical'] && !global.race['orbit_decayed']){
                     let repair = global.tech['medic'] || 1;

--- a/src/main.js
+++ b/src/main.js
@@ -3879,7 +3879,7 @@ function fastLoop(){
             if (biodome > 0){
                 breakdown.p['Food'][`ᄂ${loc('space_syndicate')}+0`] = -((1 - red_synd) * 100) + '%';
                 breakdown.p['Food'][`ᄂ${loc('space_red_ziggurat_title')}+0`] = ((zigVal - 1) * 100) + '%';
-                breakdown.p['Food'][`ᄂ${loc('sign_virgo')}+0`] = ((virgo - 1) * 100) + '%';
+                breakdown.p['Food'][`ᄂ${loc('sign_virgo')}+1`] = ((virgo - 1) * 100) + '%';
             }
 
             let generated = food_base + (hunting * q_multiplier) + (biodome * red_synd * zigVal * virgo);

--- a/src/portal.js
+++ b/src/portal.js
@@ -1604,7 +1604,11 @@ const fortressModules = {
                 let soldiers = global.tech.hell_gun >= 2 ? jobScale(2) : jobScale(1);
                 let min = global.tech.hell_gun >= 2 ? 35 : 20;
                 let max = global.tech.hell_gun >= 2 ? 75 : 40;
-                return `<div>${loc('portal_gun_emplacement_effect',[soldiers])}</div><div>${loc('portal_gun_emplacement_effect2',[min,max])}</div><div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
+                let soldierEffect = loc('portal_gun_emplacement_effect',[soldiers]);
+                if (global.race['hivemind']){
+                    soldierEffect = loc('portal_gun_emplacement_effect_hivemind');
+                }
+                return `<div>${soldierEffect}</div><div>${loc('portal_gun_emplacement_effect2',[min,max])}</div><div class="has-text-caution">${loc('minus_power',[$(this)[0].powered()])}</div>`;
             },
             action(args){
                 if (payCosts($(this)[0])){

--- a/src/space.js
+++ b/src/space.js
@@ -1074,6 +1074,7 @@ const spaceProjects = {
                 if (global.race['high_pop']){
                     fab = highPopAdjust(fab);
                 }
+                fab = +fab.toFixed(2);
                 return `<div class="has-text-caution">${loc('space_used_support',[planetName().red])}</div><div>${loc('space_red_fabrication_effect1',[jobScale(1)])}</div>${c_worker}<div>${loc('space_red_fabrication_effect2',[fab])}</div>`;
             },
             s_type: 'red',

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -2771,8 +2771,8 @@ const tauCetiModules = {
         },
         tauceti_casino: {
             id: 'tauceti-tauceti_casino',
-            title(){ return loc('city_casino'); },
-            desc(){ return loc('city_casino'); },
+            title(){ return structName('casino'); },
+            desc(){ return structName('casino'); },
             type: 'gambling',
             category: 'commercial',
             reqs: { gambling: 1, isolation: 1 },

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -423,7 +423,7 @@ const outerTruth = {
                 let vault = bank_vault() * 2;
                 vault = spatialReasoning(vault);
                 vault = (+(vault).toFixed(0)).toLocaleString();
-                return loc('plus_max_resource',[`\$${vault}`,global.resource.Money.name]);
+                return loc('plus_max_resource',[`\$${vault}`,loc('resource_Money_name')]);
             },
             action(){
                 if (payCosts($(this)[0])){

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7236,6 +7236,7 @@
   "portal_gun_emplacement_title": "Gun Emplacement",
   "portal_gun_emplacement_desc": "Reduces soldier requirement of Soul Forge",
   "portal_gun_emplacement_effect": "Soul Forge: -%0 Soldiers Required",
+  "portal_gun_emplacement_effect_hivemind": "Soul Forge: Fewer Soldiers Required",
   "portal_gun_emplacement_effect2": "Kills %0-%1 Pit Demons per Day",
   "portal_soul_attractor_title": "Soul Attractor",
   "portal_soul_attractor_effect": "Attracts %0-%1 roaming souls into your Soul Forge per day.",


### PR DESCRIPTION
Fix description of Technophobe gene complexity perk (resolves #1483)
Fix description of Harmonic Energy tower discount
Fix missing Halloween skin for Casino struct on Tau Ceti
Fix effect text for Titan Bank
Amend description of Gun Emplacement with Hivemind trait
Fix rounding issues in descriptions for Boot Camp and Fabrication
Show the Virgo star sign bonus for both Farms and Biodomes at the same time

Rebased version of #1531