### PR TITLE
Fix labels of SR universe description buttons

### DIFF
--- a/src/space.js
+++ b/src/space.js
@@ -7845,7 +7845,7 @@ export function setUniverse(){
 
         $('#evolution').append(parent);
 
-        let srDescButton = $(`<a class="is-sr-only" role="button">${universe_types[universe].name} description</a>`);
+        let srDescButton = $(`<a class="is-sr-only" role="button">${universe_types[universe].name()} description</a>`);
         $('#evolution').append(srDescButton);
 
         $('#'+id).on('click',function(){


### PR DESCRIPTION
The commit to add WebGL support to the map seems to have converted several properties into methods, including the .name value used in the universe screen-reader-only description buttons (added in #1540). Most uses of the old form were updated but the new button was not and as a result, the function itself is read aloud in the label instead of the universe name. This PR just changes .name to .name() so that the method is called correctly. As far as I can tell, all other instances of the non-method forms were converted correctly.