### PR TITLE
Two Tab Improvements for Screen Readers

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" type="text/css" href="evolve/evolve.css">
     <script src="https://unpkg.com/jquery@3.6.3/dist/jquery.min.js" integrity="sha384-Ft/vb48LwsAEtgltj7o+6vtS2esTU9PCpDqcXs4OCVQFZu5BqprHtUCZ4kjK+bpE" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/vue@3.5.22/dist/vue.global.prod.js" integrity="sha384-8b+88atXoPL4ijtVqe+2pA+PC8VNYSGqubRseMLV0qxfa5GMHeftEEHvk4eM4RFT" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/buefy@3.0.3/dist/buefy.min.js" integrity="sha384-kzphVPeSA3m6Hdi+/ngwhuw668bSPDbYvfGPe+8CZ6ZDpQuAD1oT0ezNHoKbUu0n" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/buefy@3.0.10/dist/buefy.min.js" integrity="sha384-nOS3Yjj6L0qHAEM242ARckkkNXP9KMePRKbxYAoX/h542ZSx3IvYD7haRIp0hmG3" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/sortablejs@1.10.2/Sortable.min.js" integrity="sha384-6qM1TfKo1alBw3Uw9AWXnaY5h0G3ScEjxtUm4TwRJm7HRmDX8UfiDleTAEEg5vIe" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/chart.js@3.8.2/dist/chart.min.js" integrity="sha384-z7c1KnSCkMpfoib43Lq1v2pokQC8cdqBWmH2qiyH2KkmNv60hACtZUjoCEkp1Y08" crossorigin="anonymous"></script>

--- a/src/evolve.less
+++ b/src/evolve.less
@@ -2420,6 +2420,11 @@ a {
     vertical-align: top;
 }
 
+// hide blank Hell observe tab on main tab-bar
+#mainTabs .hiddenObserveTab {
+    display: none;
+}
+
 .content li {
     margin-top: 0;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1357,7 +1357,7 @@ export function index(){
     tabs.append(settings);
 
     // (Hidden Last Tab) Hell Observation Tab
-    let observe = $(`<b-tab-item disabled>
+    let observe = $(`<b-tab-item disabled header-class="hiddenObserveTab">
         <template #header></template>
         <div id="mTabObserve"></div>
     </b-tab-item>`);

--- a/wiki.html
+++ b/wiki.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" type="text/css" href="wiki/wiki.css">
     <script src="https://unpkg.com/jquery@3.6.3/dist/jquery.min.js" integrity="sha384-Ft/vb48LwsAEtgltj7o+6vtS2esTU9PCpDqcXs4OCVQFZu5BqprHtUCZ4kjK+bpE" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/vue@3.5.22/dist/vue.global.js" integrity="sha384-o0XhjjchKAjA3RDDJZatNHsCZEyZGduAW1aoWEOks1/88a83+CPVAdJfYVcM6G/A" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/buefy@3.0.3/dist/buefy.min.js" integrity="sha384-kzphVPeSA3m6Hdi+/ngwhuw668bSPDbYvfGPe+8CZ6ZDpQuAD1oT0ezNHoKbUu0n" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/buefy@3.0.10/dist/buefy.min.js" integrity="sha384-nOS3Yjj6L0qHAEM242ARckkkNXP9KMePRKbxYAoX/h542ZSx3IvYD7haRIp0hmG3" crossorigin="anonymous"></script>
     <script src="https://unpkg.com/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
     <script src="lib/cryptojs.min.js"></script>
     <script src="lib/lz-string.min.js"></script>


### PR DESCRIPTION
This PR includes two changes to improve the accessibility of tabs in the game.

1. Update Buefy from 3.0.3 to 3.0.10: The latest version of Buefy 3.0.10 includes a fix to its tabs to make them more screen reader friendly and accessible (see [this PR to Buefy](https://github.com/buefy/buefy/pull/4351) for more details). This PR updates the urls and sha384 hashes for the updated version of the minified script in index.html and wiki.html to load the new version. I can't be completely sure the update will not add any visual changes, but the game still loads and plays properly under my screen reader with the improved tab behavior.

2. Hide the unlabeled observation tab from screen readers: Currently, there is an unlabeled, seemingly unselectable 8th tab in the main tab bar used for the Hell Observation screen, as interpreted by screen readers. This is somewhat confusing for people using screen readers, and this PR adds `display: none` to its CSS. This does slightly change the visual appearance, I believe, since it previously wasn't completely visually hidden either. However, the comment in `index.js` calls it the "hidden observation tab", and it appears to already be hidden on mobile, so this may be the intended behavior.