### PR TITLE
More fixes

### DIFF
--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2508,11 +2508,21 @@ function geneSlotPanel(parent,primary,primaryMethods){
             },
             rankUp(i){
                 let s = geneSlots()[i];
-                if (!s || !s.g || s.r >= geneRankCap(i)){ return; }
-                let cost = geneRankCost(s.r + 1,s.g,i);
-                if (global.resource.Genes.amount < cost){ return; }
-                global.resource.Genes.amount -= cost;
-                s.r++;
+                if (!s || !s.g){ return; }
+
+                let rankCap = geneRankCap(i);
+                if (s.r >= rankCap){ return; }
+
+                let keyMult = keyMultiplier();
+                if (keyMult > rankCap - s.r)
+                    keyMult = rankCap - s.r;
+
+                for (let n = 0; n < keyMult; n++){
+                    let cost = geneRankCost(s.r + 1,s.g,i);
+                    if (global.resource.Genes.amount < cost){ return; }
+                    global.resource.Genes.amount -= cost;
+                    s.r++;
+                }
                 afterGeneChange(s.g);
             },
             breakCap(i){

--- a/src/arpa.js
+++ b/src/arpa.js
@@ -2730,6 +2730,7 @@ function afterGeneChange(gene){
     syncGenes();
     if (gene === 'mastery'){ calc_mastery(true); }
     if (gene === 'persuasive' || gene === 'logistician'){ updateTrades(); }
+    if (gene === 'queuemaster'){ calcQueueMax(); buildQueue(); }
     genetics();
 }
 

--- a/src/civics.js
+++ b/src/civics.js
@@ -2321,7 +2321,11 @@ export function armyRating(val,type,wound,analysis){
             data.push({ k: 'trait_pathetic_name', v: -(pathetic) });
         }
         if (type === 'hellArmy'){
-            rating *= geneBonus('infernal');
+            let infernal = geneBonus('infernal');
+            if (infernal > 1){
+                army *= infernal;
+                data.push({ k: 'trait_pathetic_name', v: (pathetic - 1) });
+            }
         }
         if (global.race['holy'] && type === 'hellArmy'){
             let holy = (traits.holy.vars()[0] / 100);

--- a/src/functions.js
+++ b/src/functions.js
@@ -3737,7 +3737,13 @@ export function getTraitDesc(info, trait, opts){
             info.append(`<div class="type has-text-caution">${loc(`wiki_trait_${traits[trait].type}`)}<span>${loc(`wiki_trait_value`,[traits[trait].val])}</span></div>`);
         }
         else {
-            info.append(`<div class="type has-text-caution">${loc(`wiki_trait_${traits[trait].type}`)}</div>`);
+            if (traits[trait].type === 'minor'){
+                let base = traits[trait].base;
+                info.append(`<div class="type"><span class="has-text-caution">${loc(`wiki_trait_minor`)} <span class="pickBase base${base}">${base}</span></span></div>`);
+            }
+            else{
+                info.append(`<div class="type has-text-caution">${loc(`wiki_trait_${traits[trait].type}`)}</div>`);
+            }
         }
         if (fanatic){
             info.append(`<div class="has-text-danger">${loc(`wiki_trait_fanaticism`,[fanatic])}</div>`);

--- a/src/main.js
+++ b/src/main.js
@@ -12100,11 +12100,13 @@ function midLoop(){
                 let attempts = global.queue.queue[idx].q;
                 let struct = global.queue.queue[idx];
                 let report_in = c_action['queue_complete'] ? c_action.queue_complete() : 1;
+                let built = 0;
+                let label = global.queue.queue[idx].label;
                 for (let i=0; i<attempts; i++){
                     if (c_action.action({isQueue: true}) !== false){
                         triggerd = true;
                         if (report_in - i <= 1){
-                            messageQueue(loc('build_success',[global.queue.queue[idx].label]),'success',false,['queue','building_queue']);
+                            built++;
                         }
                         if (global.queue.queue[idx].q > 1){
                             global.queue.queue[idx].q--;
@@ -12124,6 +12126,13 @@ function midLoop(){
                         break;
                     }
                 }
+                if (built === 1){
+                    messageQueue(loc('build_success',[label]),'success',false,['queue','building_queue']);
+                }
+                else if (built > 1){
+                    messageQueue(loc('build_success_many',[label, built]),'success',false,['queue','building_queue']);
+                }
+
                 if (triggerd){
                     postBuild(c_action,struct.action,struct.type);
                 }

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -6775,8 +6775,13 @@ function razeStructures(region,razings){
         let lost = losses[s];
         global[cat][s].count -= lost;
         global[cat][s]['razed'] = (global[cat][s]['razed'] || 0) + lost;
-        if (global[cat][s].hasOwnProperty('on') && global[cat][s].on > global[cat][s].count){
-            global[cat][s].on = global[cat][s].count;
+
+        if (global[cat][s].hasOwnProperty('on')){
+            let turned_off = lost;
+            if (global[cat][s].on < turned_off){
+                turned_off = global[cat][s].on;
+            }
+            global[cat][s].on -= turned_off;
         }
         zMessage(loc('infestation_razed',[lost,structTitle(cat,region,s),regionName(region)]),'danger');
     });

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -7741,8 +7741,7 @@ export function shipAttackPower(ship){
 }
 
 export function shipSpeed(ship){
-    // Featherlight: avian hulls are built lighter than anyone else's.
-    let mass = 1 / geneBonus('featherlight');
+    let mass = 1;
     switch (ship.class){
         case 'corvette':
             mass = global.tech['syard_mass'] ? (ship.armor === 'neutronium' ? 1 : 0.95) : ship.armor === 'neutronium' ? 1.1 : 1;
@@ -7767,6 +7766,9 @@ export function shipSpeed(ship){
             break;
     }
     if (ship.armor === 'aerographene'){ mass /= AEROGRAPHENE_SPEED; }
+
+    // Featherlight: avian hulls are built lighter than anyone else's.
+    mass /= geneBonus('featherlight');
 
     let boost = 1;
     switch (ship.location?.name ?? ""){

--- a/src/truepath.js
+++ b/src/truepath.js
@@ -12271,6 +12271,14 @@ export function drawMap() {
     // frame's batch set up explicitly. No-op on the 2D path.
     if (ctx.beginFrame){ ctx.beginFrame(); }
 
+    if (starLockOn) {
+        // Move camera onto locked on body, keeping its position in the center
+        const pos = genXYZcoord(starLockOn);
+        const bounds = document.getElementById("mapCanvas").getBoundingClientRect();
+        mapShift.x = bounds.width / 2 - pX(pos) * mapScale;
+        mapShift.y = bounds.height / 2 - pY(pos) * mapScale;
+    }
+
     ctx.save();
     ctx.fillStyle = "#000000";
     ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -13040,10 +13048,10 @@ function buildSolarMap(parentNode, keep) {
             if (drag === 'pan' && press && !press.moved){
                 let hit = starAt(e) || bodyAt(e);
                 if (hit){
-                    recenterOn(genXYZcoord(hit));
-                    drawMap();
                     // Lock on so zooming pulls in on it rather than following the cursor away.
+                    // Draw after to immediately recenter on clicked body
                     starLockOn = hit;
+                    drawMap();
                     // Finding the cow is the whole of it — there is nothing else to do out there.
                     if (cowGlyph(hit)){
                         unlockFeat('secret_cow', global.race.universe === 'micro' ? true : false);
@@ -13249,6 +13257,7 @@ function buildSolarMap(parentNode, keep) {
             // This is the "back to the default view of Sol" control — it already restores the
             // opening zoom, so it restores the opening bearing with it.
             mapYaw = mapDefaultYaw('spc_sun');
+            starLockOn = 'spc_sun';
             camUpdate();
             recenterOn(genXYZcoord('spc_sun'));
             drawMap();
@@ -13261,6 +13270,7 @@ function buildSolarMap(parentNode, keep) {
             .on("click", () => {
                 mapScale = 20.0;
                 mapYaw = mapDefaultYaw('tauceti');
+                starLockOn = 'tauceti';
                 camUpdate();
                 recenterOn(genXYZcoord('tauceti'));
                 drawMap();

--- a/src/vars.js
+++ b/src/vars.js
@@ -1449,7 +1449,7 @@ if (convertVersion(global['version']) <= 105000){
     // Truepath ships got their navigation reworked, notably changing 2D space to 3D. 
     // Reconstruct what we can with the info we have, keep rest blank to refill itself over time
     if (global.space && global.space.shipyard && global.space.shipyard.ships && Array.isArray(global.space.shipyard.ships)){
-        global.space.shipyard.ships.forEach(ship => {
+        let fn = (ship) => {
             if (ship.transit > 0) {
                 ship.inTransit = true;
 
@@ -1491,7 +1491,7 @@ if (convertVersion(global['version']) <= 105000){
                     ship.timeToNextStep = 200;
                 }
             }
-            else if (ship.transit === 0){
+            else if (ship.transit <= 0){
                 ship.inTransit = false;
                 ship.location = {
                     name: ship.location,
@@ -1514,7 +1514,9 @@ if (convertVersion(global['version']) <= 105000){
             delete ship.xy;
             if (ship.tf)
                 delete ship.tf;
-        })
+        };
+        global.space.shipyard.ships.forEach(fn);
+        (global?.race?.inactive?.ships ?? []).forEach(fn);
     }
 
     // Medium frames went from one weapon bay to two at half the damage per shot.

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -416,6 +416,7 @@
   "powerplant": "Powerplant",
   "reactor": "Reactor",
   "build_success": "%0 has been constructed.",
+  "build_success_many": "%1x %0 have been constructed.",
   "research_success": "%0 has been researched.",
   "action_options": "%0 options",
   "action_ready": "Affordable in [%0]",


### PR DESCRIPTION
Fixes:
- Gaining/changing queuemaster gene immediately updates queue size.
- Update ships stored on isolation to new transit system.
- Rebuilding razed buildings no longer powers additional ones on.
- Key multipliers now work on ranking up genes.
- Fixed ReferenceError when applying Infernal gene.
- Fixed Featherlight gene not applying its effect.

Changes:
- Locking onto a planet/moon will now track its position on the map.
- Queue building multiple of the same building within one update now sends a single message to the log, instead of multiple for each build.
- Gene types (A, C, G, T) are now displayed on wiki in the minor trait section.