### PR TITLE
Make Achievement and Feat Pages More Accessible

### DIFF
--- a/src/achieve.js
+++ b/src/achieve.js
@@ -485,7 +485,7 @@ export function drawAchieve(args){
         Object.keys(feats).forEach(function (feat){
             let baseIcon = getBaseIcon(feat,'feat');
             if (global.stats.feat[feat]){
-                let star = global.stats.feat[feat] > 1 ? `<p class="flair" title="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}"><svg class="star${global.stats.feat[feat]}" version="1.1" x="0px" y="0px" width="16px" height="16px" viewBox="${svgViewBox(baseIcon)}" xml:space="preserve">${svgIcons(baseIcon)}</svg></p>` : '';
+                let star = global.stats.feat[feat] > 1 ? `<p class="flair" title="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}" role="presentation"><svg class="star${global.stats.feat[feat]}" version="1.1" x="0px" y="0px" width="16px" height="16px" viewBox="${svgViewBox(baseIcon)}" xml:space="preserve" aria-label="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}" role="img">${svgIcons(baseIcon)}</svg></p>` : '';
                 if (feat === 'easter'){
                     let egg = easterEgg(4,14);
                     if (egg.length > 0){

--- a/src/functions.js
+++ b/src/functions.js
@@ -2912,7 +2912,7 @@ export function trickOrTreatBind(id,trick){
 }
 
 function single_emblem(achieve,size,icon,iconName,fool,uAffix){
-    return global.stats.achieve[achieve] && (fool ? global.stats.achieve[achieve][uAffix] - 1 : global.stats.achieve[achieve][uAffix]) > 0 ? `<p class="flair" title="${sLevel(global.stats.achieve[achieve][uAffix])} ${iconName}"><svg class="star${fool ? global.stats.achieve[achieve][uAffix] - 1 : global.stats.achieve[achieve][uAffix]}" version="1.1" x="0px" y="0px" width="${size}px" height="${size}px" viewBox="${svgViewBox(icon)}" xml:space="preserve">${svgIcons(icon)}</svg><span class="is-sr-only">${sLevel(global.stats.achieve[achieve][uAffix])} ${iconName}</span></p>` : '';
+    return global.stats.achieve[achieve] && (fool ? global.stats.achieve[achieve][uAffix] - 1 : global.stats.achieve[achieve][uAffix]) > 0 ? `<p class="flair" title="${sLevel(global.stats.achieve[achieve][uAffix])} ${iconName}" role="presentation"><svg class="star${fool ? global.stats.achieve[achieve][uAffix] - 1 : global.stats.achieve[achieve][uAffix]}" version="1.1" x="0px" y="0px" width="${size}px" height="${size}px" viewBox="${svgViewBox(icon)}" xml:space="preserve" aria-label="${sLevel(global.stats.achieve[achieve][uAffix])} ${iconName}" role="img">${svgIcons(icon)}</svg></p>` : '';
 }
 
 export function format_emblem(achieve,size,baseIcon,fool,universe){

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -550,3 +550,15 @@ function featDesc(feat,showFlair){
     popover(`f-${feat}`,content,options);
     $(`#f-sr-desc-${feat}`).append(content.clone());
 }
+
+function srNoteCompleted(condVal){
+    if ((typeof condVal === 'number') && (condVal >= 1) && (condVal <= 5)){ // assume condVal is challenge level
+        return `<span class="is-sr-only">&nbsp;(${loc('wiki_achievements_completed_at',[condVal-1])})</span>`;
+    }
+    if (condVal){ // if condVal is a truthy value not 1-5, return basic completed note
+        return `<span class="is-sr-only">&nbsp;(${loc('wiki_achievements_completed')})</span>`;
+    }
+    else { // if no condVal was passed or the value is falsy, return incompleted note
+        return `<span class="is-sr-only">&nbsp;(${loc('wiki_achievements_incomplete')})</span>`;
+    }
+}

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -422,7 +422,7 @@ function featDesc(feat,showFlair){
         let eggs = `<div class="has-text-warning">${loc('wiki_feat_egghunt_found')}</div><div class="flexed">`;
         for (let i=1; i<=18; i++){
             let egg = global.special.egg[year][`egg${i}`] ? 'has-text-success' : 'has-text-danger';
-            eggs = eggs + `<span class="${egg}">${loc('wiki_feat_egghunt_num',[i])}</span>`
+            eggs = eggs + `<span class="${egg}">${loc('wiki_feat_egghunt_num',[i])}${srNoteCompleted(global.special.egg[year][`egg${i}`] ? true : false)}</span>`
         }
         eggs = eggs + `</div>`;
         content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${eggs}${flair}`);
@@ -433,11 +433,11 @@ function featDesc(feat,showFlair){
         let tricks = `<div class="has-text-warning">${loc('wiki_feat_trickortreat_found')}</div><div class="flexed">`;
         for (let i=1; i<=8; i++){
             let treat = global.special.trick[year][`treat${i}`] ? 'has-text-success' : 'has-text-danger';   
-            tricks = tricks + `<span class="wide ${treat}">${loc('wiki_feat_treat_num',[i])}</span>`
+            tricks = tricks + `<span class="wide ${treat}">${loc('wiki_feat_treat_num',[i])}${srNoteCompleted(global.special.trick[year][`treat${i}`] ? true : false)}</span>`
         }
         for (let i=1; i<=8; i++){
             let trick = global.special.trick[year][`trick${i}`] ? 'has-text-success' : 'has-text-danger';   
-            tricks = tricks + `<span class="wide ${trick}">${loc('wiki_feat_trick_num',[i])}</span>`
+            tricks = tricks + `<span class="wide ${trick}">${loc('wiki_feat_trick_num',[i])}${srNoteCompleted(global.special.trick[year][`trick${i}`] ? true : false)}</span>`
         }
         tricks = tricks + `</div>`;
         content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${tricks}${flair}`);

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -217,10 +217,10 @@ function achieveDesc(achievement,showFlair,universe){
                         : global.stats.achieve[`extinct_${key}`].hasOwnProperty('e') && global.stats.achieve[`extinct_${key}`].e >= 0
                         )
                     ){
-                    killed = killed + `<span class="wide iclr${global.stats.achieve[`extinct_${key}`][achievement === 'mass_extinction' ? [uAffix] : 'e']}">${races[key].name}</span>`;
+                    killed = killed + `<span class="wide iclr${global.stats.achieve[`extinct_${key}`][achievement === 'mass_extinction' ? [uAffix] : 'e']}">${races[key].name}${srNoteCompleted(global.stats.achieve[`extinct_${key}`][achievement === 'mass_extinction' ? [uAffix] : 'e'])}</span>`;
                 }
                 else {
-                    killed = killed + `<span class="wide has-text-danger">${races[key].name}</span>`;
+                    killed = killed + `<span class="wide has-text-danger">${races[key].name}${srNoteCompleted(false)}</span>`;
                 }
             }
         });
@@ -235,10 +235,10 @@ function achieveDesc(achievement,showFlair,universe){
         Object.keys(biomes).sort((a,b) => biomes[a].label.localeCompare(biomes[b].label)).forEach(function (key){
             if (!universe || (key !== 'hellscape' && key !== 'eden') || (key === 'hellscape' && universe !== 'evil') || (key === 'eden' && universe === 'evil')){
                 if (global.stats.achieve[`biome_${key}`] && global.stats.achieve[`biome_${key}`][uAffix] >= 0){
-                    biome_list = biome_list + `<span class="wide iclr${global.stats.achieve[`biome_${key}`][uAffix]}">${biomes[key].label}</span>`;
+                    biome_list = biome_list + `<span class="wide iclr${global.stats.achieve[`biome_${key}`][uAffix]}">${biomes[key].label}${srNoteCompleted(global.stats.achieve[`biome_${key}`][uAffix])}</span>`;
                 }
                 else {
-                    biome_list = biome_list + `<span class="wide has-text-danger">${biomes[key].label}</span>`;
+                    biome_list = biome_list + `<span class="wide has-text-danger">${biomes[key].label}${srNoteCompleted(false)}</span>`;
                 }
             }
         });
@@ -251,10 +251,10 @@ function achieveDesc(achievement,showFlair,universe){
             if (key !== 'hybrid' && key !== 'omnivore'){
                 let label = ['carnivore','herbivore','omnivore'].includes(key) ? loc(`evo_${key}_title`) : loc(`genelab_genus_${key}`);
                 if (achievement === 'creator' ? global.stats.achieve[`genus_${key}`] && global.stats.achieve[`genus_${key}`][uAffix] >= 0 : global.stats.achieve[`genus_${key}`] && global.stats.achieve[`genus_${key}`].h >= 0){
-                    genus = genus + `<span class="wide iclr${achievement === 'creator' ? global.stats.achieve[`genus_${key}`][uAffix] : global.stats.achieve[`genus_${key}`].h}">${label}</span>`;
+                    genus = genus + `<span class="wide iclr${achievement === 'creator' ? global.stats.achieve[`genus_${key}`][uAffix] : global.stats.achieve[`genus_${key}`].h}">${label}${srNoteCompleted(achievement === 'creator' ? global.stats.achieve[`genus_${key}`][uAffix] : global.stats.achieve[`genus_${key}`].h)}</span>`;
                 }
                 else {
-                    genus = genus + `<span class="wide has-text-danger">${label}</span>`;
+                    genus = genus + `<span class="wide has-text-danger">${label}${srNoteCompleted(false)}</span>`;
                 }
             }
         });
@@ -277,10 +277,10 @@ function achieveDesc(achievement,showFlair,universe){
             if (key !== 'omnivore'){
                 let label = ['carnivore','herbivore','omnivore'].includes(key) ? loc(`evo_${key}_title`) : loc(`genelab_genus_${key}`);
                 if (genus[key] && genus[key] >= 1){
-                    checked = checked + `<span class="wide iclr${genus[key]}">${label}</span>`;
+                    checked = checked + `<span class="wide iclr${genus[key]}">${label}${srNoteCompleted(genus[key])}</span>`;
                 }
                 else if (key !== 'hybrid'){
-                    checked = checked + `<span class="wide has-text-danger">${label}</span>`;
+                    checked = checked + `<span class="wide has-text-danger">${label}${srNoteCompleted(false)}</span>`;
                 }
             }
         });
@@ -305,7 +305,7 @@ function achieveDesc(achievement,showFlair,universe){
         }
         Object.keys(monsters).forEach(function (boss){
             if (list[boss] && list[boss] > 0){
-                defeated = defeated + `<span class="swide iclr${list[boss]}">${loc(`portal_mech_boss_${boss}`)}</span>`;
+                defeated = defeated + `<span class="swide iclr${list[boss]}">${loc(`portal_mech_boss_${boss}`)}${srNoteCompleted(list[boss])}</span>`;
             }
             else {
                 defeated = defeated + `<span class="swide has-text-danger">${loc(`portal_mech_boss_${boss}`)}${srNoteCompleted(false)}</span>`;
@@ -462,10 +462,10 @@ function featDesc(feat,showFlair){
         }).forEach(function (key){
             if (key !== 'protoplasm' && (key !== 'custom' || (key === 'custom' && global.stats.achieve['ascended'])) && (key !== 'hybrid' || (key === 'hybrid' && global.stats.achieve['what_is_best'] && global.stats.achieve.what_is_best.e >= 5))){
                 if (species[key] && species[key] >= 1){
-                    checked = checked + `<span class="wide iclr${species[key]}">${races[key].name}</span>`;
+                    checked = checked + `<span class="wide iclr${species[key]}">${races[key].name}${srNoteCompleted(species[key])}</span>`;
                 }
                 else {
-                    checked = checked + `<span class="wide has-text-danger">${races[key].name}</span>`;
+                    checked = checked + `<span class="wide has-text-danger">${races[key].name}${srNoteCompleted(false)}</span>`;
                 }
             }
         });
@@ -531,10 +531,10 @@ function featDesc(feat,showFlair){
         }).forEach(function (key){
             if (key !== 'protoplasm' && (key !== 'custom' || (key === 'custom' && global.stats.achieve['ascended'])) && (key !== 'hybrid' || (key === 'hybrid' && global.stats.achieve['what_is_best']))){
                 if (global.stats['synth'] && global.stats.synth[key]){
-                    checked = checked + `<span class="wide iclr5">${races[key].name}</span>`;
+                    checked = checked + `<span class="wide iclr5">${races[key].name}${srNoteCompleted(true)}</span>`;
                 }
                 else {
-                    checked = checked + `<span class="wide has-text-danger">${races[key].name}</span>`;
+                    checked = checked + `<span class="wide has-text-danger">${races[key].name}${srNoteCompleted(false)}</span>`;
                 }
             }
         });

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -127,12 +127,26 @@ export function achievePage(universe, filter){
             list.append(achieve);
 
             let color = global.stats.achieve[achievement] && global.stats.achieve[achievement][uAffix] && global.stats.achieve[achievement][uAffix] > 0 ? 'warning' : 'fade';
-            achieve.append(`<span id="a-${achievement}" class="achieve has-text-${color}">${achievements[achievement].name}</span>`);
+            achieve.append(`<span id="a-${achievement}" class="achieve has-text-${color}" aria-hidden="true">${achievements[achievement].name}</span>`);
+            achieve.append(`<button id="a-sr-expand-${achievement}" aria-expanded="false" aria-controls="a-sr-desc-${achievement}" class="is-sr-only">${achievements[achievement].name}</button><div id="a-sr-desc-${achievement}" class="is-sr-only" aria-hidden="true"></div>`);
 
             let emblems = format_emblem(achievement,16,false,false,universe);
             achieve.append(`<span class="icons">${emblems}</span>`);
             
             achieveDesc(achievement, color === 'warning' ? true : false, universe);
+
+            $(`#a-sr-expand-${achievement}`).on('click',function(){
+                let expander = $(`#a-sr-expand-${achievement}`);
+                let descDiv = $(`#a-sr-desc-${achievement}`);
+                if (expander.attr('aria-expanded') === 'false'){
+                    expander.attr('aria-expanded', 'true');
+                    descDiv.removeAttr('aria-hidden');
+                }
+                else {
+                    expander.attr('aria-expanded', 'false');
+                    descDiv.attr('aria-hidden', true);
+                }
+            });
         });
     });
 }
@@ -155,9 +169,24 @@ export function featPage(){
         let color = global.stats.feat[feat] && global.stats.feat[feat] > 0 ? 'warning' : 'fade';
         let baseIcon = getBaseIcon(feat,'feat');
         let star = global.stats.feat[feat] > 1 ? `<p class="flair" title="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}"><svg class="star${global.stats.feat[feat]}" version="1.1" x="0px" y="0px" width="16px" height="16px" viewBox="${svgViewBox(baseIcon)}" xml:space="preserve">${svgIcons(baseIcon)}</svg></p>` : '';
-        achieve.append(`<span id="f-${feat}" class="achieve has-text-${color}">${feats[feat].name}</span>${star}`);
+        achieve.append(`<span id="f-${feat}" class="achieve has-text-${color}" aria-hidden="true">${feats[feat].name}</span>`);
+        achieve.append(`<button id="f-sr-expand-${feat}" aria-expanded="false" aria-controls="f-sr-desc-${feat}" class="is-sr-only">${feats[feat].name}</button><div id="f-sr-desc-${feat}" class="is-sr-only" aria-hidden="true"></div>`);
+        achieve.append(`${star}`);
 
         featDesc(feat, color === 'warning' ? true : false);
+
+        $(`#f-sr-expand-${feat}`).on('click',function(){
+            let expander = $(`#f-sr-expand-${feat}`);
+            let descDiv = $(`#f-sr-desc-${feat}`);
+            if (expander.attr('aria-expanded') === 'false'){
+                expander.attr('aria-expanded', 'true');
+                descDiv.removeAttr('aria-hidden');
+            }
+            else {
+                expander.attr('aria-expanded', 'false');
+                descDiv.attr('aria-hidden', true);
+            }
+        });
     });
 }
 
@@ -380,6 +409,7 @@ function achieveDesc(achievement,showFlair,universe){
         content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${desc}</div>${flair}`);
     }
     popover(`a-${achievement}`,content,options);
+    $(`#a-sr-desc-${achievement}`).append(content.clone());
 }
 
 function featDesc(feat,showFlair){
@@ -518,4 +548,5 @@ function featDesc(feat,showFlair){
         content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${flair}`);
     }
     popover(`f-${feat}`,content,options);
+    $(`#f-sr-desc-${feat}`).append(content.clone());
 }

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -168,7 +168,7 @@ export function featPage(){
 
         let color = global.stats.feat[feat] && global.stats.feat[feat] > 0 ? 'warning' : 'fade';
         let baseIcon = getBaseIcon(feat,'feat');
-        let star = global.stats.feat[feat] > 1 ? `<p class="flair" title="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}"><svg class="star${global.stats.feat[feat]}" version="1.1" x="0px" y="0px" width="16px" height="16px" viewBox="${svgViewBox(baseIcon)}" xml:space="preserve">${svgIcons(baseIcon)}</svg></p>` : '';
+        let star = global.stats.feat[feat] > 1 ? `<p class="flair" title="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}" role="presentation"><svg class="star${global.stats.feat[feat]}" version="1.1" x="0px" y="0px" width="16px" height="16px" viewBox="${svgViewBox(baseIcon)}" xml:space="preserve" aria-label="${sLevel(global.stats.feat[feat])} ${loc(baseIcon)}" role="img">${svgIcons(baseIcon)}</svg></p>` : '';
         achieve.append(`<span id="f-${feat}" class="achieve has-text-${color}" aria-hidden="true">${feats[feat].name}</span>`);
         achieve.append(`<button id="f-sr-expand-${feat}" aria-expanded="false" aria-controls="f-sr-desc-${feat}" class="is-sr-only">${feats[feat].name}</button><div id="f-sr-desc-${feat}" class="is-sr-only" aria-hidden="true"></div>`);
         achieve.append(`${star}`);

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -308,7 +308,7 @@ function achieveDesc(achievement,showFlair,universe){
                 defeated = defeated + `<span class="swide iclr${list[boss]}">${loc(`portal_mech_boss_${boss}`)}</span>`;
             }
             else {
-                defeated = defeated + `<span class="swide has-text-danger">${loc(`portal_mech_boss_${boss}`)}</span>`;
+                defeated = defeated + `<span class="swide has-text-danger">${loc(`portal_mech_boss_${boss}`)}${srNoteCompleted(false)}</span>`;
             }
         });
         defeated = defeated + `</div>`;
@@ -319,31 +319,31 @@ function achieveDesc(achievement,showFlair,universe){
     }
     else if (achievement === 'banana'){
         let checklist = `<div class="list">`;
-        checklist = checklist + `<div class="has-text-${global.stats.banana.b1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana1`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.banana.b2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana2`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.banana.b3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana3`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.banana.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana4`,[500])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.banana.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana5`,[50])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.banana.b1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana1`)}${srNoteCompleted(global.stats.banana.b1[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.banana.b2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana2`)}${srNoteCompleted(global.stats.banana.b2[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.banana.b3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana3`)}${srNoteCompleted(global.stats.banana.b3[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.banana.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana4`,[500])}${srNoteCompleted(global.stats.banana.b4[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.banana.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana5`,[50])}${srNoteCompleted(global.stats.banana.b5[uAffix])}</div>`;
         checklist = checklist + `</div>`;
         content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement === 'endless_hunger'){
         let checklist = `<div class="list">`;
-        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger1`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger2`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger3`,[80])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger4`,[1200])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger5`)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger1`)}${srNoteCompleted(global.stats.endless_hunger.b1[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger2`)}${srNoteCompleted(global.stats.endless_hunger.b2[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger3`,[80])}${srNoteCompleted(global.stats.endless_hunger.b3[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger4`,[1200])}${srNoteCompleted(global.stats.endless_hunger.b4[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger5`)}${srNoteCompleted(global.stats.endless_hunger.b5[uAffix])}</div>`;
         checklist = checklist + `</div>`;
         content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement === 'zombie_genocider'){
         // Task 5 is not written yet, so only the ones that exist are listed.
         let checklist = `<div class="list">`;
-        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider1`,[(53594).toLocaleString()])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider2`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider3`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider4`)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z1[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider1`,[(53594).toLocaleString()])}${srNoteCompleted(global.stats.zombie_genocider.z1[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z2[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider2`)}${srNoteCompleted(global.stats.zombie_genocider.z2[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider3`)}${srNoteCompleted(global.stats.zombie_genocider.z3[uAffix])}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider4`)}${srNoteCompleted(global.stats.zombie_genocider.z4[uAffix])}</div>`;
         checklist = checklist + `</div>`;
         content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
@@ -384,11 +384,11 @@ function achieveDesc(achievement,showFlair,universe){
     }
     else if (achievement === 'what_is_best'){
         let checklist = `<div class="list">`;
-        checklist = checklist + `<div class="has-text-${global.stats.warlord.k ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_k`,[50])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.warlord.p ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_p`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.warlord.a ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_a`,[250])}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.warlord.r ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_r`)}</div>`;
-        checklist = checklist + `<div class="has-text-${global.stats.warlord.g ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_g`)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.warlord.k ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_k`,[50])}${srNoteCompleted(global.stats.warlord.k)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.warlord.p ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_p`)}${srNoteCompleted(global.stats.warlord.p)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.warlord.a ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_a`,[250])}${srNoteCompleted(global.stats.warlord.a)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.warlord.r ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_r`)}${srNoteCompleted(global.stats.warlord.r)}</div>`;
+        checklist = checklist + `<div class="has-text-${global.stats.warlord.g ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_g`)}${srNoteCompleted(global.stats.warlord.g)}</div>`;
         checklist = checklist + `</div>`;
         content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -481,12 +481,11 @@ function featDesc(feat,showFlair){
             return traitSkin('name',a).localeCompare(traitSkin('name',b));
         }).forEach(function (gene){
             let owned = genePermanent(gene) ? `has-text-success` : `has-text-danger`;
-            checked = checked + `<span class="wide ${owned}">${traitSkin('name',gene)}</span>`;
+            checked = checked + `<span class="wide ${owned}">${traitSkin('name',gene)}${srNoteCompleted(genePermanent(gene))}</span>`;
         });
         checked = checked + `</div>`;
-        popover(`f-${feat}`,$(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`),{
-            wide: true
-        });
+        content = $(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`);
+        options = { wide: true };
     }
     else if (feat === 'grand_death_tour'){
         let path = `<div class="flexed">`;

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -163,6 +163,8 @@ export function featPage(){
 
 function achieveDesc(achievement,showFlair,universe){
     let uAffix = universeAffix(universe || 'standard');
+    let content = $();
+    let options = {};
     
     let flair = showFlair ? `<div class="has-text-flair">${achievements[achievement].flair}</div>` : ``;
     if (achievement === 'mass_extinction' || achievement === 'vigilante'){
@@ -194,9 +196,10 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         killed = killed + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${killed}${flair}`),{
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${killed}${flair}`);
+        options = {
             wide: true
-        });
+        };
     }
     else if (achievement === 'explorer'){
         let biome_list = `<div class="flexed">`;
@@ -211,7 +214,7 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         biome_list = biome_list + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${biome_list}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${biome_list}${flair}`);
     }
     else if (achievement === 'creator' || achievement === 'heavyweight'){
         let genus = `<div class="flexed">`;
@@ -227,7 +230,7 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         genus = genus + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${genus}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${genus}${flair}`);
     }
     else if (achievement === 'enlightenment'){
         let genus = {};
@@ -253,7 +256,7 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         checked = checked + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="wide has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checked}${flair}`));
+        content = $(`<div class="wide has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checked}${flair}`);
     }
     else if (achievement === 'gladiator'){
         let defeated = `<div class="flexed wide">`;
@@ -280,9 +283,10 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         defeated = defeated + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`,[42])}</div>${defeated}${flair}`),{
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`,[42])}</div>${defeated}${flair}`);
+        options = {
             wide: true
-        });
+        };
     }
     else if (achievement === 'banana'){
         let checklist = `<div class="list">`;
@@ -292,7 +296,7 @@ function achieveDesc(achievement,showFlair,universe){
         checklist = checklist + `<div class="has-text-${global.stats.banana.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana4`,[500])}</div>`;
         checklist = checklist + `<div class="has-text-${global.stats.banana.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_banana5`,[50])}</div>`;
         checklist = checklist + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement === 'endless_hunger'){
         let checklist = `<div class="list">`;
@@ -302,7 +306,7 @@ function achieveDesc(achievement,showFlair,universe){
         checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger4`,[1200])}</div>`;
         checklist = checklist + `<div class="has-text-${global.stats.endless_hunger.b5[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_endless_hunger5`)}</div>`;
         checklist = checklist + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement === 'zombie_genocider'){
         // Task 5 is not written yet, so only the ones that exist are listed.
@@ -312,7 +316,7 @@ function achieveDesc(achievement,showFlair,universe){
         checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z3[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider3`)}</div>`;
         checklist = checklist + `<div class="has-text-${global.stats.zombie_genocider.z4[uAffix] ? `success` : `danger`}">${loc(`wiki_achieve_zombie_genocider4`)}</div>`;
         checklist = checklist + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement === 'pathfinder'){
         let path = `<div class="flexed">`;
@@ -326,7 +330,7 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         path = path + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${path}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${path}${flair}`);
     }
     else if (achievement === 'overlord'){
         let wom_list = `<div class="flexed">`;
@@ -347,7 +351,7 @@ function achieveDesc(achievement,showFlair,universe){
             }
         });
         wom_list = wom_list + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${wom_list}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${wom_list}${flair}`);
     }
     else if (achievement === 'what_is_best'){
         let checklist = `<div class="list">`;
@@ -357,27 +361,30 @@ function achieveDesc(achievement,showFlair,universe){
         checklist = checklist + `<div class="has-text-${global.stats.warlord.r ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_r`)}</div>`;
         checklist = checklist + `<div class="has-text-${global.stats.warlord.g ? `success` : `danger`}">${loc(`wiki_achieve_what_is_best_g`)}</div>`;
         checklist = checklist + `</div>`;
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc(`wiki_achieve_${achievement}`)}</div>${checklist}${flair}`);
     }
     else if (achievement.includes('extinct_') && achievement.substring(8) !== 'custom' && achievement.substring(8) !== 'hybrid'){
         let race = achievement.substring(8);
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_extinct_race',[loc(`race_${race}`)])}</div>${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_extinct_race',[loc(`race_${race}`)])}</div>${flair}`);
     }
     else if (achievement.includes('genus_')){
         let genus = achievement.substring(6);
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_genus_type',[loc(`genelab_genus_${genus}`)])}</div>${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_genus_type',[loc(`genelab_genus_${genus}`)])}</div>${flair}`);
     }
     else if (achievement.includes('biome_') || achievement.includes('atmo_')){
         let planet = achievement.substring(achievement.indexOf('_') + 1);
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_planet_type',[achievement.substring(0,1) === 'b' ? loc(`biome_${planet}_name`) : loc(`planet_${planet}`)])}</div>${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${loc('wiki_achieve_planet_type',[achievement.substring(0,1) === 'b' ? loc(`biome_${planet}_name`) : loc(`planet_${planet}`)])}</div>${flair}`);
     }
     else {
         let desc = achieveDescData[achievement] ? loc(`wiki_achieve_${achievement}`,achieveDescData[achievement]) : loc(`wiki_achieve_${achievement}`);
-        popover(`a-${achievement}`,$(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${desc}</div>${flair}`));
+        content = $(`<div class="has-text-label">${achievements[achievement].desc}</div><div>${desc}</div>${flair}`);
     }
+    popover(`a-${achievement}`,content,options);
 }
 
 function featDesc(feat,showFlair){
+    let content = $();
+    let options = {};
     let flair = showFlair ? `<div class="has-text-flair">${feats[feat].flair}</div>` : ``;
     if (feat === 'egghunt'){
         const date = new Date();
@@ -388,7 +395,7 @@ function featDesc(feat,showFlair){
             eggs = eggs + `<span class="${egg}">${loc('wiki_feat_egghunt_num',[i])}</span>`
         }
         eggs = eggs + `</div>`;
-        popover(`f-${feat}`,$(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${eggs}${flair}`));
+        content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${eggs}${flair}`);
     }
     else if (feat === 'trickortreat'){
         const date = new Date();
@@ -403,7 +410,7 @@ function featDesc(feat,showFlair){
             tricks = tricks + `<span class="wide ${trick}">${loc('wiki_feat_trick_num',[i])}</span>`
         }
         tricks = tricks + `</div>`;
-        popover(`f-${feat}`,$(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${tricks}${flair}`));
+        content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${tricks}${flair}`);
     }
     else if (feat === 'equilibrium'){
         let species = {};
@@ -433,9 +440,10 @@ function featDesc(feat,showFlair){
             }
         });
         checked = checked + `</div>`;
-        popover(`f-${feat}`,$(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`),{
+        content = $(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`);
+        options = {
             wide: true
-        });
+        };
     }
     else if (feat === 'gene_splicer'){
         let checked = `<div class="flexed wide">`;
@@ -478,7 +486,8 @@ function featDesc(feat,showFlair){
             }
         });
         path += `</div>`;
-        popover(`f-${feat}`,$(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${path}${flair}`),{ wide: true, classes: 'w25' });
+        content = $(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${path}${flair}`);
+        options = { wide: true, classes: 'w25' };
     }
     else if (feat === 'planned_obsolescence') {
         let checked = `<div class="flexed wide">`;    
@@ -500,11 +509,13 @@ function featDesc(feat,showFlair){
             }
         });
         checked = checked + `</div>`;
-        popover(`f-${feat}`,$(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`),{
+        content = $(`<div class="wide has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${checked}${flair}`);
+        options = {
             wide: true
-        });
+        };
     }
     else {
-        popover(`f-${feat}`,$(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${flair}`));
+        content = $(`<div class="has-text-label">${feats[feat].desc}</div><div>${loc(`wiki_feat_${feat}`)}</div>${flair}`);
     }
+    popover(`f-${feat}`,content,options);
 }

--- a/src/wiki/achieve.js
+++ b/src/wiki/achieve.js
@@ -352,10 +352,10 @@ function achieveDesc(achievement,showFlair,universe){
         ['ashanddust','exodus','obsolete','bluepill','retired'].forEach(function (key){
             let label = loc(`achieve_${key}_name`);
             if (global.stats.achieve[key] && global.stats.achieve[key][uAffix] >= 5){
-                path = path + `<span class="wide iclr${global.stats.achieve[key][uAffix]}">${label}</span>`;
+                path = path + `<span class="wide iclr${global.stats.achieve[key][uAffix]}">${label}${srNoteCompleted(true)}</span>`;
             }
             else {
-                path = path + `<span class="wide has-text-danger">${label}</span>`;
+                path = path + `<span class="wide has-text-danger">${label}${srNoteCompleted(false)}</span>`;
             }
         });
         path = path + `</div>`;
@@ -373,10 +373,10 @@ function achieveDesc(achievement,showFlair,universe){
 
         Object.keys(womling).forEach(function (key){
             if (global.stats.womling[womling[key]] && global.stats.womling[womling[key]][uAffix] > 0){
-                wom_list = wom_list + `<span class="wide iclr5">${loc(`wiki_achieve_overlord_${key}`)}</span>`;
+                wom_list = wom_list + `<span class="wide iclr5">${loc(`wiki_achieve_overlord_${key}`)}${srNoteCompleted(true)}</span>`;
             }
             else {
-                wom_list = wom_list + `<span class="wide has-text-danger">${loc(`wiki_achieve_overlord_${key}`)}</span>`;
+                wom_list = wom_list + `<span class="wide has-text-danger">${loc(`wiki_achieve_overlord_${key}`)}${srNoteCompleted(false)}</span>`;
             }
         });
         wom_list = wom_list + `</div>`;
@@ -509,10 +509,10 @@ function featDesc(feat,showFlair){
 
             let label = loc(map[key]);
             if (reset >= 1){
-                path += `<span class="wide10 iclr${reset}">${label}</span>`;
+                path += `<span class="wide10 iclr${reset}">${label}${srNoteCompleted(reset)}</span>`;
             }
             else {
-                path += `<span class="wide10 has-text-danger">${label}</span>`;
+                path += `<span class="wide10 has-text-danger">${label}${srNoteCompleted(false)}</span>`;
             }
         });
         path += `</div>`;

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -12764,6 +12764,7 @@
   "wiki_achievements_obtained": "Obtained",
   "wiki_achievements_incomplete": "Incomplete",
   "wiki_achievements_completed": "Completed",
+  "wiki_achievements_completed_at": "Completed at challenge level %0",
   "wiki_search_placeholder": "No results found.",
   "wiki_search_regex_support": "RegEx Supported"
 }


### PR DESCRIPTION
This PR attempts to improve the accessibility of the Achievements and Feats wiki pages for screen reader users while leaving the visual interface unchanged. More specifically, it aims to make it easier for screen reader users to read the achievement and feat descriptions (which were in popovers that can sometimes be difficult to reach using the keyboard), and to add screen-reader-only notes to many achievement and feat requirements which previously only marked completion using CSS color changes. For example, I think this PR provides the first way for screen reader users to tell what species they have pillared using the Equilibrium feat. It also adjusts the html for star icons as some screen readers seemed to interpret them as multiple elements (iether an unlabeled svg and span element or with the icon nested within the layout  \<p> element).

* Refactors `achieveDesc()` and `featDesc()` to separate the building of the description content from the assignment of the popover so it can be used in a more accessible location: Each function now has local variables `content` and `options`, which are assigned specific values in each branch, and they are used in a single popover call at the bottom of each function.
* Adds screen-reader-only expandable versions of achievements and feats: The existing visual elements are hidden from screen readers and paired with buttons that expose their descriptions (in a screen-reader-only div appended right after the buttons) when expanded.
* Adds `srNoteCompleted()` to make screen-reader-only status information for individual achievement and feat requirements. Components can be marked as incomplete, completed, or completed at a specific challenge/star level based on the value passed to the function (for the most part using the same conditions used to decide the colors of the components).
* One new English string was added to support the SR note indicating the completed challenge level, `wiki_achievements_completed_at`. The other two note types reuse existing strings.
* Adds these status notes to the task and itemized checklist achievements and feats, including Mass Extinction, Vigilante, Explorer, Creator, Gladiator, Enlightenment, Equilibrium, Planned Obsolescence, Banana Smoothie, Endless Hunger, Warlord, Pathfinder, Overlord, Death Tour, Egg Hunt, Trick or Treat, Zombie Genocider (at least the four currently written tasks), and Gene Splicer.
* Updates several achievement star icons so screen readers interpret each icon as a single labeled image rather than multiple elements.

The new controls and status text use `is-sr-only`, so the changes should not alter the visual presentation of the pages.