### PR TITLE
Minor Beta fixes

### DIFF
--- a/src/civics.js
+++ b/src/civics.js
@@ -8,7 +8,7 @@ import { defineGovernor, govActive, removeTask } from './governor.js';
 import { drawTech } from  './actions.js';
 import { soulForgeSoldiers } from './portal.js';
 import { jobScale } from './jobs.js';
-import { templeCount } from './actions.js';
+import { templeCount, actions } from './actions.js';
 import { astrologySign, astroVal } from './seasons.js';
 import { warhead } from './resets.js';
 import { fleetCmd, fleetCmdUnlocked, fleetCmdRange, battleLogModal } from './truepath.js';

--- a/src/iceage.js
+++ b/src/iceage.js
@@ -5007,7 +5007,7 @@ function aberrant_fight(lifeform, real=false, seed=global['warseed']){
             }
             if (revive_active > 0){ //gain extra hp. Can go above hp cap.
                 hp = enemy_stats.health * revive_active;
-                fight_log.push(['aberrant_revive', enemy_stats.health * revive_active]);
+                fight_log.push(['aberrant_revive', (enemy_stats.health * revive_active).toFixed(0)]);
                 revive_active = 0;
             }
         }
@@ -5758,7 +5758,6 @@ export function surfaceEcosystem(){ //run every longLoop (5 seconds)
         messageQueue(loc('tech_plant_odd_seed_result2'),'info',false,['progress']);
         global.tech['ecosystem_genetics'] = 3;
     }
-    console.log(global.surface.trees?.empowered, global.aberrants.herbivores.traits.empowered);
     if (global.surface.trees?.empowered >= 300 && !global.aberrants.herbivores.traits.empowered){
         global.aberrants.herbivores.traits = {empowered:1 , ...global.aberrants.herbivores.traits};
         global.aberrants.herbivores.traits.empowered = 1;

--- a/src/main.js
+++ b/src/main.js
@@ -12802,7 +12802,7 @@ function midLoop(){
             ['underground', 'surface'].forEach(function (category){
                 for(let [zone, entry] of Object.entries(actions[category])){
                     for(let [struct, entry2] of Object.entries(entry)){
-                        if(global[category][struct]?.count && !entry2.spared){
+                        if(global[category][struct]?.count && !entry2.spared && zone_reach[category][zone]){
                             let potential = (global.tech['living_extinction'] - zone_reach[category][zone]) / 500;
                             let razed = (potential - Math.random()) * (global[category][struct].count / 100 * Math.random());
                             razed = Math.max(0, razed);

--- a/src/main.js
+++ b/src/main.js
@@ -3458,41 +3458,42 @@ function fastLoop(){
                         global.civic[job].workers = 0;
                     }
                 }
-                if (job !== 'unemployed' && job !== 'hunter' && job !== 'forager'){
-                    let stress_level = job_data[job].stress();
-                    if (global.city.ptrait.includes('mellow')){
-                        stress_level += planetTraits.mellow.vars()[1];
-                    }
-                    if (global.race['content']){
-                        let per = geneVars('content')[0] * (job === 'hell_surveyor' ? 0.5 : 1);
-                        stress_level += global.race['content'] * per;
-                    }
-                    if (support_on['botanical']){
-                        let tenders = global.civic['gardener'] ? global.civic.gardener.workers : 0;
-                        if (global.race['high_pop']){
-                            tenders /= traits.high_pop.vars()[0];
-                        }
-                        let tended = 1 + (tenders * job_data.gardener.boost() / 100);
-                        stress_level += support_on['botanical'] * actions.space.spc_red.botanical.calm * tended;
-                    }
-                    if (global.city.ptrait.includes('dense') && job === 'miner'){
-                        stress_level -= planetTraits.dense.vars()[1];
-                    }
-                    if (global.race['freespirit'] && job !== 'farmer' && job !== 'lumberjack' && job !== 'quarry_worker' && job !== 'crystal_miner' && job !== 'scavenger'){
-                        stress_level /= 1 + (traits.freespirit.vars()[0] / 100);
-                    }
-
-                    let workers = global.civic[job].workers;
-                    if (global.race['high_pop']){
-                        workers /= traits.high_pop.vars()[0];
-                    }
-
-                    if (global.race['sky_lover'] && ['miner','coal_miner','crystal_miner','pit_miner','core_miner'].includes(job)){
-                        workers *= 1 + (traits.sky_lover.vars()[0] / 100);
-                    }
-
-                    stress -= workers / stress_level;
+                let stress_level = job_data[job].stress();
+                if (!stress_level){
+                    return;
                 }
+                if (global.city.ptrait.includes('mellow')){
+                    stress_level += planetTraits.mellow.vars()[1];
+                }
+                if (global.race['content']){
+                    let per = geneVars('content')[0] * (job === 'hell_surveyor' ? 0.5 : 1);
+                    stress_level += global.race['content'] * per;
+                }
+                if (support_on['botanical']){
+                    let tenders = global.civic['gardener'] ? global.civic.gardener.workers : 0;
+                    if (global.race['high_pop']){
+                        tenders /= traits.high_pop.vars()[0];
+                    }
+                    let tended = 1 + (tenders * job_data.gardener.boost() / 100);
+                    stress_level += support_on['botanical'] * actions.space.spc_red.botanical.calm * tended;
+                }
+                if (global.city.ptrait.includes('dense') && job === 'miner'){
+                    stress_level -= planetTraits.dense.vars()[1];
+                }
+                if (global.race['freespirit'] && job !== 'farmer' && job !== 'lumberjack' && job !== 'quarry_worker' && job !== 'crystal_miner' && job !== 'scavenger'){
+                    stress_level /= 1 + (traits.freespirit.vars()[0] / 100);
+                }
+
+                let workers = global.civic[job].workers;
+                if (global.race['high_pop']){
+                    workers /= traits.high_pop.vars()[0];
+                }
+
+                if (global.race['sky_lover'] && ['miner','coal_miner','crystal_miner','pit_miner','core_miner'].includes(job)){
+                    workers *= 1 + (traits.sky_lover.vars()[0] / 100);
+                }
+
+                stress -= workers / stress_level;
             }
         });
         global.civic[global.civic.d_job].workers += global.resource[global.race.species].amount - total;


### PR DESCRIPTION
Added missing import to civics

Fixed floating point issues for aberrant reviving

Remove errant console.log in ice age content

Gardeners (and any jobs with 0 base stress) do not apply to job stress anymore.

Living extinction reset leaves perk underground buildings alone (and doesn't cause NaN issues in the process)

Note: This pull does *not* rebuild the game.